### PR TITLE
feat: setting preset (close: #57)

### DIFF
--- a/src/main/agent/llm/ui-tars.ts
+++ b/src/main/agent/llm/ui-tars.ts
@@ -6,11 +6,11 @@ import OpenAI from 'openai';
 
 import { convertToOpenAIMessages } from '@main/agent/utils';
 import { logger } from '@main/logger';
-import { store } from '@main/store/create';
 import { preprocessResizeImage } from '@main/utils/image';
 
 import { MAX_PIXELS } from '../constant';
 import { VLM, VlmRequest, VlmRequestOptions, VlmResponse } from './base';
+import { SettingStore } from '@main/store/setting';
 
 export interface UITARSOptions {
   reflection: boolean;
@@ -26,7 +26,7 @@ export interface UITARSOptions {
 
 export class UITARS implements VLM<VlmRequest, VlmResponse> {
   get vlmModel() {
-    return store.getState().getSetting('vlmModelName');
+    return SettingStore.getStore().vlmModelName;
   }
 
   // [image, prompt]
@@ -44,8 +44,8 @@ export class UITARS implements VLM<VlmRequest, VlmResponse> {
       conversations,
       images: compressedImages,
     });
-    const vlmBaseUrl = store.getState().getSetting('vlmBaseUrl');
-    const vlmApiKey = store.getState().getSetting('vlmApiKey');
+    const vlmBaseUrl = SettingStore.getStore().vlmBaseUrl;
+    const vlmApiKey = SettingStore.getStore().vlmApiKey;
     logger.info('vlmBaseUrl', vlmBaseUrl, 'vlmApiKey', vlmApiKey);
 
     const openai = new OpenAI({

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -13,7 +13,7 @@ import {
 } from 'electron';
 import squirrelStartup from 'electron-squirrel-startup';
 import ElectronStore from 'electron-store';
-import { updateElectronApp, UpdateSourceType } from 'update-electron-app';
+import { UpdateSourceType, updateElectronApp } from 'update-electron-app';
 import { mainZustandBridge } from 'zutron/main';
 
 import * as env from '@main/env';
@@ -222,6 +222,10 @@ const registerIPCHandlers = () => {
   ipcMain.handle('utio:resetPreset', async () => {
     SettingStore.resetPreset();
     return SettingStore.getStore();
+  });
+
+  ipcMain.handle('setting:clear', async () => {
+    SettingStore.clear();
   });
 };
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -28,6 +28,7 @@ import { UTIOService } from './services/utio';
 import { store } from './store/create';
 import { SettingStore } from './store/setting';
 import { createTray } from './tray';
+import { registerSettingsHandlers } from './services/settings';
 
 const { isProd } = env;
 
@@ -196,36 +197,7 @@ const registerIPCHandlers = () => {
     };
   });
 
-  ipcMain.handle('setting:importPresetFromFile', async (_, yamlContent) => {
-    await SettingStore.importPresetFromText(yamlContent);
-    return SettingStore.getStore();
-  });
-
-  ipcMain.handle('setting:importPresetFromUrl', async (_, url, autoUpdate) => {
-    await SettingStore.importPresetFromUrl(url, autoUpdate);
-    return SettingStore.getStore();
-  });
-
-  ipcMain.handle('setting:updatePresetFromRemote', async () => {
-    const settings = SettingStore.getStore();
-    if (settings.presetSource?.type === 'remote' && settings.presetSource.url) {
-      await SettingStore.importPresetFromUrl(
-        settings.presetSource.url,
-        settings.presetSource.autoUpdate,
-      );
-      return SettingStore.getStore();
-    } else {
-      throw new Error('No remote preset configured');
-    }
-  });
-
-  ipcMain.handle('setting:resetPreset', async () => {
-    SettingStore.remove('presetSource');
-  });
-
-  ipcMain.handle('setting:clear', async () => {
-    SettingStore.clear();
-  });
+  registerSettingsHandlers();
 };
 
 /**

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -220,8 +220,7 @@ const registerIPCHandlers = () => {
   });
 
   ipcMain.handle('setting:resetPreset', async () => {
-    SettingStore.resetPreset();
-    return SettingStore.getStore();
+    SettingStore.remove('presetSource');
   });
 
   ipcMain.handle('setting:clear', async () => {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -260,5 +260,3 @@ app
     logger.info('app.whenReady end');
   })
   .catch(console.log);
-
-// ... 保留其他代码 ...

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -196,17 +196,17 @@ const registerIPCHandlers = () => {
     };
   });
 
-  ipcMain.handle('utio:importPresetFromFile', async (_, yamlContent) => {
+  ipcMain.handle('setting:importPresetFromFile', async (_, yamlContent) => {
     await SettingStore.importPresetFromText(yamlContent);
     return SettingStore.getStore();
   });
 
-  ipcMain.handle('utio:importPresetFromUrl', async (_, url, autoUpdate) => {
+  ipcMain.handle('setting:importPresetFromUrl', async (_, url, autoUpdate) => {
     await SettingStore.importPresetFromUrl(url, autoUpdate);
     return SettingStore.getStore();
   });
 
-  ipcMain.handle('utio:updatePresetFromRemote', async () => {
+  ipcMain.handle('setting:updatePresetFromRemote', async () => {
     const settings = SettingStore.getStore();
     if (settings.presetSource?.type === 'remote' && settings.presetSource.url) {
       await SettingStore.importPresetFromUrl(
@@ -219,7 +219,7 @@ const registerIPCHandlers = () => {
     }
   });
 
-  ipcMain.handle('utio:resetPreset', async () => {
+  ipcMain.handle('setting:resetPreset', async () => {
     SettingStore.resetPreset();
     return SettingStore.getStore();
   });

--- a/src/main/services/settings.ts
+++ b/src/main/services/settings.ts
@@ -1,48 +1,95 @@
+/**
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
 import { ipcMain } from 'electron';
-import { dispatch } from '../store/create';
 import { SettingStore } from '../store/setting';
 import { logger } from '../logger';
+import { LocalStore } from '@main/store/validate';
 
 export function registerSettingsHandlers() {
-  ipcMain.handle('setting:importPresetFromFile', async (_, yamlContent) => {
+  /**
+   * Get setting
+   */
+  ipcMain.handle('setting:get', () => {
+    return SettingStore.getStore();
+  });
+
+  /**
+   * Clear setting
+   */
+  ipcMain.handle('setting:clear', () => {
+    SettingStore.clear();
+  });
+
+  /**
+   * Reset setting preset
+   */
+  ipcMain.handle('setting:resetPreset', () => {
+    SettingStore.getInstance().delete('presetSource');
+  });
+
+  /**
+   * Update setting
+   */
+  ipcMain.handle('setting:update', async (_, settings: LocalStore) => {
+    SettingStore.setStore(settings);
+  });
+
+  /**
+   * Import setting preset from text
+   */
+  ipcMain.handle('setting:importPresetFromText', async (_, yamlContent) => {
     try {
-      const settings = await SettingStore.importPresetFromText(yamlContent);
-      dispatch({ type: 'IMPORT_PRESET', payload: settings });
-      return settings;
+      const newSettings = await SettingStore.importPresetFromText(yamlContent);
+      SettingStore.setStore(newSettings);
     } catch (error) {
       logger.error('Failed to import preset:', error);
       throw error;
     }
   });
 
+  /**
+   * Import setting preset from url
+   */
   ipcMain.handle('setting:importPresetFromUrl', async (_, url, autoUpdate) => {
     try {
-      const settings = await SettingStore.fetchPresetFromUrl(url);
-      dispatch({
-        type: 'IMPORT_PRESET',
-        payload: {
-          ...settings,
-          presetSource: { type: 'remote', url, autoUpdate },
+      const newSettings = await SettingStore.fetchPresetFromUrl(url);
+      SettingStore.setStore({
+        ...newSettings,
+        presetSource: {
+          type: 'remote',
+          url: url,
+          autoUpdate: autoUpdate,
+          lastUpdated: Date.now(),
         },
       });
-      return settings;
     } catch (error) {
       logger.error('Failed to import preset from URL:', error);
       throw error;
     }
   });
 
+  /**
+   * Update setting preset from url
+   */
   ipcMain.handle('setting:updatePresetFromRemote', async () => {
-    dispatch({ type: 'UPDATE_PRESET_FROM_REMOTE', payload: null });
-    return SettingStore.getStore();
-  });
-
-  ipcMain.handle('setting:resetPreset', () => {
-    dispatch({ type: 'REMOVE_SETTING', payload: 'presetSource' });
-  });
-
-  ipcMain.handle('setting:clear', () => {
-    dispatch({ type: 'CLEAR_SETTINGS', payload: null });
-    return SettingStore.getStore();
+    const settings = SettingStore.getStore();
+    if (settings.presetSource?.type === 'remote' && settings.presetSource.url) {
+      const newSettings = await SettingStore.fetchPresetFromUrl(
+        settings.presetSource.url,
+      );
+      SettingStore.setStore({
+        ...newSettings,
+        presetSource: {
+          type: 'remote',
+          url: settings.presetSource.url,
+          autoUpdate: settings.presetSource.autoUpdate,
+          lastUpdated: Date.now(),
+        },
+      });
+    } else {
+      throw new Error('No remote preset configured');
+    }
   });
 }

--- a/src/main/services/settings.ts
+++ b/src/main/services/settings.ts
@@ -1,0 +1,48 @@
+import { ipcMain } from 'electron';
+import { dispatch } from '../store/create';
+import { SettingStore } from '../store/setting';
+import { logger } from '../logger';
+
+export function registerSettingsHandlers() {
+  ipcMain.handle('setting:importPresetFromFile', async (_, yamlContent) => {
+    try {
+      const settings = await SettingStore.importPresetFromText(yamlContent);
+      dispatch({ type: 'IMPORT_PRESET', payload: settings });
+      return settings;
+    } catch (error) {
+      logger.error('Failed to import preset:', error);
+      throw error;
+    }
+  });
+
+  ipcMain.handle('setting:importPresetFromUrl', async (_, url, autoUpdate) => {
+    try {
+      const settings = await SettingStore.fetchPresetFromUrl(url);
+      dispatch({
+        type: 'IMPORT_PRESET',
+        payload: {
+          ...settings,
+          presetSource: { type: 'remote', url, autoUpdate },
+        },
+      });
+      return settings;
+    } catch (error) {
+      logger.error('Failed to import preset from URL:', error);
+      throw error;
+    }
+  });
+
+  ipcMain.handle('setting:updatePresetFromRemote', async () => {
+    dispatch({ type: 'UPDATE_PRESET_FROM_REMOTE', payload: null });
+    return SettingStore.getStore();
+  });
+
+  ipcMain.handle('setting:resetPreset', () => {
+    dispatch({ type: 'REMOVE_SETTING', payload: 'presetSource' });
+  });
+
+  ipcMain.handle('setting:clear', () => {
+    dispatch({ type: 'CLEAR_SETTINGS', payload: null });
+    return SettingStore.getStore();
+  });
+}

--- a/src/main/services/utio.ts
+++ b/src/main/services/utio.ts
@@ -1,3 +1,7 @@
+/**
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
 import os from 'node:os';
 
 import { screen } from 'electron';
@@ -5,7 +9,7 @@ import { screen } from 'electron';
 import { UTIO, UTIOPayload } from '@ui-tars/utio';
 
 import { logger } from '../logger';
-import { store } from '../store/create';
+import { SettingStore } from '@main/store/setting';
 
 export class UTIOService {
   private static instance: UTIOService;
@@ -19,7 +23,7 @@ export class UTIOService {
   }
 
   private getEndpoint(): string | undefined {
-    const endpoint = store.getState().getSetting('utioBaseUrl');
+    const endpoint = SettingStore.getStore().utioBaseUrl;
     logger.debug('[UTIO] endpoint:', endpoint);
     return endpoint;
   }

--- a/src/main/store/create.ts
+++ b/src/main/store/create.ts
@@ -19,6 +19,13 @@ import { closeScreenMarker } from '@main/window/ScreenMarker';
 import { runAgent } from './runAgent';
 import { SettingStore } from './setting';
 import { AppState } from './types';
+import { logger } from '@main/logger';
+
+SettingStore.instance.onDidAnyChange((newValue, oldValue) => {
+  logger.log(
+    `SettingStore: ${JSON.stringify(oldValue)} changed to ${JSON.stringify(newValue)}`,
+  );
+});
 
 export const store = createStore<AppState>(
   (set, get) =>

--- a/src/main/store/create.ts
+++ b/src/main/store/create.ts
@@ -17,15 +17,7 @@ import {
 
 import { closeScreenMarker } from '@main/window/ScreenMarker';
 import { runAgent } from './runAgent';
-import { SettingStore, DEFAULT_SETTING } from './setting';
-import { logger } from '@main/logger';
 import type { AppState } from './types';
-
-SettingStore.getInstance().onDidAnyChange((newValue, oldValue) => {
-  logger.log(
-    `SettingStore: ${JSON.stringify(oldValue)} changed to ${JSON.stringify(newValue)}`,
-  );
-});
 
 export const store = createStore<AppState>(
   (set, get) =>
@@ -35,9 +27,7 @@ export const store = createStore<AppState>(
       instructions: '',
       status: StatusEnum.INIT,
       messages: [],
-      settings: null,
       errorMsg: null,
-      getSetting: (key) => SettingStore.get(key),
       ensurePermissions: {},
 
       abortController: null,
@@ -59,54 +49,6 @@ export const store = createStore<AppState>(
       CLOSE_LAUNCHER: () => {
         LauncherWindow.getInstance().blur();
         LauncherWindow.getInstance().hide();
-      },
-
-      GET_SETTINGS: () => {
-        const settings = SettingStore.getStore();
-        set({ settings });
-      },
-
-      SET_SETTINGS: (settings) => {
-        console.log('SET_SETTINGS', settings);
-        SettingStore.getInstance().set(settings);
-        set((state) => ({ ...state, settings }));
-      },
-
-      CLEAR_SETTINGS: () => {
-        debugger;
-        SettingStore.getInstance().set(DEFAULT_SETTING);
-        set((state) => {
-          return {
-            ...state,
-            settings: DEFAULT_SETTING,
-          };
-        });
-      },
-
-      REMOVE_SETTING: (key) => {
-        SettingStore.getInstance().delete(key);
-        const newSettings = { ...SettingStore.getInstance().store };
-        set((state) => ({ ...state, settings: newSettings }));
-      },
-
-      IMPORT_PRESET: (settings) => {
-        SettingStore.getInstance().set(settings);
-        set((state) => ({ ...state, settings }));
-      },
-
-      UPDATE_PRESET_FROM_REMOTE: async () => {
-        const settings = SettingStore.getStore();
-        if (
-          settings.presetSource?.type === 'remote' &&
-          settings.presetSource.url
-        ) {
-          const newSettings = await SettingStore.fetchPresetFromUrl(
-            settings.presetSource.url,
-          );
-          store.getState().IMPORT_PRESET(newSettings);
-        } else {
-          throw new Error('No remote preset configured');
-        }
       },
 
       GET_ENSURE_PERMISSIONS: async () => {

--- a/src/main/store/runAgent.ts
+++ b/src/main/store/runAgent.ts
@@ -29,12 +29,12 @@ export const runAgent = async (
 ) => {
   logger.info('runAgent');
   const settings = SettingStore.getStore();
-  const { instructions, abortController, getSetting } = getState();
+  const { instructions, abortController } = getState();
   const device = new Desktop();
   const vlm = new UITARS();
   assert(instructions, 'instructions is required');
 
-  const language = getSetting('language') || 'en';
+  const language = settings.language ?? 'en';
 
   const agent = new ComputerUseAgent({
     systemPrompt: getSystemPrompt(language),

--- a/src/main/store/setting.ts
+++ b/src/main/store/setting.ts
@@ -3,10 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import ElectronStore from 'electron-store';
+import yaml from 'js-yaml';
+import z from 'zod';
 
 import * as env from '@main/env';
+import { logger } from '@main/logger';
 
 import { LocalStore, VlmProvider } from './types';
+import { validatePreset } from './validate';
 
 export class SettingStore {
   private static instance = new ElectronStore<LocalStore>({
@@ -45,5 +49,59 @@ export class SettingStore {
 
   public static openInEditor(): void {
     SettingStore.instance.openInEditor();
+  }
+
+  public static async importPresetFromUrl(
+    url: string,
+    autoUpdate = false,
+  ): Promise<void> {
+    try {
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw new Error(`Failed to fetch preset: ${response.status}`);
+      }
+
+      const yamlText = await response.text();
+      const preset = yaml.load(yamlText);
+      const validatedPreset = validatePreset(preset);
+
+      SettingStore.setStore({
+        ...validatedPreset,
+        presetSource: {
+          type: 'remote',
+          url,
+          autoUpdate,
+          lastUpdated: Date.now(),
+        },
+      });
+    } catch (error) {
+      logger.error(error);
+      throw new Error(`Failed to import preset: ${error.message}`);
+    }
+  }
+
+  public static async importPresetFromText(yamlText: string): Promise<void> {
+    try {
+      const preset = yaml.load(yamlText);
+      const validatedPreset = validatePreset(preset);
+      console.log('validatedPreset', validatedPreset);
+
+      SettingStore.setStore({
+        ...validatedPreset,
+        presetSource: {
+          type: 'local',
+          lastUpdated: Date.now(),
+        },
+      });
+    } catch (error) {
+      logger.error(error);
+      throw new Error(`Failed to import preset: ${error.message}`);
+    }
+  }
+
+  public static resetPreset(): void {
+    const store = SettingStore.getStore();
+    const { presetSource, ...settings } = store;
+    SettingStore.setStore(settings);
   }
 }

--- a/src/main/store/setting.ts
+++ b/src/main/store/setting.ts
@@ -11,16 +11,18 @@ import { logger } from '@main/logger';
 import { LocalStore, VlmProvider } from './types';
 import { validatePreset } from './validate';
 
+const DEFAULT_SETTING: LocalStore = {
+  language: 'en',
+  vlmProvider: (env.vlmProvider as VlmProvider) || VlmProvider.Huggingface,
+  vlmBaseUrl: env.vlmBaseUrl || '',
+  vlmApiKey: env.vlmApiKey || '',
+  vlmModelName: env.vlmModelName || '',
+};
+
 export class SettingStore {
-  private static instance = new ElectronStore<LocalStore>({
+  public static instance = new ElectronStore<LocalStore>({
     name: 'ui_tars.setting',
-    defaults: {
-      language: 'en',
-      vlmProvider: (env.vlmProvider as VlmProvider) || VlmProvider.Huggingface,
-      vlmBaseUrl: env.vlmBaseUrl || '',
-      vlmApiKey: env.vlmApiKey || '',
-      vlmModelName: env.vlmModelName || '',
-    },
+    defaults: DEFAULT_SETTING,
   });
 
   public static set<K extends keyof LocalStore>(
@@ -38,12 +40,16 @@ export class SettingStore {
     return SettingStore.instance.get(key);
   }
 
+  public static remove<K extends keyof LocalStore>(key: K): void {
+    SettingStore.instance.delete(key);
+  }
+
   public static getStore(): LocalStore {
     return SettingStore.instance.store;
   }
 
   public static clear(): void {
-    SettingStore.instance.clear();
+    SettingStore.instance.set(DEFAULT_SETTING);
   }
 
   public static openInEditor(): void {
@@ -100,23 +106,5 @@ export class SettingStore {
         `Failed to import preset: ${error instanceof Error ? error.message : error}`,
       );
     }
-  }
-
-  public static resetPreset(): void {
-    const store = SettingStore.getStore();
-    const { presetSource, ...settings } = store;
-
-    // 1. 先清空所有数据
-    SettingStore.clear();
-
-    // 2. 重新设置基础数据
-    SettingStore.setStore({
-      ...settings,
-      language: settings.language || 'en',
-      vlmProvider: settings.vlmProvider || VlmProvider.Huggingface,
-      vlmBaseUrl: settings.vlmBaseUrl || '',
-      vlmApiKey: settings.vlmApiKey || '',
-      vlmModelName: settings.vlmModelName || '',
-    });
   }
 }

--- a/src/main/store/setting.ts
+++ b/src/main/store/setting.ts
@@ -102,6 +102,18 @@ export class SettingStore {
   public static resetPreset(): void {
     const store = SettingStore.getStore();
     const { presetSource, ...settings } = store;
-    SettingStore.setStore(settings);
+
+    // 1. 先清空所有数据
+    SettingStore.clear();
+
+    // 2. 重新设置基础数据
+    SettingStore.setStore({
+      ...settings,
+      language: settings.language || 'en',
+      vlmProvider: settings.vlmProvider || VlmProvider.Huggingface,
+      vlmBaseUrl: settings.vlmBaseUrl || '',
+      vlmApiKey: settings.vlmApiKey || '',
+      vlmModelName: settings.vlmModelName || '',
+    });
   }
 }

--- a/src/main/store/setting.ts
+++ b/src/main/store/setting.ts
@@ -10,6 +10,7 @@ import { logger } from '@main/logger';
 
 import { LocalStore, VlmProvider } from './types';
 import { validatePreset } from './validate';
+import { BrowserWindow } from 'electron';
 
 export const DEFAULT_SETTING: LocalStore = {
   language: 'en',
@@ -17,6 +18,8 @@ export const DEFAULT_SETTING: LocalStore = {
   vlmBaseUrl: env.vlmBaseUrl || '',
   vlmApiKey: env.vlmApiKey || '',
   vlmModelName: env.vlmModelName || '',
+  reportStorageBaseUrl: '',
+  utioBaseUrl: '',
 };
 
 export class SettingStore {
@@ -27,6 +30,16 @@ export class SettingStore {
       SettingStore.instance = new ElectronStore<LocalStore>({
         name: 'ui_tars.setting',
         defaults: DEFAULT_SETTING,
+      });
+
+      SettingStore.instance.onDidAnyChange((newValue, oldValue) => {
+        logger.log(
+          `SettingStore: ${JSON.stringify(oldValue)} changed to ${JSON.stringify(newValue)}`,
+        );
+        // Notify that value updated
+        BrowserWindow.getAllWindows().forEach((win) => {
+          win.webContents.send('setting-updated', newValue);
+        });
       });
     }
     return SettingStore.instance;

--- a/src/main/store/setting.ts
+++ b/src/main/store/setting.ts
@@ -4,7 +4,6 @@
  */
 import ElectronStore from 'electron-store';
 import yaml from 'js-yaml';
-import z from 'zod';
 
 import * as env from '@main/env';
 import { logger } from '@main/logger';
@@ -76,7 +75,9 @@ export class SettingStore {
       });
     } catch (error) {
       logger.error(error);
-      throw new Error(`Failed to import preset: ${error.message}`);
+      throw new Error(
+        `Failed to import preset: ${error instanceof Error ? error.message : error}`,
+      );
     }
   }
 
@@ -95,7 +96,9 @@ export class SettingStore {
       });
     } catch (error) {
       logger.error(error);
-      throw new Error(`Failed to import preset: ${error.message}`);
+      throw new Error(
+        `Failed to import preset: ${error instanceof Error ? error.message : error}`,
+      );
     }
   }
 

--- a/src/main/store/types.ts
+++ b/src/main/store/types.ts
@@ -42,7 +42,6 @@ export type AppState = {
   CLOSE_SETTINGS_WINDOW: () => void;
   OPEN_LAUNCHER: () => void;
   CLOSE_LAUNCHER: () => void;
-  SET_SETTINGS: typeof SettingStore.setStore;
   GET_SETTINGS: () => void;
   GET_ENSURE_PERMISSIONS: () => void;
   RUN_AGENT: () => void;
@@ -50,6 +49,11 @@ export type AppState = {
   SET_INSTRUCTIONS: (instructions: string) => void;
   SET_MESSAGES: (messages: Conversation[]) => void;
   CLEAR_HISTORY: () => void;
+  SET_SETTINGS: (state: LocalStore) => void;
+  CLEAR_SETTINGS: () => void;
+  REMOVE_SETTING: (key: keyof LocalStore) => void;
+  IMPORT_PRESET: (settings: LocalStore) => void;
+  UPDATE_PRESET_FROM_REMOTE: () => Promise<void>;
 };
 
 export enum VlmProvider {

--- a/src/main/store/types.ts
+++ b/src/main/store/types.ts
@@ -5,6 +5,7 @@
 import { ComputerUseUserData, Conversation } from '@ui-tars/shared/types';
 
 import { SettingStore } from './setting';
+import { LocalStore, PresetSource } from './validate';
 
 export type NextAction =
   | { type: 'key'; text: string }
@@ -57,13 +58,4 @@ export enum VlmProvider {
   vLLM = 'vLLM',
 }
 
-export type LocalStore = {
-  language: 'zh' | 'en';
-  vlmProvider: VlmProvider;
-  vlmBaseUrl: string;
-  vlmApiKey: string;
-  vlmModelName: string;
-  screenshotScale?: number; // 0.1 ~ 1.0
-  reportStorageBaseUrl?: string;
-  utioBaseUrl?: string;
-};
+export type { PresetSource, LocalStore };

--- a/src/main/store/types.ts
+++ b/src/main/store/types.ts
@@ -4,7 +4,6 @@
  */
 import { ComputerUseUserData, Conversation } from '@ui-tars/shared/types';
 
-import { SettingStore } from './setting';
 import { LocalStore, PresetSource } from './validate';
 
 export type NextAction =
@@ -32,8 +31,6 @@ export type AppState = {
   status: ComputerUseUserData['status'];
   errorMsg: string | null;
   messages: ComputerUseUserData['conversations'];
-  settings: Partial<LocalStore> | null;
-  getSetting: typeof SettingStore.get;
   abortController: AbortController | null;
   thinking: boolean;
 
@@ -42,18 +39,12 @@ export type AppState = {
   CLOSE_SETTINGS_WINDOW: () => void;
   OPEN_LAUNCHER: () => void;
   CLOSE_LAUNCHER: () => void;
-  GET_SETTINGS: () => void;
   GET_ENSURE_PERMISSIONS: () => void;
   RUN_AGENT: () => void;
   STOP_RUN: () => void;
   SET_INSTRUCTIONS: (instructions: string) => void;
   SET_MESSAGES: (messages: Conversation[]) => void;
   CLEAR_HISTORY: () => void;
-  SET_SETTINGS: (state: LocalStore) => void;
-  CLEAR_SETTINGS: () => void;
-  REMOVE_SETTING: (key: keyof LocalStore) => void;
-  IMPORT_PRESET: (settings: LocalStore) => void;
-  UPDATE_PRESET_FROM_REMOTE: () => Promise<void>;
 };
 
 export enum VlmProvider {

--- a/src/main/store/validate.ts
+++ b/src/main/store/validate.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { z } from 'zod';
+
+import { VlmProvider } from './types';
+
+const PresetSourceSchema = z.object({
+  type: z.enum(['local', 'remote']),
+  url: z.string().url().optional(),
+  autoUpdate: z.boolean().optional(),
+  lastUpdated: z.number().optional(),
+});
+
+export const PresetSchema = z.object({
+  // Required fields
+  language: z.enum(['zh', 'en']),
+  vlmProvider: z.nativeEnum(VlmProvider),
+  vlmBaseUrl: z.string().url(),
+  vlmApiKey: z.string().min(1),
+  vlmModelName: z.string().min(1),
+
+  // Optional fields
+  screenshotScale: z.number().min(0.1).max(1).optional().default(1),
+  reportStorageBaseUrl: z.string().url().optional(),
+  utioBaseUrl: z.string().url().optional(),
+  presetSource: PresetSourceSchema.optional(),
+});
+
+export type PresetSource = z.infer<typeof PresetSourceSchema>;
+export type LocalStore = z.infer<typeof PresetSchema>;
+
+export const validatePreset = (data: unknown): LocalStore => {
+  return PresetSchema.parse(data);
+};

--- a/src/main/store/validate.ts
+++ b/src/main/store/validate.ts
@@ -22,7 +22,7 @@ export const PresetSchema = z.object({
   vlmModelName: z.string().min(1),
 
   // Optional fields
-  screenshotScale: z.number().min(0.1).max(1).optional().default(1),
+  screenshotScale: z.number().min(0.1).max(1).optional(),
   reportStorageBaseUrl: z.string().url().optional(),
   utioBaseUrl: z.string().url().optional(),
   presetSource: PresetSourceSchema.optional(),

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -48,6 +48,9 @@ const electronHandler = {
       ipcRenderer.invoke('utio:updatePresetFromRemote'),
     resetPreset: () => ipcRenderer.invoke('utio:resetPreset'),
   },
+  setting: {
+    clear: () => ipcRenderer.invoke('setting:clear'),
+  },
 };
 
 // Initialize Zutron bridge

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -40,6 +40,13 @@ const electronHandler = {
   utio: {
     shareReport: (params: UTIOPayload<'shareReport'>) =>
       ipcRenderer.invoke('utio:shareReport', params),
+    importPresetFromFile: (yamlContent: string) =>
+      ipcRenderer.invoke('utio:importPresetFromFile', yamlContent),
+    importPresetFromUrl: (url: string, autoUpdate: boolean) =>
+      ipcRenderer.invoke('utio:importPresetFromUrl', url, autoUpdate),
+    updatePresetFromRemote: () =>
+      ipcRenderer.invoke('utio:updatePresetFromRemote'),
+    resetPreset: () => ipcRenderer.invoke('utio:resetPreset'),
   },
 };
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -40,15 +40,15 @@ const electronHandler = {
   utio: {
     shareReport: (params: UTIOPayload<'shareReport'>) =>
       ipcRenderer.invoke('utio:shareReport', params),
-    importPresetFromFile: (yamlContent: string) =>
-      ipcRenderer.invoke('utio:importPresetFromFile', yamlContent),
-    importPresetFromUrl: (url: string, autoUpdate: boolean) =>
-      ipcRenderer.invoke('utio:importPresetFromUrl', url, autoUpdate),
-    updatePresetFromRemote: () =>
-      ipcRenderer.invoke('utio:updatePresetFromRemote'),
-    resetPreset: () => ipcRenderer.invoke('utio:resetPreset'),
   },
   setting: {
+    importPresetFromFile: (yamlContent: string) =>
+      ipcRenderer.invoke('setting:importPresetFromFile', yamlContent),
+    importPresetFromUrl: (url: string, autoUpdate: boolean) =>
+      ipcRenderer.invoke('setting:importPresetFromUrl', url, autoUpdate),
+    updatePresetFromRemote: () =>
+      ipcRenderer.invoke('setting:updatePresetFromRemote'),
+    resetPreset: () => ipcRenderer.invoke('setting:resetPreset'),
     clear: () => ipcRenderer.invoke('setting:clear'),
   },
 };

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -7,7 +7,7 @@ import { preloadZustandBridge } from 'zutron/preload';
 
 import type { UTIOPayload } from '@ui-tars/utio';
 
-import type { AppState } from '@main/store/types';
+import type { AppState, LocalStore } from '@main/store/types';
 
 export type Channels = 'ipc-example';
 
@@ -42,14 +42,20 @@ const electronHandler = {
       ipcRenderer.invoke('utio:shareReport', params),
   },
   setting: {
-    importPresetFromFile: (yamlContent: string) =>
-      ipcRenderer.invoke('setting:importPresetFromFile', yamlContent),
+    getSetting: () => ipcRenderer.invoke('setting:get'),
+    clearSetting: () => ipcRenderer.invoke('setting:clear'),
+    updateSetting: (setting: Partial<LocalStore>) =>
+      ipcRenderer.invoke('setting:update', setting),
+    importPresetFromText: (yamlContent: string) =>
+      ipcRenderer.invoke('setting:importPresetFromText', yamlContent),
     importPresetFromUrl: (url: string, autoUpdate: boolean) =>
       ipcRenderer.invoke('setting:importPresetFromUrl', url, autoUpdate),
     updatePresetFromRemote: () =>
       ipcRenderer.invoke('setting:updatePresetFromRemote'),
     resetPreset: () => ipcRenderer.invoke('setting:resetPreset'),
-    clear: () => ipcRenderer.invoke('setting:clear'),
+    onUpdate: (callback: (setting: LocalStore) => void) => {
+      ipcRenderer.on('setting-updated', (_, state) => callback(state));
+    },
   },
 };
 

--- a/src/renderer/src/components/ChatInput/index.tsx
+++ b/src/renderer/src/components/ChatInput/index.tsx
@@ -36,6 +36,7 @@ import { uploadReport } from '@renderer/utils/share';
 import reportHTMLUrl from '@resources/report.html?url';
 import { isCallUserMessage } from '@renderer/utils/message';
 import { useScreenRecord } from '@renderer/hooks/useScreenRecord';
+import { useSetting } from '@renderer/hooks/useSetting';
 
 const ChatInput = forwardRef((_props, _ref) => {
   const {
@@ -43,8 +44,8 @@ const ChatInput = forwardRef((_props, _ref) => {
     instructions: savedInstructions,
     messages,
     restUserData,
-    settings,
   } = useStore();
+  const { settings } = useSetting();
 
   const [localInstructions, setLocalInstructions] = React.useState(
     savedInstructions ?? '',

--- a/src/renderer/src/hooks/useRunAgent.ts
+++ b/src/renderer/src/hooks/useRunAgent.ts
@@ -10,11 +10,13 @@ import { Conversation } from '@ui-tars/shared/types';
 import { useStore } from '@renderer/hooks/useStore';
 
 import { usePermissions } from './usePermissions';
+import { useSetting } from './useSetting';
 
 export const useRunAgent = () => {
   const dispatch = useDispatch();
   const toast = useToast();
-  const { messages, settings } = useStore();
+  const { settings } = useSetting();
+  const { messages } = useStore();
   const { ensurePermissions } = usePermissions();
 
   const run = (value: string, callback: () => void = () => {}) => {

--- a/src/renderer/src/hooks/useSetting.ts
+++ b/src/renderer/src/hooks/useSetting.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { LocalStore } from '@main/store/validate';
+import { useEffect, useState } from 'react';
+
+export function useSetting() {
+  const settingRpc = window.electron.setting;
+  const [settings, setSettings] = useState<Partial<LocalStore>>({});
+
+  useEffect(() => {
+    const initSetting = async () => {
+      const currentSetting = await settingRpc.getSetting();
+      setSettings(currentSetting);
+    };
+
+    settingRpc.onUpdate((newState) => {
+      setSettings(newState);
+    });
+
+    initSetting();
+
+    // FIXME: clear setting update listener
+  }, []);
+
+  const {
+    updateSetting,
+    clearSetting,
+    updatePresetFromRemote,
+    importPresetFromText,
+    importPresetFromUrl,
+  } = settingRpc;
+
+  return {
+    settings,
+    updateSetting,
+    clearSetting,
+    updatePresetFromRemote,
+    importPresetFromText,
+    importPresetFromUrl,
+  };
+}

--- a/src/renderer/src/pages/settings/PresetImport.tsx
+++ b/src/renderer/src/pages/settings/PresetImport.tsx
@@ -1,3 +1,7 @@
+/**
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
 import {
   Box,
   Button,

--- a/src/renderer/src/pages/settings/PresetImport.tsx
+++ b/src/renderer/src/pages/settings/PresetImport.tsx
@@ -50,7 +50,7 @@ export function PresetImport({ isOpen, onClose }: PresetImportProps) {
       });
 
       // Send text content via IPC
-      await window.electron.utio.importPresetFromFile(yamlText);
+      await window.electron.setting.importPresetFromFile(yamlText);
       dispatch({ type: 'GET_SETTINGS', payload: null });
 
       toast({
@@ -71,7 +71,7 @@ export function PresetImport({ isOpen, onClose }: PresetImportProps) {
 
   const handleRemoteImport = async () => {
     try {
-      await window.electron.utio.importPresetFromUrl(remoteUrl, autoUpdate);
+      await window.electron.setting.importPresetFromUrl(remoteUrl, autoUpdate);
       dispatch({ type: 'GET_SETTINGS', payload: null });
 
       toast({

--- a/src/renderer/src/pages/settings/PresetImport.tsx
+++ b/src/renderer/src/pages/settings/PresetImport.tsx
@@ -1,0 +1,153 @@
+import {
+  Box,
+  Button,
+  FormControl,
+  FormLabel,
+  Input,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Switch,
+  Tab,
+  TabList,
+  TabPanel,
+  TabPanels,
+  Tabs,
+  Text,
+  VStack,
+  useToast,
+} from '@chakra-ui/react';
+import { useRef, useState } from 'react';
+
+interface PresetImportProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function PresetImport({ isOpen, onClose }: PresetImportProps) {
+  const [remoteUrl, setRemoteUrl] = useState('');
+  const [autoUpdate, setAutoUpdate] = useState(true);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const toast = useToast();
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    try {
+      // Use FileReader to read file contents
+      const reader = new FileReader();
+      const yamlText = await new Promise<string>((resolve, reject) => {
+        reader.onload = () => resolve(reader.result as string);
+        reader.onerror = () => reject(reader.error);
+        reader.readAsText(file);
+      });
+
+      // Send text content via IPC
+      await window.electron.utio.importPresetFromFile(yamlText);
+
+      toast({
+        title: 'Preset imported successfully',
+        status: 'success',
+        duration: 2000,
+      });
+      onClose();
+    } catch (error) {
+      toast({
+        title: 'Failed to import preset',
+        description: error.message,
+        status: 'error',
+        duration: 3000,
+      });
+    }
+  };
+
+  const handleRemoteImport = async () => {
+    try {
+      await window.electron.utio.importPresetFromUrl(remoteUrl, autoUpdate);
+      toast({
+        title: 'Preset imported successfully',
+        status: 'success',
+        duration: 2000,
+      });
+      onClose();
+    } catch (error) {
+      toast({
+        title: 'Failed to import preset',
+        description: error.message,
+        status: 'error',
+        duration: 3000,
+      });
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Import Preset</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>
+          <Tabs>
+            <TabList>
+              <Tab>Local File</Tab>
+              <Tab>Remote URL</Tab>
+            </TabList>
+            <TabPanels>
+              <TabPanel>
+                <VStack spacing={4}>
+                  <Text>Select a YAML file to import settings preset</Text>
+                  <input
+                    type="file"
+                    accept=".yaml,.yml"
+                    ref={fileInputRef}
+                    style={{ display: 'none' }}
+                    onChange={handleFileChange}
+                  />
+                  <Button onClick={() => fileInputRef.current?.click()}>
+                    Choose File
+                  </Button>
+                </VStack>
+              </TabPanel>
+              <TabPanel>
+                <VStack spacing={4}>
+                  <FormControl>
+                    <FormLabel>Preset URL</FormLabel>
+                    <Input
+                      value={remoteUrl}
+                      onChange={(e) => setRemoteUrl(e.target.value)}
+                      placeholder="https://example.com/preset.yaml"
+                    />
+                  </FormControl>
+                  <FormControl display="flex" alignItems="center">
+                    <FormLabel mb="0">Auto update on startup</FormLabel>
+                    <Switch
+                      isChecked={autoUpdate}
+                      onChange={(e) => setAutoUpdate(e.target.checked)}
+                    />
+                  </FormControl>
+                </VStack>
+              </TabPanel>
+            </TabPanels>
+          </Tabs>
+        </ModalBody>
+        <ModalFooter>
+          <Button variant="ghost" mr={3} onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            variant="tars-ghost"
+            onClick={handleRemoteImport}
+            isDisabled={!remoteUrl}
+          >
+            Import
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/src/renderer/src/pages/settings/PresetImport.tsx
+++ b/src/renderer/src/pages/settings/PresetImport.tsx
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import {
-  Box,
   Button,
   FormControl,
   FormLabel,
@@ -25,8 +24,8 @@ import {
   VStack,
   useToast,
 } from '@chakra-ui/react';
+import { useSetting } from '@renderer/hooks/useSetting';
 import { useRef, useState } from 'react';
-import { useDispatch } from 'zutron';
 
 interface PresetImportProps {
   isOpen: boolean;
@@ -38,7 +37,7 @@ export function PresetImport({ isOpen, onClose }: PresetImportProps) {
   const [autoUpdate, setAutoUpdate] = useState(true);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const toast = useToast();
-  const dispatch = useDispatch(window.zutron);
+  const { importPresetFromText, importPresetFromUrl } = useSetting();
 
   const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -53,10 +52,7 @@ export function PresetImport({ isOpen, onClose }: PresetImportProps) {
         reader.readAsText(file);
       });
 
-      // Send text content via IPC
-      await window.electron.setting.importPresetFromFile(yamlText);
-      dispatch({ type: 'GET_SETTINGS', payload: null });
-
+      await importPresetFromText(yamlText);
       toast({
         title: 'Preset imported successfully',
         status: 'success',
@@ -66,7 +62,8 @@ export function PresetImport({ isOpen, onClose }: PresetImportProps) {
     } catch (error) {
       toast({
         title: 'Failed to import preset',
-        description: error.message,
+        description:
+          error instanceof Error ? error.message : 'Unknown error occurred',
         status: 'error',
         duration: 3000,
       });
@@ -75,9 +72,7 @@ export function PresetImport({ isOpen, onClose }: PresetImportProps) {
 
   const handleRemoteImport = async () => {
     try {
-      await window.electron.setting.importPresetFromUrl(remoteUrl, autoUpdate);
-      dispatch({ type: 'GET_SETTINGS', payload: null });
-
+      await importPresetFromUrl(remoteUrl, autoUpdate);
       toast({
         title: 'Preset imported successfully',
         status: 'success',
@@ -87,7 +82,8 @@ export function PresetImport({ isOpen, onClose }: PresetImportProps) {
     } catch (error) {
       toast({
         title: 'Failed to import preset',
-        description: error.message,
+        description:
+          error instanceof Error ? error.message : 'Unknown error occurred',
         status: 'error',
         duration: 3000,
       });

--- a/src/renderer/src/pages/settings/PresetImport.tsx
+++ b/src/renderer/src/pages/settings/PresetImport.tsx
@@ -22,6 +22,7 @@ import {
   useToast,
 } from '@chakra-ui/react';
 import { useRef, useState } from 'react';
+import { useDispatch } from 'zutron';
 
 interface PresetImportProps {
   isOpen: boolean;
@@ -33,6 +34,7 @@ export function PresetImport({ isOpen, onClose }: PresetImportProps) {
   const [autoUpdate, setAutoUpdate] = useState(true);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const toast = useToast();
+  const dispatch = useDispatch(window.zutron);
 
   const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -49,6 +51,7 @@ export function PresetImport({ isOpen, onClose }: PresetImportProps) {
 
       // Send text content via IPC
       await window.electron.utio.importPresetFromFile(yamlText);
+      dispatch({ type: 'GET_SETTINGS', payload: null });
 
       toast({
         title: 'Preset imported successfully',
@@ -69,6 +72,8 @@ export function PresetImport({ isOpen, onClose }: PresetImportProps) {
   const handleRemoteImport = async () => {
     try {
       await window.electron.utio.importPresetFromUrl(remoteUrl, autoUpdate);
+      dispatch({ type: 'GET_SETTINGS', payload: null });
+
       toast({
         title: 'Preset imported successfully',
         status: 'success',

--- a/src/renderer/src/pages/settings/index.tsx
+++ b/src/renderer/src/pages/settings/index.tsx
@@ -34,7 +34,7 @@ import { isWindows } from '@renderer/utils/os';
 
 import { PresetImport } from './PresetImport';
 
-const Settings = () => {
+export default function Settings() {
   const { settings, thinking } = useStore();
   console.log('settings', settings);
 
@@ -101,234 +101,277 @@ const Settings = () => {
   };
 
   return (
-    <Box
-      px={4}
-      py={!isWindows ? 8 : 0}
-      position="relative"
-      overflow="auto"
-      maxH="100vh"
-    >
-      {!isWindows && (
+    <Box h="100vh" overflow="hidden" px={6} pt={6} pb={0}>
+      <Tabs
+        display="flex"
+        flexDirection="column"
+        h="full"
+        pt={4} // 添加顶部间距
+      >
         <Box
-          className="draggable-area"
-          w="100%"
-          h={34}
-          position="absolute"
+          borderColor="gray.200"
+          bg="white"
+          position="sticky"
           top={0}
-        />
-      )}
-      <Tabs variant="line">
-        <TabList>
-          <Tab>General</Tab>
-          <Box ml="auto" display="flex" alignItems="center">
-            {settings?.presetSource?.type === 'remote' && (
-              <Button
-                size="sm"
-                mr={2}
-                onClick={handleUpdatePreset}
-                variant="tars-ghost"
-              >
-                Update Preset
-              </Button>
-            )}
-            <IconButton
-              icon={<IoAdd />}
-              aria-label="Import Preset"
-              variant="ghost"
-              onClick={() => setPresetModalOpen(true)}
-            />
-          </Box>
-        </TabList>
-
-        <TabPanels>
-          <TabPanel>
-            <VStack spacing={8} align="stretch">
+          zIndex={1}
+          px={2}
+          flexShrink={0}
+        >
+          <TabList>
+            <Tab>General</Tab>
+            <Box ml="auto" display="flex" alignItems="center">
               {settings?.presetSource?.type === 'remote' && (
-                <Box p={4} bg="gray.50" borderRadius="md">
-                  <Text fontSize="sm" color="gray.600">
-                    Settings managed by remote preset from{' '}
-                    {settings.presetSource.url}
-                    {settings.presetSource.lastUpdated &&
-                      ` (Last updated: ${new Date(settings.presetSource.lastUpdated).toLocaleString()})`}
-                  </Text>
-                  <Button
-                    size="sm"
-                    mt={2}
-                    onClick={() => window.electron.utio.resetPreset()}
-                    variant="ghost"
-                  >
-                    Reset to Manual
-                  </Button>
-                </Box>
+                <Button
+                  size="sm"
+                  mr={2}
+                  onClick={handleUpdatePreset}
+                  variant="tars-ghost"
+                >
+                  Update Preset
+                </Button>
               )}
+              <IconButton
+                icon={<IoAdd />}
+                aria-label="Import Preset"
+                variant="ghost"
+                onClick={() => setPresetModalOpen(true)}
+              />
+            </Box>
+          </TabList>
+        </Box>
 
-              {settings ? (
-                <Formik initialValues={settings} onSubmit={handleSubmit}>
-                  {({ values = {}, setFieldValue }) => (
-                    <Form>
-                      <VStack spacing={4} align="stretch">
-                        <FormControl>
-                          <FormLabel color="gray.700">Language</FormLabel>
-                          <Field
-                            as={Select}
-                            name="language"
-                            value={values.language}
-                            bg="white"
-                            borderColor="gray.200"
-                            _hover={{ borderColor: 'gray.300' }}
-                            _focus={{
-                              borderColor: 'gray.400',
-                              boxShadow: 'none',
-                            }}
-                          >
-                            <option key="en" value="en">
-                              English
-                            </option>
-                            <option key="zh" value="zh">
-                              中文
-                            </option>
-                          </Field>
-                        </FormControl>
+        <TabPanels flex="1" overflow="hidden">
+          <TabPanel h="full" position="relative" overflow="hidden" p={0}>
+            <Box
+              position="absolute"
+              top={0}
+              left={0}
+              right={0}
+              bottom={0}
+              overflowY="auto"
+              px={2}
+              sx={{
+                '&::-webkit-scrollbar': {
+                  width: '10px',
+                  backgroundColor: 'transparent',
+                },
+                '&::-webkit-scrollbar-track': {
+                  backgroundColor: 'transparent',
+                },
+                '&::-webkit-scrollbar-thumb': {
+                  backgroundColor: 'rgba(0, 0, 0, 0.3)',
+                  border: '2px solid transparent',
+                  borderRadius: '10px',
+                  backgroundClip: 'padding-box',
+                  '&:hover': {
+                    backgroundColor: 'rgba(0, 0, 0, 0.4)',
+                  },
+                },
+                // 只在滚动时显示滚动条
+                '&::-webkit-scrollbar-thumb:window-inactive': {
+                  backgroundColor: 'transparent',
+                },
+              }}
+            >
+              <VStack spacing={2} align="stretch" py={4}>
+                {settings?.presetSource?.type === 'remote' && (
+                  <Box p={4} bg="gray.50" borderRadius="md">
+                    <Text fontSize="sm" color="gray.600">
+                      Settings managed by remote preset from{' '}
+                      {settings.presetSource.url}
+                      {settings.presetSource.lastUpdated &&
+                        ` (Last updated: ${new Date(settings.presetSource.lastUpdated).toLocaleString()})`}
+                    </Text>
+                    <Button
+                      size="sm"
+                      mt={2}
+                      onClick={() => window.electron.utio.resetPreset()}
+                      variant="ghost"
+                    >
+                      Reset to Manual
+                    </Button>
+                  </Box>
+                )}
 
-                        <FormControl>
-                          <FormLabel color="gray.700">VLM Provider</FormLabel>
-                          <Field
-                            as={Select}
-                            name="vlmProvider"
-                            value={values.vlmProvider}
-                            bg="white"
-                            borderColor="gray.200"
-                            _hover={{ borderColor: 'gray.300' }}
-                            _focus={{
-                              borderColor: 'gray.400',
-                              boxShadow: 'none',
-                            }}
-                            onChange={(e) => {
-                              const newValue = e.target.value;
-                              setFieldValue('vlmProvider', newValue);
-
-                              if (!settings.vlmBaseUrl) {
-                                setFieldValue('vlmProvider', newValue);
-                                if (newValue === VlmProvider.vLLM) {
-                                  setFieldValue(
-                                    'vlmBaseUrl',
-                                    'http://localhost:8000/v1',
-                                  );
-                                  setFieldValue('vlmModelName', 'ui-tars');
-                                } else if (
-                                  newValue === VlmProvider.Huggingface
-                                ) {
-                                  setFieldValue(
-                                    'vlmBaseUrl',
-                                    'https://<your_service>.us-east-1.aws.endpoints.huggingface.cloud/v1',
-                                  );
-                                  setFieldValue('vlmApiKey', 'your_api_key');
-                                  setFieldValue(
-                                    'vlmModelName',
-                                    'your_model_name',
-                                  );
-                                }
-                              }
-                            }}
-                          >
-                            {Object.values(VlmProvider).map((item) => (
-                              <option key={item} value={item}>
-                                {item}
+                {settings ? (
+                  <Formik initialValues={settings} onSubmit={handleSubmit}>
+                    {({ values = {}, setFieldValue }) => (
+                      <Form>
+                        <VStack spacing={4} align="stretch">
+                          <FormControl>
+                            <FormLabel color="gray.700">Language</FormLabel>
+                            <Field
+                              as={Select}
+                              name="language"
+                              value={values.language}
+                              bg="white"
+                              borderColor="gray.200"
+                              _hover={{ borderColor: 'gray.300' }}
+                              _focus={{
+                                borderColor: 'gray.400',
+                                boxShadow: 'none',
+                              }}
+                            >
+                              <option key="en" value="en">
+                                English
                               </option>
-                            ))}
-                          </Field>
-                        </FormControl>
+                              <option key="zh" value="zh">
+                                中文
+                              </option>
+                            </Field>
+                          </FormControl>
 
-                        <FormControl>
-                          <FormLabel color="gray.700">VLM Base URL</FormLabel>
-                          <Field
-                            as={Input}
-                            name="vlmBaseUrl"
-                            value={values.vlmBaseUrl}
-                            placeholder="please input VLM Base URL"
-                          />
-                        </FormControl>
+                          <FormControl>
+                            <FormLabel color="gray.700">VLM Provider</FormLabel>
+                            <Field
+                              as={Select}
+                              name="vlmProvider"
+                              value={values.vlmProvider}
+                              bg="white"
+                              borderColor="gray.200"
+                              _hover={{ borderColor: 'gray.300' }}
+                              _focus={{
+                                borderColor: 'gray.400',
+                                boxShadow: 'none',
+                              }}
+                              onChange={(e) => {
+                                const newValue = e.target.value;
+                                setFieldValue('vlmProvider', newValue);
 
-                        <FormControl>
-                          <FormLabel color="gray.700">VLM API Key</FormLabel>
-                          <Field
-                            as={Input}
-                            name="vlmApiKey"
-                            value={values.vlmApiKey}
-                            placeholder="please input VLM API_Key"
-                          />
-                        </FormControl>
+                                if (!settings.vlmBaseUrl) {
+                                  setFieldValue('vlmProvider', newValue);
+                                  if (newValue === VlmProvider.vLLM) {
+                                    setFieldValue(
+                                      'vlmBaseUrl',
+                                      'http://localhost:8000/v1',
+                                    );
+                                    setFieldValue('vlmModelName', 'ui-tars');
+                                  } else if (
+                                    newValue === VlmProvider.Huggingface
+                                  ) {
+                                    setFieldValue(
+                                      'vlmBaseUrl',
+                                      'https://<your_service>.us-east-1.aws.endpoints.huggingface.cloud/v1',
+                                    );
+                                    setFieldValue('vlmApiKey', 'your_api_key');
+                                    setFieldValue(
+                                      'vlmModelName',
+                                      'your_model_name',
+                                    );
+                                  }
+                                }
+                              }}
+                            >
+                              {Object.values(VlmProvider).map((item) => (
+                                <option key={item} value={item}>
+                                  {item}
+                                </option>
+                              ))}
+                            </Field>
+                          </FormControl>
 
-                        <FormControl>
-                          <FormLabel color="gray.700">VLM Model Name</FormLabel>
-                          <Field
-                            as={Input}
-                            name="vlmModelName"
-                            value={values.vlmModelName}
-                            placeholder="please input VLM Model Name"
-                          />
-                        </FormControl>
+                          <FormControl>
+                            <FormLabel color="gray.700">VLM Base URL</FormLabel>
+                            <Field
+                              as={Input}
+                              name="vlmBaseUrl"
+                              value={values.vlmBaseUrl}
+                              placeholder="please input VLM Base URL"
+                            />
+                          </FormControl>
 
-                        {/* <FormControl>
-                          <FormLabel color="gray.700">
-                            Report Storage Base URL
-                          </FormLabel>
-                          <Field
-                            as={Input}
-                            name="reportStorageBaseUrl"
-                            value={values.reportStorageBaseUrl}
-                            placeholder="https://your-report-storage-endpoint.com/upload"
-                          />
-                        </FormControl>
+                          <FormControl>
+                            <FormLabel color="gray.700">VLM API Key</FormLabel>
+                            <Field
+                              as={Input}
+                              name="vlmApiKey"
+                              value={values.vlmApiKey}
+                              placeholder="please input VLM API_Key"
+                            />
+                          </FormControl>
 
-                        <FormControl>
-                          <FormLabel color="gray.700">UTIO Base URL</FormLabel>
-                          <Field
-                            as={Input}
-                            name="utioBaseUrl"
-                            value={values.utioBaseUrl}
-                            placeholder="https://your-utio-endpoint.com/collect"
-                          />
-                        </FormControl> */}
+                          <FormControl>
+                            <FormLabel color="gray.700">
+                              VLM Model Name
+                            </FormLabel>
+                            <Field
+                              as={Input}
+                              name="vlmModelName"
+                              value={values.vlmModelName}
+                              placeholder="please input VLM Model Name"
+                            />
+                          </FormControl>
 
-                        <HStack spacing={4}>
-                          <Button
-                            type="submit"
-                            rounded="base"
-                            variant="tars-ghost"
-                          >
-                            Save
-                          </Button>
-                          <Button
-                            onClick={handleCancel}
-                            rounded="base"
-                            variant="ghost"
-                            fontWeight="normal"
-                          >
-                            Cancel
-                          </Button>
-                        </HStack>
-                      </VStack>
-                    </Form>
-                  )}
-                </Formik>
-              ) : (
-                <Center>
-                  <Spinner color="color.primary" />
-                </Center>
-              )}
-            </VStack>
+                          <FormControl>
+                            <FormLabel color="gray.700">
+                              Report Storage Base URL
+                            </FormLabel>
+                            <Field
+                              as={Input}
+                              name="reportStorageBaseUrl"
+                              value={values.reportStorageBaseUrl}
+                              placeholder="https://your-report-storage-endpoint.com/upload"
+                            />
+                          </FormControl>
+
+                          <FormControl>
+                            <FormLabel color="gray.700">
+                              UTIO Base URL
+                            </FormLabel>
+                            <Field
+                              as={Input}
+                              name="utioBaseUrl"
+                              value={values.utioBaseUrl}
+                              placeholder="https://your-utio-endpoint.com/collect"
+                            />
+                          </FormControl>
+                        </VStack>
+                      </Form>
+                    )}
+                  </Formik>
+                ) : (
+                  <Center>
+                    <Spinner color="color.primary" />
+                  </Center>
+                )}
+              </VStack>
+            </Box>
           </TabPanel>
         </TabPanels>
+
+        <Box
+          px={2}
+          py={4}
+          borderTop="1px"
+          borderColor="gray.200"
+          bg="white"
+          position="sticky"
+          bottom={0}
+          zIndex={1}
+          flexShrink={0}
+        >
+          <HStack spacing={4} justify="flex-start">
+            <Button type="submit" rounded="base" variant="tars-ghost">
+              Save
+            </Button>
+            <Button
+              onClick={handleCancel}
+              rounded="base"
+              variant="ghost"
+              fontWeight="normal"
+            >
+              Cancel
+            </Button>
+          </HStack>
+        </Box>
       </Tabs>
+
       <PresetImport
         isOpen={isPresetModalOpen}
         onClose={() => setPresetModalOpen(false)}
       />
     </Box>
   );
-};
-
-export default Settings;
+}
 
 export { Settings as Component };

--- a/src/renderer/src/pages/settings/index.tsx
+++ b/src/renderer/src/pages/settings/index.tsx
@@ -120,16 +120,6 @@ export default function Settings() {
           <TabList>
             <Tab>General</Tab>
             <Box ml="auto" display="flex" alignItems="center">
-              {settings?.presetSource?.type === 'remote' && (
-                <Button
-                  size="sm"
-                  mr={2}
-                  onClick={handleUpdatePreset}
-                  variant="tars-ghost"
-                >
-                  Update Preset
-                </Button>
-              )}
               <IconButton
                 icon={<IoAdd />}
                 aria-label="Import Preset"
@@ -175,21 +165,53 @@ export default function Settings() {
             >
               <VStack spacing={2} align="stretch" py={4}>
                 {settings?.presetSource?.type === 'remote' && (
-                  <Box p={4} bg="gray.50" borderRadius="md">
-                    <Text fontSize="sm" color="gray.600">
-                      Settings managed by remote preset from{' '}
-                      {settings.presetSource.url}
-                      {settings.presetSource.lastUpdated &&
-                        ` (Last updated: ${new Date(settings.presetSource.lastUpdated).toLocaleString()})`}
-                    </Text>
-                    <Button
-                      size="sm"
-                      mt={2}
-                      onClick={() => window.electron.utio.resetPreset()}
-                      variant="ghost"
-                    >
-                      Reset to Manual
-                    </Button>
+                  <Box
+                    p={4}
+                    bg="gray.50"
+                    borderRadius="md"
+                    borderWidth="1px"
+                    borderColor="gray.200"
+                    mb={4}
+                  >
+                    <VStack spacing={3} align="stretch">
+                      <HStack spacing={3} justify="space-between">
+                        <Text fontWeight="medium" color="gray.700">
+                          Remote Preset Management
+                        </Text>
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          colorScheme="gray"
+                          onClick={handleUpdatePreset}
+                        >
+                          Update Preset
+                        </Button>
+                      </HStack>
+
+                      <Box>
+                        <Text fontSize="sm" color="gray.600" noOfLines={2}>
+                          {settings.presetSource.url}
+                        </Text>
+                        {settings.presetSource.lastUpdated && (
+                          <Text fontSize="xs" color="gray.500" mt={1}>
+                            Last updated:{' '}
+                            {new Date(
+                              settings.presetSource.lastUpdated,
+                            ).toLocaleString()}
+                          </Text>
+                        )}
+                      </Box>
+
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        colorScheme="gray"
+                        onClick={() => window.electron.utio.resetPreset()}
+                        alignSelf="flex-start"
+                      >
+                        Reset to Manual
+                      </Button>
+                    </VStack>
                   </Box>
                 )}
 

--- a/src/renderer/src/pages/settings/index.tsx
+++ b/src/renderer/src/pages/settings/index.tsx
@@ -37,9 +37,8 @@ import { PresetImport } from './PresetImport';
 
 export default function Settings() {
   const { settings, thinking } = useStore();
-  console.log('settings', settings);
-
   const [isPresetModalOpen, setPresetModalOpen] = useState(false);
+  const [retrieveSetting, setRetrieveSetting] = useState(true);
   const toast = useToast();
   const dispatch = useDispatch(window.zutron);
 
@@ -103,12 +102,7 @@ export default function Settings() {
 
   const handleClearSettings = async () => {
     try {
-      await window.electron.setting.clear();
-      // 刷新设置
-      dispatch({
-        type: 'GET_SETTINGS',
-        payload: null,
-      });
+      dispatch({ type: 'CLEAR_SETTINGS', payload: null });
       toast({
         title: 'All settings cleared successfully',
         status: 'success',

--- a/src/renderer/src/pages/settings/index.tsx
+++ b/src/renderer/src/pages/settings/index.tsx
@@ -85,7 +85,7 @@ export default function Settings() {
   console.log('initialValues', settings);
   const handleUpdatePreset = async () => {
     try {
-      await window.electron.utio.updatePresetFromRemote();
+      await window.electron.setting.updatePresetFromRemote();
       toast({
         title: 'Preset updated successfully',
         status: 'success',
@@ -233,7 +233,7 @@ export default function Settings() {
                         variant="outline"
                         colorScheme="red"
                         onClick={async () => {
-                          await window.electron.utio.resetPreset();
+                          await window.electron.setting.resetPreset();
                           // refresh setting
                           dispatch({
                             type: 'GET_SETTINGS',

--- a/src/renderer/src/pages/settings/index.tsx
+++ b/src/renderer/src/pages/settings/index.tsx
@@ -25,7 +25,7 @@ import {
 } from '@chakra-ui/react';
 import { Field, Form, Formik } from 'formik';
 import { useLayoutEffect, useState } from 'react';
-import { IoAdd, IoInformationCircle } from 'react-icons/io5';
+import { IoAdd, IoInformationCircle, IoTrash } from 'react-icons/io5';
 import { useDispatch } from 'zutron';
 
 import { VlmProvider } from '@main/store/types';
@@ -94,6 +94,29 @@ export default function Settings() {
     } catch (error) {
       toast({
         title: 'Failed to update preset',
+        description: error.message,
+        status: 'error',
+        duration: 3000,
+      });
+    }
+  };
+
+  const handleClearSettings = async () => {
+    try {
+      await window.electron.setting.clear();
+      // 刷新设置
+      dispatch({
+        type: 'GET_SETTINGS',
+        payload: null,
+      });
+      toast({
+        title: 'All settings cleared successfully',
+        status: 'success',
+        duration: 2000,
+      });
+    } catch (error) {
+      toast({
+        title: 'Failed to clear settings',
         description: error.message,
         status: 'error',
         duration: 3000,
@@ -231,7 +254,11 @@ export default function Settings() {
                 )}
 
                 {settings ? (
-                  <Formik initialValues={settings} onSubmit={handleSubmit}>
+                  <Formik
+                    initialValues={settings}
+                    onSubmit={handleSubmit}
+                    enableReinitialize
+                  >
                     {({ values = {}, setFieldValue }) => {
                       const isRemotePreset =
                         settings?.presetSource?.type === 'remote';
@@ -411,24 +438,34 @@ export default function Settings() {
           zIndex={1}
           flexShrink={0}
         >
-          <HStack spacing={4} justify="flex-start">
-            <Button
-              form="settings-form"
-              as="button"
-              type="submit"
-              rounded="base"
-              variant="tars-ghost"
-            >
-              Save
-            </Button>
-            <Button
-              onClick={handleCancel}
-              rounded="base"
+          <HStack spacing={4} justify="space-between">
+            <HStack spacing={4}>
+              <Button
+                form="settings-form"
+                as="button"
+                type="submit"
+                rounded="base"
+                variant="tars-ghost"
+              >
+                Save
+              </Button>
+              <Button
+                onClick={handleCancel}
+                rounded="base"
+                variant="ghost"
+                fontWeight="normal"
+              >
+                Cancel
+              </Button>
+            </HStack>
+
+            <IconButton
+              aria-label="Clear all settings"
+              icon={<IoTrash />}
               variant="ghost"
-              fontWeight="normal"
-            >
-              Cancel
-            </Button>
+              colorScheme="red"
+              onClick={handleClearSettings}
+            />
           </HStack>
         </Box>
       </Tabs>

--- a/src/renderer/src/pages/settings/index.tsx
+++ b/src/renderer/src/pages/settings/index.tsx
@@ -209,7 +209,19 @@ export default function Settings() {
                         size="sm"
                         variant="outline"
                         colorScheme="red"
-                        onClick={() => window.electron.utio.resetPreset()}
+                        onClick={async () => {
+                          await window.electron.utio.resetPreset();
+                          // refresh setting
+                          dispatch({
+                            type: 'GET_SETTINGS',
+                            payload: null,
+                          });
+                          toast({
+                            title: 'Reset to manual mode successfully',
+                            status: 'success',
+                            duration: 2000,
+                          });
+                        }}
                         alignSelf="flex-start"
                       >
                         Reset to Manual
@@ -241,7 +253,7 @@ export default function Settings() {
                       };
 
                       return (
-                        <Form>
+                        <Form id="settings-form">
                           <VStack spacing={4} align="stretch">
                             <FormControl>
                               <FormLabel color="gray.700">Language</FormLabel>
@@ -400,7 +412,13 @@ export default function Settings() {
           flexShrink={0}
         >
           <HStack spacing={4} justify="flex-start">
-            <Button type="submit" rounded="base" variant="tars-ghost">
+            <Button
+              form="settings-form"
+              as="button"
+              type="submit"
+              rounded="base"
+              variant="tars-ghost"
+            >
               Save
             </Button>
             <Button

--- a/src/renderer/src/pages/settings/index.tsx
+++ b/src/renderer/src/pages/settings/index.tsx
@@ -101,7 +101,13 @@ const Settings = () => {
   };
 
   return (
-    <Box px={4} py={!isWindows ? 8 : 0} position="relative" overflow="hidden">
+    <Box
+      px={4}
+      py={!isWindows ? 8 : 0}
+      position="relative"
+      overflow="auto"
+      maxH="100vh"
+    >
       {!isWindows && (
         <Box
           className="draggable-area"

--- a/src/renderer/src/pages/settings/index.tsx
+++ b/src/renderer/src/pages/settings/index.tsx
@@ -55,12 +55,6 @@ export default function Settings() {
       duration: 1500,
       isClosable: true,
       variant: 'ui-tars-success',
-      // onCloseComplete: () => {
-      //   dispatch({
-      //     type: 'CLOSE_SETTINGS_WINDOW',
-      //     payload: null,
-      //   });
-      // },
     });
   };
 
@@ -220,11 +214,6 @@ export default function Settings() {
                         colorScheme="red"
                         onClick={async () => {
                           await window.electron.setting.resetPreset();
-                          // refresh setting
-                          dispatch({
-                            type: 'GET_SETTINGS',
-                            payload: null,
-                          });
                           toast({
                             title: 'Reset to manual mode successfully',
                             status: 'success',


### PR DESCRIPTION
## Summary

This pull request refined the setting page ui and introduce setting `Preset`, A preset is a collection of settings, UI TARS Desktop supports setting presets via files or URLs.

Close:#57

## Minor Changes

- **Refine setting store**: Due to the instability and difficulty of `zutron`, this PR removed `SettingStore`(`electron-store`) from `store` (`zutron` and `zustand`), we'll design a new state management solution later.
- **Scroll bar in setting**: To avoid the setting window too long, we introduced a inner scroll bar similar to macOS. 

## Features

### Import from file

| Function | Snapshot |
| --- | ---|
| Open Setting |<img width="320" alt="image" src="https://github.com/user-attachments/assets/1d2ae27c-9b2e-4896-96a6-04832f850907" /> |
| Import Success | <img width="320" alt="image" src="https://github.com/user-attachments/assets/38f77101-7388-4363-ab27-668180f51aaa" />|
| Exception: Invalid Content | <img width="320" alt="image" src="https://github.com/user-attachments/assets/5ebec2b2-12f6-4d1a-84a7-8202ef651223" /> |

### Import from URL

| Function | Snapshot |
| --- | ---|
| Open Setting | <img width="320" alt="image" src="https://github.com/user-attachments/assets/d446da0e-3bb4-4ca5-bc95-4f235d979fd0" /> |
| Import Success (Default) | <img width="320" alt="image" src="https://github.com/user-attachments/assets/a6470ed4-80ac-45a1-aaba-39e598d5af0f" /> |
| Import Success (Auto Update) | <img width="320" alt="image" src="https://github.com/user-attachments/assets/b5364d66-6654-401b-969e-f85baeedbda0" />|

## Misnouncelles

| Function | Snapshot |
| --- | ---|
| Clear Setting | <img width="320" alt="image" src="https://github.com/user-attachments/assets/c7707d00-7e6c-4182-a11d-de109503e509" /> |
| Inner Scroll Bar | <img width="320" alt="image" src="https://github.com/user-attachments/assets/777a175c-4b65-4e0c-8bd3-2d6e43d5625d" />|

---

## References (Summary generated by AI)
 
This pull request focuses on refactoring the settings management system by centralizing the settings store and improving the handling of settings presets. The most important changes include replacing the `store` with `SettingStore`, adding new methods for preset management, and updating various files to use the new `SettingStore`.

### Centralization of Settings Management:

* [`src/main/agent/llm/ui-tars.ts`](diffhunk://#diff-9109a96bd02e3b7c1fdedd1deff8d7e53aaad3657e388e3246f8813e3d877395L9-R13): Replaced usage of `store` with `SettingStore` for accessing settings such as `vlmModelName`, `vlmBaseUrl`, and `vlmApiKey`. [[1]](diffhunk://#diff-9109a96bd02e3b7c1fdedd1deff8d7e53aaad3657e388e3246f8813e3d877395L9-R13) [[2]](diffhunk://#diff-9109a96bd02e3b7c1fdedd1deff8d7e53aaad3657e388e3246f8813e3d877395L29-R29) [[3]](diffhunk://#diff-9109a96bd02e3b7c1fdedd1deff8d7e53aaad3657e388e3246f8813e3d877395L47-R48)
* [`src/main/services/utio.ts`](diffhunk://#diff-82cd80e6b189591ef67219e23c1bb29f6da9f839956a06fa73228ac355bfdd67L8-R8): Replaced usage of `store` with `SettingStore` for accessing `utioBaseUrl`. [[1]](diffhunk://#diff-82cd80e6b189591ef67219e23c1bb29f6da9f839956a06fa73228ac355bfdd67L8-R8) [[2]](diffhunk://#diff-82cd80e6b189591ef67219e23c1bb29f6da9f839956a06fa73228ac355bfdd67L22-R22)
* [`src/main/store/create.ts`](diffhunk://#diff-9d4378a54f4b04db7b5f7e9acafa4d09a4dd2b7d08549f5f97e34bb9ede28c9fL20-R20): Removed settings-related methods and state from `store`. [[1]](diffhunk://#diff-9d4378a54f4b04db7b5f7e9acafa4d09a4dd2b7d08549f5f97e34bb9ede28c9fL20-R20) [[2]](diffhunk://#diff-9d4378a54f4b04db7b5f7e9acafa4d09a4dd2b7d08549f5f97e34bb9ede28c9fL31-L33) [[3]](diffhunk://#diff-9d4378a54f4b04db7b5f7e9acafa4d09a4dd2b7d08549f5f97e34bb9ede28c9fL57-L66)
* [`src/main/store/runAgent.ts`](diffhunk://#diff-77ec587aa56eb5a129f0f5f7273247d6d842eca2b107054b5b0ce21bcecde897L32-R37): Updated to use `SettingStore` for accessing language settings.

### Addition of Preset Management Methods:

* [`src/main/services/settings.ts`](diffhunk://#diff-fcb224d55f9a04f412b0a23b3d085ac20597b8bada35b7b40d5a011313ed4dbfR1-R91): Implemented new IPC handlers for managing settings, including getting, clearing, resetting, updating, and importing presets.
* [`src/main/store/setting.ts`](diffhunk://#diff-a8067c2daa9a0f6daf41e9c90b1e78686cc90b49eec3fdd9e1f10517431f8e8bR6-R138): Added methods for importing presets from URL or text and handling preset updates.

### Integration of New Settings Management:

* [`src/main/main.ts`](diffhunk://#diff-7adaa52a2eacb085ba5e07e6683a61fb3601547dc00b51fd50fbaf685e13fe96R29-R31): Registered the new settings handlers and implemented logic for checking and updating remote presets. [[1]](diffhunk://#diff-7adaa52a2eacb085ba5e07e6683a61fb3601547dc00b51fd50fbaf685e13fe96R29-R31) [[2]](diffhunk://#diff-7adaa52a2eacb085ba5e07e6683a61fb3601547dc00b51fd50fbaf685e13fe96R169-R181) [[3]](diffhunk://#diff-7adaa52a2eacb085ba5e07e6683a61fb3601547dc00b51fd50fbaf685e13fe96R199-R200)
* [`src/preload/index.ts`](diffhunk://#diff-ab22c748afd4538220cdeba0013847231dc39f27e2b94e71fb21002712d375c0R44-R59): Added new methods to the `electronHandler` for interacting with settings from the renderer process.

### Renderer Process Updates:

* [`src/renderer/src/hooks/useSetting.ts`](diffhunk://#diff-f914a94fade080037ddb9da50e61ce69bd505833ec3e7e24ca13f27511780158R1-R43): Created a new hook to manage settings in the renderer process, including fetching initial settings and handling updates.
* Updated various components and hooks to use the new `useSetting` hook instead of accessing settings directly from the store. [[1]](diffhunk://#diff-c527c5ebe53f704b59cdf494dc1a26e5b4ab7c6f2a8bfff1e75de8ecd7db3066R39-R48) [[2]](diffhunk://#diff-c6ef67e41382db2fb745a6d842e54524b5bf33eaf596c6f054131a3a2c7f6449R13-R19)

These changes collectively improve the modularity and maintainability of the settings management system by centralizing settings logic and providing a clear interface for managing settings and presets.
