### PR TITLE
feat: enable easy copying of images to clipboard

### DIFF
--- a/src/renderer/src/components/Image/index.tsx
+++ b/src/renderer/src/components/Image/index.tsx
@@ -2,35 +2,115 @@
  * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { Image, ImageProps } from '@chakra-ui/react';
+import { Image as ChakraImage, ImageProps, Box } from '@chakra-ui/react';
 import clsx from 'clsx';
 import mediumZoom, { type Zoom } from 'medium-zoom';
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import { TbCopy, TbCopyCheckFilled } from 'react-icons/tb';
 
 const SnapshotImage: React.FC<ImageProps> = (props) => {
   const { className, ...rest } = props;
+  const [copied, setCopied] = useState<boolean>(false);
   const imgRef = useRef<HTMLImageElement>(null);
+
+  const handleCopyImage = async () => {
+    if (imgRef.current) {
+      try {
+        const imageUrl = imgRef.current.src;
+        let img: HTMLImageElement | null = new Image();
+        img.src = imageUrl;
+
+        img.onload = async () => {
+          // use canvas to copy image, avoid csp issue in data:url
+          const canvas = document.createElement('canvas');
+          const ctx = canvas.getContext('2d');
+          if (ctx && img) {
+            canvas.width = img.width;
+            canvas.height = img.height;
+            ctx.drawImage(img, 0, 0);
+
+            // get blob from canvas
+            canvas.toBlob(async (blob) => {
+              if (blob) {
+                const item = new ClipboardItem({ 'image/png': blob });
+                await navigator.clipboard.write([item]);
+              }
+              canvas.width = 0;
+              canvas.height = 0;
+            });
+
+            // clear
+            img.src = '';
+            img.onload = null;
+            img = null;
+
+            setCopied(true);
+            setTimeout(() => {
+              setCopied(false);
+            }, 500);
+          }
+        };
+      } catch (error) {
+        console.error('Failed to copy image to clipboard:', error);
+        alert('Failed to copy image!');
+      }
+    }
+  };
 
   useEffect(() => {
     let zoom: Zoom | undefined;
-    const timeout = setTimeout(() => {
+    const initZoom = () => {
       if (imgRef.current) {
         zoom = mediumZoom(imgRef.current, {
-          background: 'rgba(255,255,255,.7)',
+          background: 'rgba(0,0,0,.7)',
           margin: 50,
         });
       }
-    }, 500);
-
+    };
+    requestAnimationFrame(initZoom);
     return () => {
-      clearTimeout(timeout);
       zoom?.detach();
       zoom?.close();
     };
   }, []);
 
   return (
-    <Image ref={imgRef} className={clsx('snapshot', className)} {...rest} />
+    <Box
+      sx={{
+        display: 'flex',
+        flexDir: 'column',
+        alignItems: 'end',
+        position: 'relative',
+      }}
+    >
+      <ChakraImage
+        ref={imgRef}
+        className={clsx('snapshot', className)}
+        {...rest}
+      />
+      <Box
+        onClick={handleCopyImage}
+        sx={{
+          width: '24px',
+          height: '24px',
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          bottom: '8px',
+          right: '8px',
+          position: 'absolute',
+          opacity: 0.1,
+          cursor: 'pointer',
+          transition: 'opacity 0.2s',
+          _hover: { opacity: 0.5 },
+          _focus: {
+            outline: 'none',
+          },
+        }}
+      >
+        {copied ? <TbCopyCheckFilled /> : <TbCopy />}
+      </Box>
+    </Box>
   );
 };
 


### PR DESCRIPTION
enable image copy to clipboard using canvas to bypass CSP restrictions

<img width="360" alt="Screenshot 2025-02-18 at 3 21 20 PM" src="https://github.com/user-attachments/assets/e4ab368c-0829-4ccf-a667-de3ee66e8685" />


hover：

<img width="360" alt="Screenshot 2025-02-18 at 3 21 24 PM" src="https://github.com/user-attachments/assets/d9ed5c32-6e50-4e0a-aaca-e28d88079692" />

copied：
<img width="360" alt="Screenshot 2025-02-18 at 3 21 37 PM" src="https://github.com/user-attachments/assets/e78e6b6a-af3b-4e67-a225-19059a79606b" />

