### PR TITLE
fix(permission): macOS permissions updates are not real-time

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ env:
 jobs:
   test:
     name: Test & Typecheck
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
 
     steps:
       - uses: actions/checkout@v4

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -33,6 +33,10 @@
     {
       "language": "javascriptreact",
       "mapTo": "javascript"
+    },
+    {
+      "language": "*",
+      "template": []
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "react-use": "^17.6.0",
     "rimraf": "^6.0.1",
     "sass-embedded": "^1.83.1",
+    "swr": "^2.3.0",
     "tailwind-merge": "2.5.5",
     "ts-node": "^10.9.2",
     "tsx": "^4.19.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -255,6 +255,9 @@ importers:
       sass-embedded:
         specifier: ^1.83.1
         version: 1.83.1
+      swr:
+        specifier: ^2.3.0
+        version: 2.3.0(react@18.3.1)
       tailwind-merge:
         specifier: 2.5.5
         version: 2.5.5
@@ -3060,6 +3063,10 @@ packages:
 
   deprecation@2.3.1:
     resolution: {integrity: sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
 
   destroy@1.2.0:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
@@ -6040,6 +6047,11 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  swr@2.3.0:
+    resolution: {integrity: sha512-NyZ76wA4yElZWBHzSgEJc28a0u6QZvhb6w0azeL2k7+Q1gAzVK+IqQYXhVOC/mzi+HZIozrZvBVeSeOZNR2bqA==}
+    peerDependencies:
+      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -9209,14 +9221,6 @@ snapshots:
     optionalDependencies:
       vite: 5.4.11(@types/node@20.17.11)(sass-embedded@1.83.1)(sass@1.83.0)(terser@5.37.0)
 
-  '@vitest/mocker@3.0.2(vite@5.4.11(@types/node@22.10.7)(sass-embedded@1.83.1)(sass@1.83.0)(terser@5.37.0))':
-    dependencies:
-      '@vitest/spy': 3.0.2
-      estree-walker: 3.0.3
-      magic-string: 0.30.17
-    optionalDependencies:
-      vite: 5.4.11(@types/node@22.10.7)(sass-embedded@1.83.1)(sass@1.83.0)(terser@5.37.0)
-
   '@vitest/pretty-format@3.0.2':
     dependencies:
       tinyrainbow: 2.0.0
@@ -10034,6 +10038,8 @@ snapshots:
   depd@2.0.0: {}
 
   deprecation@2.3.1: {}
+
+  dequal@2.0.3: {}
 
   destroy@1.2.0: {}
 
@@ -13438,6 +13444,12 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  swr@2.3.0(react@18.3.1):
+    dependencies:
+      dequal: 2.0.3
+      react: 18.3.1
+      use-sync-external-store: 1.4.0(react@18.3.1)
+
   symbol-tree@3.2.4:
     optional: true
 
@@ -13819,7 +13831,6 @@ snapshots:
   use-sync-external-store@1.4.0(react@18.3.1):
     dependencies:
       react: 18.3.1
-    optional: true
 
   username@5.1.0:
     dependencies:
@@ -13955,7 +13966,7 @@ snapshots:
   vitest@3.0.2(@types/node@22.10.7)(jsdom@20.0.3)(sass-embedded@1.83.1)(sass@1.83.0)(terser@5.37.0):
     dependencies:
       '@vitest/expect': 3.0.2
-      '@vitest/mocker': 3.0.2(vite@5.4.11(@types/node@22.10.7)(sass-embedded@1.83.1)(sass@1.83.0)(terser@5.37.0))
+      '@vitest/mocker': 3.0.2(vite@5.4.11(@types/node@20.17.11)(sass-embedded@1.83.1)(sass@1.83.0)(terser@5.37.0))
       '@vitest/pretty-format': 3.0.2
       '@vitest/runner': 3.0.2
       '@vitest/snapshot': 3.0.2

--- a/src/main/utils/systemPermissions.test.ts
+++ b/src/main/utils/systemPermissions.test.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  hasPromptedForPermission,
+  hasScreenCapturePermission,
+  openSystemPreferences,
+} from '@computer-use/mac-screen-capture-permissions';
+import permissions from '@computer-use/node-mac-permissions';
+import { ensurePermissions } from './systemPermissions';
+import * as env from '@main/env';
+
+// Mock the dependencies
+vi.mock('@computer-use/mac-screen-capture-permissions', () => ({
+  hasPromptedForPermission: vi.fn(),
+  hasScreenCapturePermission: vi.fn(),
+  openSystemPreferences: vi.fn(),
+}));
+
+vi.mock('@computer-use/node-mac-permissions');
+vi.mock('@main/env');
+vi.mock('@main/logger');
+
+describe('systemPermissions', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(env).isE2eTest = false;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return true for both permissions in E2E test environment', () => {
+    vi.mocked(env).isE2eTest = true;
+
+    const result = ensurePermissions();
+
+    expect(result).toEqual({
+      screenCapture: true,
+      accessibility: true,
+    });
+  });
+
+  it('should handle when screen capture permission is granted', () => {
+    vi.mocked(hasScreenCapturePermission).mockReturnValue(true);
+    vi.mocked(permissions.getAuthStatus).mockImplementation((type) => {
+      if (type === 'accessibility') return 'denied';
+      if (type === 'screen') return 'authorized';
+      return 'denied';
+    });
+
+    const result = ensurePermissions();
+
+    expect(result.screenCapture).toBe(true);
+    expect(hasPromptedForPermission).toHaveBeenCalled();
+    expect(permissions.getAuthStatus).toHaveBeenCalledWith('accessibility');
+  });
+
+  it('should request permissions when not granted', () => {
+    vi.mocked(hasScreenCapturePermission).mockReturnValue(false);
+    vi.mocked(permissions.getAuthStatus).mockImplementation((type) => {
+      if (type === 'accessibility') return 'denied';
+      if (type === 'screen') return 'denied';
+      return 'denied';
+    });
+
+    const result = ensurePermissions();
+
+    expect(result.screenCapture).toBe(false);
+    expect(result.accessibility).toBe(false);
+    expect(openSystemPreferences).toHaveBeenCalled();
+    expect(permissions.askForAccessibilityAccess).toHaveBeenCalled();
+    expect(permissions.askForScreenCaptureAccess).toHaveBeenCalled();
+  });
+
+  it('should handle when accessibility permission is granted', () => {
+    vi.mocked(hasScreenCapturePermission).mockReturnValue(false);
+    vi.mocked(permissions.getAuthStatus).mockImplementation((type) => {
+      if (type === 'accessibility') return 'authorized';
+      if (type === 'screen') return 'denied';
+      return 'denied';
+    });
+
+    const result = ensurePermissions();
+
+    expect(result.accessibility).toBe(true);
+    expect(result.screenCapture).toBe(false);
+    expect(permissions.getAuthStatus).toHaveBeenCalledWith('accessibility');
+  });
+
+  it('should return true when both permissions are already granted', () => {
+    vi.mocked(hasScreenCapturePermission).mockReturnValue(true);
+    vi.mocked(permissions.getAuthStatus).mockImplementation((type) => {
+      if (type === 'accessibility') return 'authorized';
+      if (type === 'screen') return 'authorized';
+      return 'denied';
+    });
+
+    const result = ensurePermissions();
+
+    expect(result).toEqual({
+      screenCapture: true,
+      accessibility: true,
+    });
+    expect(hasPromptedForPermission).toHaveBeenCalled();
+    expect(permissions.getAuthStatus).toHaveBeenCalledWith('accessibility');
+  });
+});

--- a/src/main/utils/systemPermissions.test.ts
+++ b/src/main/utils/systemPermissions.test.ts
@@ -8,6 +8,7 @@ import {
   hasScreenCapturePermission,
   openSystemPreferences,
 } from '@computer-use/mac-screen-capture-permissions';
+import { platform } from 'os';
 import permissions from '@computer-use/node-mac-permissions';
 import { ensurePermissions } from './systemPermissions';
 import * as env from '@main/env';
@@ -23,89 +24,92 @@ vi.mock('@computer-use/node-mac-permissions');
 vi.mock('@main/env');
 vi.mock('@main/logger');
 
-describe('systemPermissions', () => {
-  beforeEach(() => {
-    vi.resetAllMocks();
-    vi.mocked(env).isE2eTest = false;
-  });
-
-  afterEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it('should return true for both permissions in E2E test environment', () => {
-    vi.mocked(env).isE2eTest = true;
-
-    const result = ensurePermissions();
-
-    expect(result).toEqual({
-      screenCapture: true,
-      accessibility: true,
-    });
-  });
-
-  it('should handle when screen capture permission is granted', () => {
-    vi.mocked(hasScreenCapturePermission).mockReturnValue(true);
-    vi.mocked(permissions.getAuthStatus).mockImplementation((type) => {
-      if (type === 'accessibility') return 'denied';
-      if (type === 'screen') return 'authorized';
-      return 'denied';
+(platform() === 'darwin' ? describe : describe.skip)(
+  'systemPermissions',
+  () => {
+    beforeEach(() => {
+      vi.resetAllMocks();
+      vi.mocked(env).isE2eTest = false;
     });
 
-    const result = ensurePermissions();
-
-    expect(result.screenCapture).toBe(true);
-    expect(hasPromptedForPermission).toHaveBeenCalled();
-    expect(permissions.getAuthStatus).toHaveBeenCalledWith('accessibility');
-  });
-
-  it('should request permissions when not granted', () => {
-    vi.mocked(hasScreenCapturePermission).mockReturnValue(false);
-    vi.mocked(permissions.getAuthStatus).mockImplementation((type) => {
-      if (type === 'accessibility') return 'denied';
-      if (type === 'screen') return 'denied';
-      return 'denied';
+    afterEach(() => {
+      vi.clearAllMocks();
     });
 
-    const result = ensurePermissions();
+    it('should return true for both permissions in E2E test environment', () => {
+      vi.mocked(env).isE2eTest = true;
 
-    expect(result.screenCapture).toBe(false);
-    expect(result.accessibility).toBe(false);
-    expect(openSystemPreferences).toHaveBeenCalled();
-    expect(permissions.askForAccessibilityAccess).toHaveBeenCalled();
-    expect(permissions.askForScreenCaptureAccess).toHaveBeenCalled();
-  });
+      const result = ensurePermissions();
 
-  it('should handle when accessibility permission is granted', () => {
-    vi.mocked(hasScreenCapturePermission).mockReturnValue(false);
-    vi.mocked(permissions.getAuthStatus).mockImplementation((type) => {
-      if (type === 'accessibility') return 'authorized';
-      if (type === 'screen') return 'denied';
-      return 'denied';
+      expect(result).toEqual({
+        screenCapture: true,
+        accessibility: true,
+      });
     });
 
-    const result = ensurePermissions();
+    it('should handle when screen capture permission is granted', () => {
+      vi.mocked(hasScreenCapturePermission).mockReturnValue(true);
+      vi.mocked(permissions.getAuthStatus).mockImplementation((type) => {
+        if (type === 'accessibility') return 'denied';
+        if (type === 'screen') return 'authorized';
+        return 'denied';
+      });
 
-    expect(result.accessibility).toBe(true);
-    expect(result.screenCapture).toBe(false);
-    expect(permissions.getAuthStatus).toHaveBeenCalledWith('accessibility');
-  });
+      const result = ensurePermissions();
 
-  it('should return true when both permissions are already granted', () => {
-    vi.mocked(hasScreenCapturePermission).mockReturnValue(true);
-    vi.mocked(permissions.getAuthStatus).mockImplementation((type) => {
-      if (type === 'accessibility') return 'authorized';
-      if (type === 'screen') return 'authorized';
-      return 'denied';
+      expect(result.screenCapture).toBe(true);
+      expect(hasPromptedForPermission).toHaveBeenCalled();
+      expect(permissions.getAuthStatus).toHaveBeenCalledWith('accessibility');
     });
 
-    const result = ensurePermissions();
+    it('should request permissions when not granted', () => {
+      vi.mocked(hasScreenCapturePermission).mockReturnValue(false);
+      vi.mocked(permissions.getAuthStatus).mockImplementation((type) => {
+        if (type === 'accessibility') return 'denied';
+        if (type === 'screen') return 'denied';
+        return 'denied';
+      });
 
-    expect(result).toEqual({
-      screenCapture: true,
-      accessibility: true,
+      const result = ensurePermissions();
+
+      expect(result.screenCapture).toBe(false);
+      expect(result.accessibility).toBe(false);
+      expect(openSystemPreferences).toHaveBeenCalled();
+      expect(permissions.askForAccessibilityAccess).toHaveBeenCalled();
+      expect(permissions.askForScreenCaptureAccess).toHaveBeenCalled();
     });
-    expect(hasPromptedForPermission).toHaveBeenCalled();
-    expect(permissions.getAuthStatus).toHaveBeenCalledWith('accessibility');
-  });
-});
+
+    it('should handle when accessibility permission is granted', () => {
+      vi.mocked(hasScreenCapturePermission).mockReturnValue(false);
+      vi.mocked(permissions.getAuthStatus).mockImplementation((type) => {
+        if (type === 'accessibility') return 'authorized';
+        if (type === 'screen') return 'denied';
+        return 'denied';
+      });
+
+      const result = ensurePermissions();
+
+      expect(result.accessibility).toBe(true);
+      expect(result.screenCapture).toBe(false);
+      expect(permissions.getAuthStatus).toHaveBeenCalledWith('accessibility');
+    });
+
+    it('should return true when both permissions are already granted', () => {
+      vi.mocked(hasScreenCapturePermission).mockReturnValue(true);
+      vi.mocked(permissions.getAuthStatus).mockImplementation((type) => {
+        if (type === 'accessibility') return 'authorized';
+        if (type === 'screen') return 'authorized';
+        return 'denied';
+      });
+
+      const result = ensurePermissions();
+
+      expect(result).toEqual({
+        screenCapture: true,
+        accessibility: true,
+      });
+      expect(hasPromptedForPermission).toHaveBeenCalled();
+      expect(permissions.getAuthStatus).toHaveBeenCalledWith('accessibility');
+    });
+  },
+);

--- a/src/renderer/src/hooks/useDispatch.ts
+++ b/src/renderer/src/hooks/useDispatch.ts
@@ -1,0 +1,5 @@
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+export const useDispatch = () => window.zutron.dispatch;

--- a/src/renderer/src/hooks/useRunAgent.ts
+++ b/src/renderer/src/hooks/useRunAgent.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { useToast } from '@chakra-ui/react';
-import { useDispatch } from 'zutron';
+import { useDispatch } from '@renderer/hooks/useDispatch';
 
 import { Conversation } from '@ui-tars/shared/types';
 
@@ -12,10 +12,10 @@ import { useStore } from '@renderer/hooks/useStore';
 import { usePermissions } from './usePermissions';
 
 export const useRunAgent = () => {
-  const dispatch = useDispatch(window.zutron);
+  const dispatch = useDispatch();
   const toast = useToast();
   const { messages, settings } = useStore();
-  const { ensurePermissions, getEnsurePermissions } = usePermissions();
+  const { ensurePermissions } = usePermissions();
 
   const run = (value: string, callback: () => void = () => {}) => {
     if (
@@ -35,7 +35,6 @@ export const useRunAgent = () => {
         duration: 2000,
         isClosable: true,
       });
-      getEnsurePermissions();
       return;
     }
 


### PR DESCRIPTION
## Summary

The original bug was that the permission updates were not timely enough. Since after `dispatch` execution, the obtained `permissions` were the old state.

## Solution

Focusing the screen to request the latest permissions was done through `swr` when not all permissions were acquired.

## Examples

| Before  | After |
| :---:  | :---: |
| ![image](https://github.com/user-attachments/assets/ed7834b6-f4c1-4a83-8014-571b3cb0b3c0) |   <video src="https://github.com/user-attachments/assets/ff0bc489-413a-4ba9-98d8-7d6e5abb8d2b" height="300" />     |