### PR TITLE
feat: add search servcie connection test

### DIFF
--- a/apps/agent-tars/src/main/customTools/search.ts
+++ b/apps/agent-tars/src/main/customTools/search.ts
@@ -1,4 +1,4 @@
-import { SearchProvider, ToolCall } from '@agent-infra/shared';
+import { SearchProvider, SearchSettings, ToolCall } from '@agent-infra/shared';
 import {
   SearchClient,
   SearchProvider as SearchProviderEnum,
@@ -31,8 +31,11 @@ const searchByTavily = async (options: { count: number; query: string }) => {
   };
 };
 
-export async function search(toolCall: ToolCall): Promise<MCPToolResult> {
-  const currentSearchConfig = SettingStore.get('search');
+export async function search(
+  toolCall: ToolCall,
+  settings?: SearchSettings,
+): Promise<MCPToolResult> {
+  const currentSearchConfig = settings || SettingStore.get('search');
   const args = JSON.parse(toolCall.function.arguments);
 
   try {

--- a/apps/agent-tars/src/main/customTools/search.ts
+++ b/apps/agent-tars/src/main/customTools/search.ts
@@ -128,11 +128,12 @@ export async function search(
       },
     ];
   } catch (e) {
-    logger.error('Search error:', e);
+    const rawErrorMessage = e instanceof Error ? e.message : JSON.stringify(e);
+    logger.error('Search error: ' + rawErrorMessage);
     return [
       {
         isError: true,
-        content: [JSON.stringify(e)],
+        content: [rawErrorMessage],
       },
     ];
   }

--- a/apps/agent-tars/src/renderer/src/components/LeftSidebar/Settings/SearchSettingsTab.tsx
+++ b/apps/agent-tars/src/renderer/src/components/LeftSidebar/Settings/SearchSettingsTab.tsx
@@ -66,7 +66,7 @@ function TestSearchService({ settings }: TestSearchServiceProps) {
       >
         <ModalContent>
           <ModalHeader>
-            <h3 className="text-lg font-medium">Search Service Error</h3>
+            <h3 className="text-lg font-medium">Search Service Test Error</h3>
           </ModalHeader>
           <ModalBody>
             <div className="max-h-96 overflow-auto">

--- a/apps/agent-tars/src/renderer/src/components/LeftSidebar/Settings/SearchSettingsTab.tsx
+++ b/apps/agent-tars/src/renderer/src/components/LeftSidebar/Settings/SearchSettingsTab.tsx
@@ -1,16 +1,5 @@
 import { useState } from 'react';
-import {
-  Button,
-  Input,
-  Select,
-  SelectItem,
-  Divider,
-  Modal,
-  ModalContent,
-  ModalHeader,
-  ModalBody,
-  ModalFooter,
-} from '@nextui-org/react';
+import { Button, Input, Select, SelectItem, Divider } from '@nextui-org/react';
 import { SearchSettings, SearchProvider } from '@agent-infra/shared';
 import { getSearchProviderLogo } from './searchUtils';
 import toast from 'react-hot-toast';
@@ -26,7 +15,6 @@ interface TestSearchServiceProps {
 }
 
 function TestSearchService({ settings }: TestSearchServiceProps) {
-  const [isErrorModalOpen, setIsErrorModalOpen] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
   const [isLoading, setIsLoading] = useState(false);
 
@@ -44,13 +32,12 @@ function TestSearchService({ settings }: TestSearchServiceProps) {
 
             if (success) {
               toast.success('Search service is ready');
+              setErrorMessage(''); // 清除之前的错误信息
             } else {
               setErrorMessage(message);
-              setIsErrorModalOpen(true);
             }
           } catch (error) {
             setErrorMessage(String(error));
-            setIsErrorModalOpen(true);
           } finally {
             setIsLoading(false);
           }
@@ -59,33 +46,14 @@ function TestSearchService({ settings }: TestSearchServiceProps) {
         Test Search Service
       </Button>
 
-      <Modal
-        isOpen={isErrorModalOpen}
-        onClose={() => setIsErrorModalOpen(false)}
-        size="lg"
-      >
-        <ModalContent>
-          <ModalHeader>
-            <h3 className="text-lg font-medium">Search Service Test Error</h3>
-          </ModalHeader>
-          <ModalBody>
-            <div className="max-h-96 overflow-auto">
-              <pre className="whitespace-pre-wrap break-words text-sm bg-gray-100 dark:bg-gray-800 p-4 rounded">
-                {errorMessage}
-              </pre>
-            </div>
-          </ModalBody>
-          <ModalFooter>
-            <Button
-              color="danger"
-              variant="light"
-              onPress={() => setIsErrorModalOpen(false)}
-            >
-              Close
-            </Button>
-          </ModalFooter>
-        </ModalContent>
-      </Modal>
+      {errorMessage && (
+        <div className="mt-4">
+          <p className="text-danger font-medium mb-2">Search Service Error:</p>
+          <pre className="whitespace-pre-wrap break-words text-sm bg-gray-100 dark:bg-gray-800 p-4 rounded text-danger">
+            {errorMessage}
+          </pre>
+        </div>
+      )}
     </>
   );
 }

--- a/apps/agent-tars/src/renderer/src/components/LeftSidebar/Settings/SearchSettingsTab.tsx
+++ b/apps/agent-tars/src/renderer/src/components/LeftSidebar/Settings/SearchSettingsTab.tsx
@@ -4,6 +4,7 @@ import { SearchSettings, SearchProvider } from '@agent-infra/shared';
 import { getSearchProviderLogo } from './searchUtils';
 import toast from 'react-hot-toast';
 import { ipcClient } from '@renderer/api';
+import { FiAlertCircle } from 'react-icons/fi';
 
 interface SearchSettingsTabProps {
   settings: SearchSettings;
@@ -47,11 +48,17 @@ function TestSearchService({ settings }: TestSearchServiceProps) {
       </Button>
 
       {errorMessage && (
-        <div className="mt-4">
-          <p className="text-danger font-medium mb-2">Search Service Error:</p>
-          <pre className="whitespace-pre-wrap break-words text-sm bg-gray-100 dark:bg-gray-800 p-4 rounded text-danger">
+        <div className="mt-4 p-3 bg-danger-50 dark:bg-danger-900/10 border border-danger-200 rounded-md">
+          <div className="flex items-center gap-2 mb-2">
+            <FiAlertCircle className="text-danger" size={16} />
+            <p className="text-danger font-medium">Search Service Error:</p>
+          </div>
+          <p className="text-danger-600 dark:text-danger-400 text-sm font-mono my-2">
             {errorMessage}
-          </pre>
+          </p>
+          <p className="text-xs text-danger-500">
+            Please check your search provider settings and try again.
+          </p>
         </div>
       )}
     </>


### PR DESCRIPTION
After adding the search service, its availability can only be verified within the Agent workflow. If the search service is unavailable, many tasks may fail, leading to wasted tokens. This PR adds a validation feature when setting up the search service to detect availability issues in advance.

<img width="499" alt="image" src="https://github.com/user-attachments/assets/b3df4022-d347-47ad-9175-79bae9f8d1ae" />


---

<img width="1732" alt="image" src="https://github.com/user-attachments/assets/34dbd273-0339-490c-98d9-43d1a80776ab" />
