### PR TITLE
refactor: enable `moduleResolution: bundler` to avoid `@ts-ignore`

### DIFF
--- a/src/main/store/setting.ts
+++ b/src/main/store/setting.ts
@@ -13,7 +13,7 @@ export class SettingStore {
     name: 'ui_tars.setting',
     defaults: {
       language: 'en',
-      vlmProvider: env.vlmProvider || VlmProvider.Huggingface,
+      vlmProvider: (env.vlmProvider as VlmProvider) || VlmProvider.Huggingface,
       vlmBaseUrl: env.vlmBaseUrl || '',
       vlmApiKey: env.vlmApiKey || '',
       vlmModelName: env.vlmModelName || '',
@@ -24,27 +24,22 @@ export class SettingStore {
     key: K,
     value: LocalStore[K],
   ): void {
-    // @ts-ignore
     SettingStore.instance.set(key, value);
   }
 
   public static setStore(state: LocalStore): void {
-    // @ts-ignore
     SettingStore.instance.set(state);
   }
 
   public static get<K extends keyof LocalStore>(key: K): LocalStore[K] {
-    // @ts-ignore
     return SettingStore.instance.get(key);
   }
 
   public static getStore(): LocalStore {
-    // @ts-ignore
     return SettingStore.instance.store;
   }
 
   public static clear(): void {
-    // @ts-ignore
     SettingStore.instance.clear();
   }
 

--- a/src/main/store/types.ts
+++ b/src/main/store/types.ts
@@ -63,7 +63,7 @@ export type LocalStore = {
   vlmBaseUrl: string;
   vlmApiKey: string;
   vlmModelName: string;
-  screenshotScale: number; // 0.1 ~ 1.0
+  screenshotScale?: number; // 0.1 ~ 1.0
   reportStorageBaseUrl?: string;
   utioBaseUrl?: string;
 };

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
+    "moduleResolution": "bundler",
     "paths": {
       "@shared/*": ["./src/shared/*"],
       "@main/*": ["./src/main/*"],


### PR DESCRIPTION
## Summary

Currently `@electron-toolkit/tsconfig`<sup>[1]</sup> sets `moduleResolution` to `node`, and [electron-store](https://github.com/sindresorhus/electron-store/blob/main/package.json)<sup>[2]</sup> is implemented based on [conf](https://github.com/sindresorhus/conf/blob/main/package.json)<sup>[3]</sup>. Currently `conf` exports types based on `exports.types`:

```json
"exports": {
	"types": "./dist/source/index.d.ts",
	"default": "./dist/source/index.js"
},
```

The current setup (`"moduleResolution": "node"` ) cannot properly handle the `types` field in `exports`<sup>[4]</sup>, so that `tsc` to be unable to recognize these types.

This PR enables `moduleResolution: bundler`<sup>[5]</sup> to remove all `@ts-ignore`s.

## References

[1] https://github.com/alex8088/electron-toolkit/blob/master/packages/tsconfig/tsconfig.json#L10
[2] https://github.com/sindresorhus/electron-store/blob/main/package.json
[3] https://github.com/sindresorhus/conf/blob/main/package.json
[4] https://www.typescriptlang.org/tsconfig/#moduleResolution
[5] https://github.com/microsoft/TypeScript/pull/51669,  https://www.typescriptlang.org/docs/handbook/modules/theory.html#module-resolution-for-libraries

