### PR TITLE
docs: brew install

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ UI-TARS Desktop is a GUI Agent application based on [UI-TARS (Vision-Language Mo
         &nbsp&nbsp 📑 <a href="https://arxiv.org/abs/2501.12326">Paper</a> &nbsp&nbsp
         | 🤗 <a href="https://huggingface.co/bytedance-research/UI-TARS-7B-DPO">Hugging Face Models</a>&nbsp&nbsp
         | &nbsp&nbsp🫨 <a href="https://discord.gg/pTXwYVjfcs">Discord</a>&nbsp&nbsp
-        | &nbsp&nbsp🤖 <a href="https://www.modelscope.cn/models/bytedance-research/UI-TARS-7B-DPO">ModelScope</a>&nbsp&nbsp 
+        | &nbsp&nbsp🤖 <a href="https://www.modelscope.cn/models/bytedance-research/UI-TARS-7B-DPO">ModelScope</a>&nbsp&nbsp
 <br>
 🖥️ Desktop Application &nbsp&nbsp
 | &nbsp&nbsp 👓 <a href="https://github.com/web-infra-dev/midscene">Midscene (use in browser)</a>
@@ -55,7 +55,6 @@ You can download the [latest release](https://github.com/bytedance/UI-TARS-deskt
 
 > **Note**: If you have [Homebrew](https://brew.sh/) installed, you can install UI-TARS Desktop by running the following command:
 > ```bash
-> brew tap ui-tars/tap
 > brew install --cask ui-tars
 > ```
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ UI-TARS Desktop is a GUI Agent application based on [UI-TARS (Vision-Language Mo
 <p align="center">
         &nbsp&nbsp 📑 <a href="https://arxiv.org/abs/2501.12326">Paper</a> &nbsp&nbsp
         | 🤗 <a href="https://huggingface.co/bytedance-research/UI-TARS-7B-DPO">Hugging Face Models</a>&nbsp&nbsp
-        | &nbsp&nbsp🤖 <a href="https://www.modelscope.cn/models/bytedance-research/UI-TARS-7B-DPO">ModelScope</a>&nbsp&nbsp 
+        | &nbsp&nbsp🤖 <a href="https://www.modelscope.cn/models/bytedance-research/UI-TARS-7B-DPO">ModelScope</a>&nbsp&nbsp
 <br>
 🖥️ Desktop Application &nbsp&nbsp
 | &nbsp&nbsp 👓 <a href="https://github.com/web-infra-dev/midscene">Midscene (use in browser)</a>
@@ -51,6 +51,12 @@ We appreciate your understanding and patience as we work to ensure the best poss
 ### Download
 
 You can download the [latest release](https://github.com/bytedance/UI-TARS-desktop/releases/latest) version of UI-TARS Desktop from our releases page.
+
+> **Note**: If you have [Homebrew](https://brew.sh/) installed, you can install UI-TARS Desktop by running the following command:
+> ```bash
+> brew tap ui-tars/tap
+> brew install --cask ui-tars
+> ```
 
 ### Install
 

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -86,6 +86,7 @@ const noopAfterCopy = (
 
 const config: ForgeConfig = {
   packagerConfig: {
+    appBundleId: 'com.bytedance.uitars',
     name: 'UI TARS',
     icon: 'resources/icon',
     asar: {


### PR DESCRIPTION
```bash
brew install --cask ui-tars
```

Because the UI-TARS Github repository is less than 30 days old, we need to use `brew tap` to specify the installation for now. After the merge(https://github.com/Homebrew/homebrew-cask/pull/201519), the `brew tap` may not be necessary.