### PR TITLE
release: v0.0.7

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -13,6 +13,8 @@
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": [
-    "ui-tars-desktop"
+    "ui-tars-desktop",
+    "ui-tars-desktop-renderer",
+    "@common/*"
   ]
 }

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -2,15 +2,18 @@
   "mode": "exit",
   "tag": "beta",
   "initialVersions": {
-    "ui-tars-desktop": "0.0.7-beta.1",
-    "@ui-tars/action-parser": "1.2.0-beta.20",
-    "@ui-tars/cli": "1.2.0-beta.20",
-    "@ui-tars/electron-ipc": "1.2.0-beta.20",
-    "@ui-tars/operator-browserbase": "1.2.0-beta.20",
-    "@ui-tars/operator-nut-js": "1.2.0-beta.20",
-    "@ui-tars/sdk": "1.2.0-beta.20",
-    "@ui-tars/shared": "1.2.0-beta.20",
-    "@ui-tars/utio": "1.2.0-beta.20"
+    "ui-tars-desktop": "0.0.7-beta.2",
+    "ui-tars-desktop-renderer": "0.0.1",
+    "@common/configs": "0.0.1",
+    "@common/electron-build": "1.0.0",
+    "@ui-tars/action-parser": "1.2.0-beta.21",
+    "@ui-tars/cli": "1.2.0-beta.21",
+    "@ui-tars/electron-ipc": "1.2.0-beta.21",
+    "@ui-tars/operator-browserbase": "1.2.0-beta.21",
+    "@ui-tars/operator-nut-js": "1.2.0-beta.21",
+    "@ui-tars/sdk": "1.2.0-beta.21",
+    "@ui-tars/shared": "1.2.0-beta.21",
+    "@ui-tars/utio": "1.2.0-beta.21"
   },
   "changesets": [
     "dull-lions-tie",

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -27,6 +27,7 @@
     "selfish-cups-divide",
     "selfish-humans-drive",
     "short-shoes-tap",
+    "stale-icons-whisper",
     "strange-schools-help",
     "witty-points-rescue"
   ]

--- a/.changeset/stale-icons-whisper.md
+++ b/.changeset/stale-icons-whisper.md
@@ -1,0 +1,12 @@
+---
+'@ui-tars/action-parser': patch
+'@ui-tars/cli': patch
+'@ui-tars/electron-ipc': patch
+'@ui-tars/operator-browserbase': patch
+'@ui-tars/operator-nut-js': patch
+'@ui-tars/sdk': patch
+'@ui-tars/shared': patch
+'@ui-tars/utio': patch
+---
+
+chore: changeset

--- a/apps/ui-tars/package.json
+++ b/apps/ui-tars/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui-tars-desktop",
-  "version": "0.0.7-beta.1",
+  "version": "0.0.7-beta.2",
   "private": true,
   "main": "./dist/main/main.js",
   "packageManager": "pnpm@9.10.0",

--- a/apps/ui-tars/package.json
+++ b/apps/ui-tars/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui-tars-desktop",
-  "version": "0.0.7-beta.2",
+  "version": "0.0.7",
   "private": true,
   "main": "./dist/main/main.js",
   "packageManager": "pnpm@9.10.0",

--- a/packages/ui-tars/action-parser/CHANGELOG.md
+++ b/packages/ui-tars/action-parser/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @ui-tars/action-parser
 
+## 1.2.0-beta.22
+
+### Patch Changes
+
+- chore: changeset
+- Updated dependencies
+  - @ui-tars/shared@1.2.0-beta.22
+
 ## 1.2.0-beta.21
 
 ### Patch Changes

--- a/packages/ui-tars/action-parser/package.json
+++ b/packages/ui-tars/action-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui-tars/action-parser",
-  "version": "1.2.0-beta.21",
+  "version": "1.2.0-beta.22",
   "description": "Action parser SDK for UI-TARS",
   "repository": {
     "type": "git",

--- a/packages/ui-tars/cli/CHANGELOG.md
+++ b/packages/ui-tars/cli/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @ui-tars/cli
 
+## 1.2.0-beta.22
+
+### Patch Changes
+
+- chore: changeset
+- Updated dependencies
+  - @ui-tars/operator-nut-js@1.2.0-beta.22
+  - @ui-tars/sdk@1.2.0-beta.22
+
 ## 1.2.0-beta.21
 
 ### Patch Changes

--- a/packages/ui-tars/cli/package.json
+++ b/packages/ui-tars/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui-tars/cli",
-  "version": "1.2.0-beta.21",
+  "version": "1.2.0-beta.22",
   "description": "CLI for UI-TARS",
   "repository": {
     "type": "git",

--- a/packages/ui-tars/electron-ipc/CHANGELOG.md
+++ b/packages/ui-tars/electron-ipc/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ui-tars/electron-ipc
 
+## 1.2.0-beta.22
+
+### Patch Changes
+
+- chore: changeset
+
 ## 1.2.0-beta.21
 
 ### Patch Changes

--- a/packages/ui-tars/electron-ipc/package.json
+++ b/packages/ui-tars/electron-ipc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui-tars/electron-ipc",
-  "version": "1.2.0-beta.21",
+  "version": "1.2.0-beta.22",
   "description": "Type-safe Electron inter-process communication for UI-TARS",
   "repository": {
     "type": "git",

--- a/packages/ui-tars/operators/browserbase/CHANGELOG.md
+++ b/packages/ui-tars/operators/browserbase/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @ui-tars/operator-browserbase
 
+## 1.2.0-beta.22
+
+### Patch Changes
+
+- chore: changeset
+- Updated dependencies
+  - @ui-tars/sdk@1.2.0-beta.22
+  - @ui-tars/shared@1.2.0-beta.22
+
 ## 1.2.0-beta.21
 
 ### Patch Changes

--- a/packages/ui-tars/operators/browserbase/package.json
+++ b/packages/ui-tars/operators/browserbase/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui-tars/operator-browserbase",
-  "version": "1.2.0-beta.21",
+  "version": "1.2.0-beta.22",
   "description": "Operator Browserbase SDK for UI-TARS",
   "repository": {
     "type": "git",

--- a/packages/ui-tars/operators/nut-js/CHANGELOG.md
+++ b/packages/ui-tars/operators/nut-js/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @ui-tars/operator-nut-js
 
+## 1.2.0-beta.22
+
+### Patch Changes
+
+- chore: changeset
+- Updated dependencies
+  - @ui-tars/sdk@1.2.0-beta.22
+  - @ui-tars/shared@1.2.0-beta.22
+
 ## 1.2.0-beta.21
 
 ### Patch Changes

--- a/packages/ui-tars/operators/nut-js/package.json
+++ b/packages/ui-tars/operators/nut-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui-tars/operator-nut-js",
-  "version": "1.2.0-beta.21",
+  "version": "1.2.0-beta.22",
   "description": "Operator Nut JS SDK for UI-TARS",
   "repository": {
     "type": "git",

--- a/packages/ui-tars/sdk/CHANGELOG.md
+++ b/packages/ui-tars/sdk/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @ui-tars/sdk
 
+## 1.2.0-beta.22
+
+### Patch Changes
+
+- chore: changeset
+- Updated dependencies
+  - @ui-tars/action-parser@1.2.0-beta.22
+  - @ui-tars/shared@1.2.0-beta.22
+
 ## 1.2.0-beta.21
 
 ### Patch Changes

--- a/packages/ui-tars/sdk/package.json
+++ b/packages/ui-tars/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui-tars/sdk",
-  "version": "1.2.0-beta.21",
+  "version": "1.2.0-beta.22",
   "description": "A powerful cross-platform(ANY device/platform) toolkit for building GUI automation agents for UI-TARS",
   "repository": {
     "type": "git",

--- a/packages/ui-tars/shared/CHANGELOG.md
+++ b/packages/ui-tars/shared/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ui-tars/shared
 
+## 1.2.0-beta.22
+
+### Patch Changes
+
+- chore: changeset
+
 ## 1.2.0-beta.21
 
 ### Patch Changes

--- a/packages/ui-tars/shared/package.json
+++ b/packages/ui-tars/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui-tars/shared",
-  "version": "1.2.0-beta.21",
+  "version": "1.2.0-beta.22",
   "description": "Shared types for UI-TARS",
   "repository": {
     "type": "git",

--- a/packages/ui-tars/utio/CHANGELOG.md
+++ b/packages/ui-tars/utio/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ui-tars/utio
 
+## 1.2.0-beta.22
+
+### Patch Changes
+
+- chore: changeset
+
 ## 1.2.0-beta.21
 
 ### Patch Changes

--- a/packages/ui-tars/utio/package.json
+++ b/packages/ui-tars/utio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui-tars/utio",
-  "version": "1.2.0-beta.21",
+  "version": "1.2.0-beta.22",
   "description": "UTIO (UI-TARS Insights and Observation)",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
## Features
- feat: support operator-browserbase (#132)

## Bugfix

- fix(app): electron build issue & tweak sdk snapshot quality (#188)
- fix(operator): macos cannot type (#126) 

## Chores

- fix(app): native module deps build and reduce 28% bundle size (#181)
- refactor(app): migrate to apps/desktop monorepo (#177)
- refactor(sdk): screenshot only return base64 and scaleFactor (#171)
- chore(sdk): allow custom factors via parseBoxToScreenCoords api (#162) 

Full Changelog: https://github.com/bytedance/UI-TARS-desktop/compare/v0.0.6...v0.0.7

<video src="https://github.com/user-attachments/assets/354c3b8b-681f-4ad0-9ab9-365dbde894af" height="100" 