### PR TITLE
fix(menu): add 'Quit' option with CmdOrCtrl+Q shortcut :bug:

### DIFF
--- a/apps/agent-tars/src/main/menu.ts
+++ b/apps/agent-tars/src/main/menu.ts
@@ -7,6 +7,7 @@ import {
   shell,
   BrowserWindow,
   MenuItemConstructorOptions,
+  app,
 } from 'electron';
 import { openLogFile, openLogDir } from './utils/logger';
 
@@ -80,6 +81,13 @@ export default class MenuBuilder {
           accelerator: 'CmdOrCtrl+W',
           click: () => {
             this.mainWindow.close();
+          },
+        },
+        {
+          label: 'Quit',
+          accelerator: 'CmdOrCtrl+Q',
+          click: () => {
+            app.quit();
           },
         },
       ],


### PR DESCRIPTION
- Import 'app' module from electron

- Add new 'Quit' menu item with proper keyboard shortcut

- Implement app.quit() function to properly terminate the application

close: #353

![image](https://github.com/user-attachments/assets/82fc0568-9383-412a-8926-6cce1be35f60)
