### PR TITLE
fix(agent-tars): mcp servers cleanup when windows all closed

### DIFF
--- a/apps/agent-tars/src/main/index.ts
+++ b/apps/agent-tars/src/main/index.ts
@@ -1,4 +1,5 @@
 import { app, shell, BrowserWindow, ipcMain } from 'electron';
+import { mapClientRef } from '@main/mcp/client';
 import { join } from 'path';
 import { registerIpcMain } from '@ui-tars/electron-ipc/main';
 import { electronApp, optimizer, is } from '@electron-toolkit/utils';
@@ -133,11 +134,16 @@ app.whenReady().then(async () => {
 // Quit when all windows are closed, except on macOS. There, it's common
 // for applications and their menu bar to stay active until the user quits
 // explicitly with Cmd + Q.
-app.on('window-all-closed', () => {
+app.on('window-all-closed', async () => {
   logger.info('All windows closed');
   if (process.platform !== 'darwin') {
     app.quit();
   }
+  logger.info('mcp cleanup');
+  // Deactivate all MCP servers
+  await mapClientRef.current?.cleanup().catch((err) => {
+    logger.error('Error during cleanup of MCP servers:', err);
+  });
 });
 
 // In this file you can include the rest of your app's specific main process

--- a/apps/agent-tars/src/main/utils/updateApp.ts
+++ b/apps/agent-tars/src/main/utils/updateApp.ts
@@ -42,7 +42,7 @@ export class AppUpdater {
     });
 
     // Listen for no available updates
-    autoUpdater.on('update-not-available', (info) => {
+    autoUpdater.on('update-not-available', (_) => {
       logger.info('No updates available.');
       dialog.showMessageBox({
         type: 'info',
@@ -69,7 +69,7 @@ export class AppUpdater {
     });
 
     // Listen for update download completion
-    autoUpdater.on('update-downloaded', (info) => {
+    autoUpdater.on('update-downloaded', (_) => {
       logger.info('Update downloaded');
       dialog
         .showMessageBox({


### PR DESCRIPTION
This pull request includes changes to the `apps/agent-tars/src/main/index.ts` file to enhance the application's cleanup process when all windows are closed. The key changes involve importing a new module and adding a cleanup routine for MCP servers.

Enhancements to cleanup process:

* [`apps/agent-tars/src/main/index.ts`](diffhunk://#diff-6bd65e9a6bcd8dfad7e2ddf5a5d45609feae1ffc7570f62c1e83eaedc541b3c9R2): Imported `mapClientRef` from `@main/mcp/client` to enable MCP server management.
* [`apps/agent-tars/src/main/index.ts`](diffhunk://#diff-6bd65e9a6bcd8dfad7e2ddf5a5d45609feae1ffc7570f62c1e83eaedc541b3c9L136-R146): Modified the `app.on('window-all-closed', async () => {` event handler to include an asynchronous cleanup routine for MCP servers, logging any errors encountered during the process.

![image](https://github.com/user-attachments/assets/efe6a1c6-a83c-4a07-be29-da95d13d75d5)
