### PR TITLE
refactor(agent-tars): too call log

### DIFF
--- a/apps/agent-tars/src/main/ipcRoutes/action.ts
+++ b/apps/agent-tars/src/main/ipcRoutes/action.ts
@@ -93,15 +93,14 @@ export const actionRoute = t.router({
               result,
             );
             results.push(result);
-          } catch (e) {
-            logger.error(
-              '[actionRoute.executeTool] execute tool error',
-              mcpTool.name,
-              e,
-            );
+          } catch (error) {
+            const rawErrorMessage =
+              error instanceof Error ? error.message : JSON.stringify(error);
+            const errorMessage = `Failed to execute tool "${mcpTool.name}": ${rawErrorMessage}`;
+            logger.error(`[actionRoute.executeTool] ${errorMessage}`);
             results.push({
               isError: true,
-              content: [JSON.stringify(e)],
+              content: [errorMessage],
             });
           }
         } else {


### PR DESCRIPTION
## Summary

In https://github.com/bytedance/UI-TARS-desktop/issues/345, we found an unclear log `[object Object]` that prevented us from troubleshooting the problem:

```
[ERROR] [actionRoute.executeTool] execute tool error browser_navigate [object Object]
```

After:

```
[ERROR] [actionRoute.executeTool] Failed to execute tool "${mcpTool.name}": ${errorMessage}`
```