### PR TITLE
fix(browser-search): Waiting for selector error.

### DIFF
--- a/packages/agent-infra/search/browser-search/src/browser-search.ts
+++ b/packages/agent-infra/search/browser-search/src/browser-search.ts
@@ -119,6 +119,12 @@ export class BrowserSearch {
 
     this.logger.info(`Searching with ${options.engine} engine: ${url}`);
 
+    const SelectorMap: Record<SearchEngine, string> = {
+      bing: '.b_pag',
+      baidu: '#page',
+      google: '#botstuff',
+    };
+
     let links = await browser.evaluateOnNewPage({
       url,
       waitForOptions: {
@@ -130,7 +136,10 @@ export class BrowserSearch {
         await interceptRequest(page);
       },
       afterPageLoad: async (page) => {
-        await page.waitForSelector('.b_pag');
+        const selector = SelectorMap[options.engine];
+        if (selector) {
+          await page.waitForSelector(selector);
+        }
       },
     });
 


### PR DESCRIPTION
The `selector` should change according to the search engine.

bing => `.b_pag`
baidu =>  `#page`
google => `#botstuff`

```ts
// https://github.com/bytedance/UI-TARS-desktop/blob/main/packages/agent-infra/search/browser-search/src/browser-search.ts
let links = await browser.evaluateOnNewPage({
  url,
  waitForOptions: {
    waitUntil: 'networkidle0',
  },
  pageFunction: searchEngine.extractSearchResults,
  pageFunctionParams: [],
  beforePageLoad: async (page) => {
    await interceptRequest(page);
  },
  afterPageLoad: async (page) => {
    // This will cause a timeout error when not matched with the search engine.
    await page.waitForSelector('.b_pag');
  },
});
```