### PR TITLE
fix: typing and key input fail

### DIFF
--- a/src/main/agent/execute.ts
+++ b/src/main/agent/execute.ts
@@ -203,7 +203,7 @@ export const execute = async (executeParams: ExecuteParams) => {
     case 'hotkey': {
       const keyStr = action_inputs?.key || action_inputs?.hotkey;
       if (keyStr) {
-        const platformCommandKey = process.platform === "darwin" ? Key.LeftCmd : Key.LeftWin;
+        const platformCommandKey = process.platform === 'darwin' ? Key.LeftCmd : Key.LeftWin;
         const keyMap: Record<string, Key> = {
           return: Key.Enter,
           enter: Key.Enter,
@@ -211,9 +211,9 @@ export const execute = async (executeParams: ExecuteParams) => {
           shift: Key.LeftShift,
           alt: Key.LeftAlt,
           space: Key.Space,
-          "page down": Key.PageDown,
+          'page down': Key.PageDown,
           pagedown: Key.PageDown,
-          "page up": Key.PageUp,
+          'page up': Key.PageUp,
           pageup: Key.PageUp,
           meta: platformCommandKey,
           win: platformCommandKey,
@@ -224,7 +224,7 @@ export const execute = async (executeParams: ExecuteParams) => {
         const keys = keyStr
           .split(/[\s+]/)
           .map((k) => keyMap[k.toLowerCase()] || Key[k.toUpperCase() as keyof typeof Key]);
-        logger.info("[hotkey]: ", keys);
+        logger.info('[hotkey]: ', keys);
         await keyboard.pressKey(...keys);
         await keyboard.releaseKey(...keys);
       }

--- a/src/main/agent/execute.ts
+++ b/src/main/agent/execute.ts
@@ -203,6 +203,7 @@ export const execute = async (executeParams: ExecuteParams) => {
     case 'hotkey': {
       const keyStr = action_inputs?.key || action_inputs?.hotkey;
       if (keyStr) {
+        const platformCommandKey = process.platform === "darwin" ? Key.LeftCmd : Key.LeftWin;
         const keyMap: Record<string, Key> = {
           return: Key.Enter,
           enter: Key.Enter,
@@ -210,16 +211,20 @@ export const execute = async (executeParams: ExecuteParams) => {
           shift: Key.LeftShift,
           alt: Key.LeftAlt,
           space: Key.Space,
-          'page down': Key.PageDown,
+          "page down": Key.PageDown,
           pagedown: Key.PageDown,
-          'page up': Key.PageUp,
+          "page up": Key.PageUp,
           pageup: Key.PageUp,
+          meta: platformCommandKey,
+          win: platformCommandKey,
+          command: platformCommandKey,
+          cmd: platformCommandKey,
         };
 
         const keys = keyStr
           .split(/[\s+]/)
-          .map((k) => keyMap[k.toLowerCase()] || Key[k as keyof typeof Key]);
-        logger.info('[hotkey]: ', keys);
+          .map((k) => keyMap[k.toLowerCase()] || Key[k.toUpperCase() as keyof typeof Key]);
+        logger.info("[hotkey]: ", keys);
         await keyboard.pressKey(...keys);
         await keyboard.releaseKey(...keys);
       }

--- a/src/main/window/ScreenMarker.ts
+++ b/src/main/window/ScreenMarker.ts
@@ -235,14 +235,14 @@ class ScreenMarker {
             }),
         });
 
-        if (env.isWindows) {
-          this.currentOverlay.setAlwaysOnTop(true, 'screen-saver');
-        }
-
         this.currentOverlay.blur();
         this.currentOverlay.setFocusable(false);
         this.currentOverlay.setContentProtection(true); // not show for vlm model
         this.currentOverlay.setIgnoreMouseEvents(true, { forward: true });
+
+        if (env.isWindows) {
+          this.currentOverlay.setAlwaysOnTop(true, 'screen-saver');
+        }
 
         // 在 Windows 上设置窗口为工具窗口
         // if (process.platform === 'win32') {


### PR DESCRIPTION
1. fix(main): resolve focus missing for typing window on Windows
- 先设置overlay window 为 non-focusable之后再设置always on top，否则overlay window在设置always on top的瞬间会抢占focus状态，导致待输入窗口丢失焦点


2. fix(main): improve hotkey handling reliability on Windows
- 优化特殊键值，增加cmd（macOS）/ win（windows）键的匹配
- 普通键值在nut-js中应使用大写字母匹配输入键值