### PR TITLE
fix(agent-tars): correct spelling errors and code consistency issues

### DIFF
--- a/apps/agent-tars/src/renderer/src/agent/AgentFlow.ts
+++ b/apps/agent-tars/src/renderer/src/agent/AgentFlow.ts
@@ -203,7 +203,7 @@ export class AgentFlow {
 
           if (this.interruptController.signal.aborted) {
             this.interruptController = new AbortController();
-            this.loadingStatusTip = 'Replaning';
+            this.loadingStatusTip = 'Replanning';
             aware.updateSignal(this.interruptController.signal);
             executor.updateSignal(this.interruptController.signal);
             await this.eventManager.addLoadingStatus(this.loadingStatusTip);
@@ -289,7 +289,7 @@ export class AgentFlow {
                 });
               }
               // Execute tool in the main thread
-              const callResult = (await executor.excuteTools([toolCall]))[0];
+              const callResult = (await executor.executeTools([toolCall]))[0];
               this.appContext.setAgentStatusTip('Executing Tool');
 
               await this.eventManager.handleToolExecution({
@@ -348,7 +348,7 @@ export class AgentFlow {
     this.interruptController = new AbortController();
     aware.updateSignal(this.interruptController.signal);
     executor.updateSignal(this.interruptController.signal);
-    this.loadingStatusTip = 'Replaning';
+    this.loadingStatusTip = 'Replanning';
     await this.eventManager.addLoadingStatus(this.loadingStatusTip);
     this.appContext.setAgentStatusTip(this.loadingStatusTip);
   }

--- a/apps/agent-tars/src/renderer/src/agent/Aware.ts
+++ b/apps/agent-tars/src/renderer/src/agent/Aware.ts
@@ -98,9 +98,9 @@ For user interrupt input in the middle of the event stream, you should handle it
 
 <event_stream>
 
-The event stream result record the complete response of the agent, you should make next decision base on the history, if current step has not been done, please don't increment the step number. If you meet the \`ended\` message, that means you entered a new session and you should reset the plan from stratch.
+The event stream result record the complete response of the agent, you should make next decision base on the history, if current step has not been done, please don't increment the step number. If you meet the \`ended\` message, that means you entered a new session and you should reset the plan from scratch.
 
-In the event stream, the \`observation\` type message is the observation of the tool use, you should attention to the field and judge the task status accroding to it.When the observer represent the error message, you should reflect the error and solve it in the next step.
+In the event stream, the \`observation\` type message is the observation of the tool use, you should attention to the field and judge the task status according to it.When the observer represent the error message, you should reflect the error and solve it in the next step.
 
 </event_stream>
 
@@ -191,12 +191,12 @@ You should use the same language as the user input by default.
 
       try {
         this.abortSignal.addEventListener('abort', abortHandler);
-        const excutorTools = await ipcClient.listTools();
+        const executorTools = await ipcClient.listTools();
         const result = await ipcClient.askLLMTool({
           messages: [
             Message.systemMessage(this.systemPrompt),
             Message.systemMessage(
-              `You are working with excutor agent, here is the excutor tools: ${excutorTools
+              `You are working with executor agent, here is the executor tools: ${executorTools
                 .map((tool) => `${tool.name}: ${tool.description}`)
                 .join(', ')}`,
             ),

--- a/apps/agent-tars/src/renderer/src/agent/Executor/index.ts
+++ b/apps/agent-tars/src/renderer/src/agent/Executor/index.ts
@@ -31,7 +31,7 @@ export class Executor {
 <chat_message_tool>
 message as summary in current step.Don't return message first when the step just started.
 
-Notice, you should not output a lot of words in chat message, bacause the chat message is always summary words. If you want to write something in detail, please use \`write_file\` to write in by markdown file by default.
+Notice, you should not output a lot of words in chat message, because the chat message is always summary words. If you want to write something in detail, please use \`write_file\` to write in by markdown file by default.
 
 In chat message tool, you should add the files that has been created in the past steps, and put the complete file path in the \`attachments\` param.
 <chat_message_tool>
@@ -114,7 +114,7 @@ You should use the same language as the user input by default.
     });
   }
 
-  async excuteTools(toolCalls: ToolCall[]) {
+  async executeTools(toolCalls: ToolCall[]) {
     if (this.abortSignal.aborted) {
       throw new DOMException('Aborted', 'AbortError');
     }


### PR DESCRIPTION

# Fix Spelling Errors and Code Consistency Issues

This commit corrects multiple spelling errors and improves code consistency across the agent-tars codebase:

- Fixed spelling: "stratch" → "scratch", "accroding" → "according", "bacause" → "because", "Replaning" → "Replanning"
- Renamed for consistency: "excuteTools" → "executeTools" (method name and calls)
- Updated variable name: "excutorTools" → "executorTools"
- Corrected wording in system prompts: "excutor agent/tools" → "executor agent/tools"

These changes improve code readability, system prompt accuracy, and maintain consistent naming conventions throughout the codebase.
