### PR TITLE
fix(agent-tars): setting state not sync (close: #421)

### DIFF
--- a/apps/agent-tars/src/renderer/src/components/LeftSidebar/Settings/SettingsModal.tsx
+++ b/apps/agent-tars/src/renderer/src/components/LeftSidebar/Settings/SettingsModal.tsx
@@ -49,8 +49,6 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
     }
   };
 
-  console.log('settings', settings);
-
   return (
     <Modal isOpen={isOpen} onClose={onClose} size="2xl">
       <ModalContent>


### PR DESCRIPTION
## Summary

- Close: #421

Currently, when saving MCP settings, the **UI thread** will notify the **Main thread** to update the setting store through IPC (`ipcClient.addMcpServer` or `ipcClient.updateMcpServer`), the `SettingStore` in  **Main thread** will be updated, but the local `settings` state in  `useAppSettings` hook (**UI thread**) are not updated, this causes the state to be out of sync.

This pull request make all changes in the Setting Store to be notified from **Main thread** to the **UI thread**  to ensure the update of local state in WebView.