### PR TITLE
feat(renderer): report storage base url setting (close: #58)

### DIFF
--- a/src/main/store/types.ts
+++ b/src/main/store/types.ts
@@ -63,4 +63,5 @@ export type LocalStore = {
   vlmApiKey: string;
   vlmModelName: string;
   screenshotScale: number; // 0.1 ~ 1.0
+  reportStorageBaseUrl?: string;
 };

--- a/src/main/window/index.ts
+++ b/src/main/window/index.ts
@@ -94,7 +94,7 @@ export function createSettingsWindow(
   console.log('mainWindowBounds', mainWindowBounds);
 
   const width = 480;
-  const height = 600;
+  const height = 700;
 
   let x, y;
   if (mainWindowBounds) {

--- a/src/renderer/src/pages/settings/index.tsx
+++ b/src/renderer/src/pages/settings/index.tsx
@@ -201,6 +201,18 @@ const Settings = () => {
                           />
                         </FormControl>
 
+                        <FormControl>
+                          <FormLabel color="gray.700">
+                            Report Storage Base URL
+                          </FormLabel>
+                          <Field
+                            as={Input}
+                            name="reportStorageBaseUrl"
+                            value={values.reportStorageBaseUrl}
+                            placeholder="https://your-report-storage-endpoint.com/upload"
+                          />
+                        </FormControl>
+
                         <HStack spacing={4}>
                           <Button
                             type="submit"

--- a/src/renderer/src/utils/share.ts
+++ b/src/renderer/src/utils/share.ts
@@ -1,0 +1,25 @@
+export async function uploadReport(
+  htmlContent: string,
+  endpoint: string,
+): Promise<{ url: string }> {
+  try {
+    const formData = new FormData();
+    const blob = new Blob([htmlContent], { type: 'text/html' });
+    formData.append('file', blob, `report-${Date.now()}.html`);
+
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      body: formData,
+    });
+
+    if (!response.ok) {
+      throw new Error(`Upload failed with status: ${response.status}`);
+    }
+
+    return await response.json();
+  } catch (error) {
+    throw new Error(
+      `Failed to upload report: ${error instanceof Error ? error.message : JSON.stringify(error)}`,
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Introducing a configurable **Report Storage Base URL** to handle report sharing via a custom HTTP endpoint.

Close: #58

### Snapshots

| Setting | Success | Fail |
| --- | --- | --- |
| <img width="484" alt="image" src="https://github.com/user-attachments/assets/737bfd01-2906-46d9-982f-21c62bd384e4" />| <img width="454" alt="image" src="https://github.com/user-attachments/assets/9f493648-0376-4324-9156-24a9a95b6c0a" /> | <img width="454" alt="image" src="https://github.com/user-attachments/assets/e3661817-89c1-4c99-b66e-444853b072ed" /> |

### Example

`POST /api/share`

Uploads a file and returns its accessible URL

**Headers**  
`Content-Type: multipart/form-data`

**Parameters**  
`file` (binary, required) - File to upload

**Success Response**  
`200 OK`
```json
{
  "url": "string"
}
```

## Type

- [ ] Bug Fix
- [x] Feature
- [ ] Chore

## Changes

- Add `Report Storage Base URL` setting
- Implement API call to Share Provider when configured
- Show error notifications for failed uploads
- Maintain original sharing logic when no provider is configured

## Unresolved issue

Server-side authentication.
