### PR TITLE
refactor(agent-tars): mcp servers settings form

### DIFF
--- a/apps/agent-tars/src/renderer/package.json
+++ b/apps/agent-tars/src/renderer/package.json
@@ -4,10 +4,10 @@
   "version": "0.0.1",
   "dependencies": {
     "@ui-tars/electron-ipc": "workspace:*",
+    "react-hook-form": "7.46.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "@nextui-org/react": "2.4.8",
-    "@nextui-org/form": "2.1.8",
     "framer-motion": "11.2.13",
     "styled-components": "6.1.11",
     "localforage": "^1.10.0",

--- a/apps/agent-tars/src/renderer/src/components/LeftSidebar/Settings/AddServerModal.tsx
+++ b/apps/agent-tars/src/renderer/src/components/LeftSidebar/Settings/AddServerModal.tsx
@@ -85,11 +85,6 @@ export function AddServerModal({
     name: 'type',
   });
 
-  const _status = useWatch({
-    control,
-    name: 'status',
-  });
-
   const onSubmitHandler = async (data: FormValues) => {
     try {
       setIsLoading(true);

--- a/apps/agent-tars/src/renderer/src/components/LeftSidebar/Settings/AddServerModal.tsx
+++ b/apps/agent-tars/src/renderer/src/components/LeftSidebar/Settings/AddServerModal.tsx
@@ -85,7 +85,7 @@ export function AddServerModal({
     name: 'type',
   });
 
-  const status = useWatch({
+  const _status = useWatch({
     control,
     name: 'status',
   });

--- a/apps/agent-tars/src/renderer/src/components/LeftSidebar/Settings/AddServerModal.tsx
+++ b/apps/agent-tars/src/renderer/src/components/LeftSidebar/Settings/AddServerModal.tsx
@@ -122,8 +122,10 @@ export function AddServerModal({
         };
       } else if (data.type === 'sse') {
         const headers: HeadersInit = {};
-        if (data.authorization) {
-          headers['Authorization'] = `Bearer ${data.authorization}`;
+        // TODO: add OAuth2.0 redirect
+        const token = data.authorization || '';
+        if (token) {
+          headers['Authorization'] = `Bearer ${token}`;
         }
         serverData = {
           ...baseData,

--- a/apps/agent-tars/src/renderer/src/components/LeftSidebar/Settings/AddServerModal.tsx
+++ b/apps/agent-tars/src/renderer/src/components/LeftSidebar/Settings/AddServerModal.tsx
@@ -14,11 +14,11 @@ import {
   AccordionItem,
 } from '@nextui-org/react';
 import { v4 as uuidv4 } from 'uuid';
-import { Form } from '@nextui-org/form';
 import { useState } from 'react';
 import { StdioMCPServer, SSEMCPServer } from '@agent-infra/mcp-shared/client';
 import { MCPServerName, MCPServerSetting } from '@agent-infra/shared';
 import { toast } from 'react-hot-toast';
+import { useForm, Controller, useWatch } from 'react-hook-form';
 
 type StdioServerData = StdioMCPServer & { id?: string; type: 'stdio' };
 type SSEServerData = SSEMCPServer & { id?: string; type: 'sse' };
@@ -28,6 +28,19 @@ interface AddServerModalProps {
   onClose: () => void;
   onSubmit: (mode: 'create' | 'edit', serverData: MCPServerSetting) => void;
   initialData?: MCPServerSetting | null;
+  mcpServerNames: string[];
+}
+
+interface FormValues {
+  name: string;
+  description: string;
+  type: 'stdio' | 'sse';
+  status: 'activate' | 'disabled';
+  command?: string;
+  args?: string;
+  env?: string;
+  url?: string;
+  authorization?: string;
 }
 
 export function AddServerModal({
@@ -35,107 +48,87 @@ export function AddServerModal({
   onClose,
   onSubmit,
   initialData,
+  mcpServerNames,
 }: AddServerModalProps) {
   const [isLoading, setIsLoading] = useState(false);
   const mode = initialData?.id ? 'edit' : 'create';
-  const [errors, setErrors] = useState<Record<string, string>>({});
-  const [serverType, setServerType] = useState<MCPServerSetting['type']>(
-    initialData?.type || 'stdio',
-  );
-  const [status, setStatus] = useState<MCPServerSetting['status']>(
-    initialData?.status || 'activate',
-  );
 
-  console.log('mode', mode, 'initialData', initialData);
-
-  const validateForm = (formData: FormData): boolean => {
-    const newErrors: Record<string, string> = {};
-
-    const name = formData.get('name') as string;
-    if (!name?.trim()) {
-      newErrors.name = 'Server name is required';
-    }
-
-    if (Object.values(MCPServerName).includes(name as MCPServerName)) {
-      newErrors.name = 'Server name is already in use';
-    }
-
-    if (serverType === 'stdio') {
-      const command = formData.get('command') as string;
-      if (!command?.trim()) {
-        newErrors.command = 'Command is required';
-      }
-    } else {
-      const url = formData.get('url') as string;
-      if (!url?.trim()) {
-        newErrors.url = 'URL is required';
-      } else if (!url.startsWith('http://') && !url.startsWith('https://')) {
-        newErrors.url = 'Please enter a valid URL';
-      }
-    }
-
-    console.log('newErrors', newErrors);
-    setErrors(newErrors);
-    return Object.keys(newErrors).length === 0;
+  const defaultValues: FormValues = {
+    name: initialData?.name || '',
+    description: initialData?.description || '',
+    type: (initialData?.type || 'stdio') as 'stdio' | 'sse',
+    status: (initialData?.status || 'activate') as 'activate' | 'disabled',
+    command: (initialData as StdioServerData)?.command || '',
+    args: (initialData as StdioServerData)?.args?.join('\n') || '',
+    env:
+      Object.entries((initialData as StdioServerData)?.env || {})
+        .map(([key, value]) => `${key}=${value}`)
+        .join('\n') || '',
+    url: (initialData as SSEServerData)?.url || '',
+    authorization:
+      (initialData as SSEServerData)?.headers?.['Authorization']?.replace(
+        'Bearer ',
+        '',
+      ) || '',
   };
 
-  const onSubmitHandler = async (e: React.FormEvent<HTMLFormElement>) => {
-    console.log('onSubmitHandler', e);
-    e.preventDefault();
+  const {
+    control,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormValues>({
+    defaultValues,
+  });
 
+  const serverType = useWatch({
+    control,
+    name: 'type',
+  });
+
+  const status = useWatch({
+    control,
+    name: 'status',
+  });
+
+  const onSubmitHandler = async (data: FormValues) => {
     try {
       setIsLoading(true);
-      const formData = new FormData(e.currentTarget);
-
-      if (!validateForm(formData)) {
-        return;
-      }
 
       const baseData = {
         id: initialData?.id || uuidv4(),
-        name: formData.get('name') as string,
-        description: formData.get('description') as string,
-        type: serverType,
-        status: status,
+        name: data.name,
+        description: data.description,
+        type: data.type,
+        status: data.status,
       };
 
       let serverData: MCPServerSetting;
-      if (serverType === 'stdio') {
+      if (data.type === 'stdio') {
         serverData = {
           ...baseData,
           type: 'stdio',
-          command: formData.get('command') as string,
-          // split args by \n or space
-          args: formData
-            .get('args')
-            ?.toString()
-            .split(/[\n\s]+/)
-            .filter(Boolean),
-          env: formData.get('env')
-            ? formData
-                .get('env')
-                ?.toString()
-                .split('\n')
-                .reduce(
-                  (acc, line) => {
-                    const [key, value] = line.split('=');
-                    acc[key] = value;
-                    return acc;
-                  },
-                  {} as Record<string, string>,
-                )
+          command: data.command as string,
+          args: data.args?.split(/[\n\s]+/).filter(Boolean),
+          env: data.env
+            ? data.env.split('\n').reduce(
+                (acc, line) => {
+                  const [key, value] = line.split('=');
+                  acc[key] = value;
+                  return acc;
+                },
+                {} as Record<string, string>,
+              )
             : {},
         };
-      } else if (serverType === 'sse') {
+      } else if (data.type === 'sse') {
         const headers: HeadersInit = {};
-        const token = formData.get('authorization');
-        if (token) {
-          headers['Authorization'] = `Bearer ${token}`;
+        if (data.authorization) {
+          headers['Authorization'] = `Bearer ${data.authorization}`;
         }
         serverData = {
           ...baseData,
           type: 'sse',
-          url: formData.get('url') as string,
+          url: data.url as string,
           headers,
         };
       } else {
@@ -145,6 +138,8 @@ export function AddServerModal({
 
       await onSubmit(mode, serverData);
       onClose();
+    } catch (error) {
+      console.error(error);
     } finally {
       setIsLoading(false);
     }
@@ -152,7 +147,7 @@ export function AddServerModal({
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} size="2xl">
-      <Form onSubmit={onSubmitHandler} validationBehavior="native">
+      <form onSubmit={handleSubmit(onSubmitHandler)}>
         <ModalContent>
           {(onClose) => (
             <>
@@ -161,121 +156,159 @@ export function AddServerModal({
               </ModalHeader>
               <ModalBody>
                 <div className="flex flex-col gap-4">
-                  <Input
+                  <Controller
                     name="name"
-                    label="Name"
-                    placeholder="Input server name"
-                    disabled={mode === 'edit'}
-                    isRequired
-                    isInvalid={!!errors.name}
-                    errorMessage={errors.name}
-                    defaultValue={initialData?.name}
-                    onChange={(_) => {
-                      setErrors((prev) => ({ ...prev, name: '' }));
-                    }}
+                    control={control}
+                    rules={
+                      mode === 'create'
+                        ? {
+                            required: 'Server name is required',
+                            validate: (value) =>
+                              !Object.values(MCPServerName).includes(
+                                value as MCPServerName,
+                              ) ||
+                              !mcpServerNames.includes(value) ||
+                              'Server name is already in use',
+                          }
+                        : undefined
+                    }
+                    render={({ field }) => (
+                      <Input
+                        {...field}
+                        label="Name"
+                        placeholder="Input server name"
+                        disabled={mode === 'edit'}
+                        isRequired
+                        isInvalid={!!errors.name}
+                        errorMessage={errors.name?.message}
+                      />
+                    )}
                   />
 
-                  <Textarea
+                  <Controller
                     name="description"
-                    label="Description"
-                    placeholder="Input server description"
-                    defaultValue={initialData?.description}
+                    control={control}
+                    render={({ field }) => (
+                      <Textarea
+                        {...field}
+                        label="Description"
+                        placeholder="Input server description"
+                      />
+                    )}
                   />
 
-                  <Select
+                  <Controller
                     name="type"
-                    label="Type"
-                    disallowEmptySelection
-                    placeholder="Select server type"
-                    selectedKeys={[serverType] as any}
-                    onChange={(e) => {
-                      setServerType(e.target.value as 'stdio' | 'sse');
-                      setErrors((prev) => ({ ...prev, type: '' }));
-                    }}
-                    isRequired
-                    isInvalid={!!errors.type}
-                    errorMessage={errors.type}
-                  >
-                    <SelectItem key="stdio" value="stdio">
-                      STDIO (Standard Input/Output)
-                    </SelectItem>
-                    <SelectItem key="sse" value="sse">
-                      SSE (Server-Sent Events)
-                    </SelectItem>
-                  </Select>
+                    control={control}
+                    rules={{ required: 'Server type is required' }}
+                    render={({ field: { value, onChange } }) => (
+                      <Select
+                        label="Type"
+                        disallowEmptySelection
+                        placeholder="Select server type"
+                        selectedKeys={[value]}
+                        onChange={(e) => onChange(e.target.value)}
+                        isRequired
+                        isInvalid={!!errors.type}
+                        errorMessage={errors.type?.message}
+                      >
+                        <SelectItem key="stdio" value="stdio">
+                          STDIO (Standard Input/Output)
+                        </SelectItem>
+                        <SelectItem key="sse" value="sse">
+                          SSE (Server-Sent Events)
+                        </SelectItem>
+                      </Select>
+                    )}
+                  />
 
                   {serverType === 'stdio' ? (
                     <>
-                      <Input
+                      <Controller
                         name="command"
-                        label="Command"
-                        placeholder="uvx or npx or other binary executable"
-                        isRequired
-                        isInvalid={!!errors.command}
-                        errorMessage={errors.command}
-                        onChange={(_) => {
-                          setErrors((prev) => ({ ...prev, command: '' }));
-                        }}
-                        defaultValue={(initialData as StdioServerData)?.command}
+                        control={control}
+                        rules={{ required: 'Command is required' }}
+                        render={({ field }) => (
+                          <Input
+                            {...field}
+                            label="Command"
+                            placeholder="uvx or npx or other binary executable"
+                            isRequired
+                            isInvalid={!!errors.command}
+                            errorMessage={errors.command?.message}
+                          />
+                        )}
                       />
 
-                      <Textarea
+                      <Controller
                         name="args"
-                        label="Arguments"
-                        placeholder="Each line is a parameter"
-                        defaultValue={(
-                          initialData as StdioServerData
-                        )?.args?.join('\n')}
+                        control={control}
+                        render={({ field }) => (
+                          <Textarea
+                            {...field}
+                            label="Arguments"
+                            placeholder="Each line is a parameter"
+                          />
+                        )}
                       />
 
-                      <Textarea
+                      <Controller
                         name="env"
-                        label="Environment Variables"
-                        placeholder="KEY1=value1&#10;KEY2=value2"
-                        isInvalid={!!errors.env}
-                        errorMessage={errors.env}
-                        onChange={(_) => {
-                          setErrors((prev) => ({ ...prev, env: '' }));
-                        }}
-                        defaultValue={Object.entries(
-                          (initialData as StdioServerData)?.env || {},
-                        )
-                          .map(([key, value]) => `${key}=${value}`)
-                          .join('\n')}
+                        control={control}
+                        render={({ field }) => (
+                          <Textarea
+                            {...field}
+                            label="Environment Variables"
+                            placeholder="KEY1=value1&#10;KEY2=value2"
+                            isInvalid={!!errors.env}
+                            errorMessage={errors.env?.message}
+                          />
+                        )}
                       />
                     </>
                   ) : (
                     <>
-                      <Input
+                      <Controller
                         name="url"
-                        label="URL"
-                        placeholder="https://example.com/sse"
-                        isRequired
-                        isInvalid={!!errors.url}
-                        errorMessage={errors.url}
-                        onChange={(_) => {
-                          setErrors((prev) => ({ ...prev, url: '' }));
+                        control={control}
+                        rules={{
+                          required: 'URL is required',
+                          validate: (value) =>
+                            !value ||
+                            value.startsWith('http://') ||
+                            value.startsWith('https://') ||
+                            'Please enter a valid URL',
                         }}
-                        defaultValue={(initialData as SSEServerData)?.url}
+                        render={({ field }) => (
+                          <Input
+                            {...field}
+                            label="URL"
+                            placeholder="https://example.com/sse"
+                            isRequired
+                            isInvalid={!!errors.url}
+                            errorMessage={errors.url?.message}
+                          />
+                        )}
                       />
                       <Accordion className="px-0">
                         <AccordionItem title="Authorization" className="px-0">
-                          <Input
+                          <Controller
                             name="authorization"
-                            label="Bearer Token"
-                            placeholder="Bearer Token"
-                            defaultValue={
-                              (initialData as SSEServerData)?.headers?.[
-                                'Authorization'
-                              ]
-                            }
-                            startContent={
-                              <div className="pointer-events-none flex items-center">
-                                <span className="text-default-400 text-small">
-                                  Bearer
-                                </span>
-                              </div>
-                            }
+                            control={control}
+                            render={({ field }) => (
+                              <Input
+                                {...field}
+                                label="Bearer Token"
+                                placeholder="Bearer Token"
+                                startContent={
+                                  <div className="pointer-events-none flex items-center">
+                                    <span className="text-default-400 text-small">
+                                      Bearer
+                                    </span>
+                                  </div>
+                                }
+                              />
+                            )}
                           />
                         </AccordionItem>
                       </Accordion>
@@ -285,14 +318,19 @@ export function AddServerModal({
                   <div className="flex flex-col gap-1">
                     <p className="text-small">Enable</p>
                     <div className="flex items-center gap-2">
-                      <Switch
+                      <Controller
                         name="status"
-                        size="sm"
-                        isSelected={status === 'activate'}
-                        onValueChange={(checked) =>
-                          setStatus(checked ? 'activate' : 'disabled')
-                        }
-                        aria-label="Server status"
+                        control={control}
+                        render={({ field: { value, onChange } }) => (
+                          <Switch
+                            size="sm"
+                            isSelected={value === 'activate'}
+                            onValueChange={(checked) =>
+                              onChange(checked ? 'activate' : 'disabled')
+                            }
+                            aria-label="Server status"
+                          />
+                        )}
                       />
                     </div>
                   </div>
@@ -320,7 +358,7 @@ export function AddServerModal({
             </>
           )}
         </ModalContent>
-      </Form>
+      </form>
     </Modal>
   );
 }

--- a/apps/agent-tars/src/renderer/src/components/LeftSidebar/Settings/AddServerModal.tsx
+++ b/apps/agent-tars/src/renderer/src/components/LeftSidebar/Settings/AddServerModal.tsx
@@ -166,10 +166,10 @@ export function AddServerModal({
                         ? {
                             required: 'Server name is required',
                             validate: (value) =>
-                              !Object.values(MCPServerName).includes(
-                                value as MCPServerName,
-                              ) ||
-                              !mcpServerNames.includes(value) ||
+                              ![
+                                ...mcpServerNames,
+                                ...Object.values(MCPServerName),
+                              ].includes(value as MCPServerName) ||
                               'Server name is already in use',
                           }
                         : undefined

--- a/apps/agent-tars/src/renderer/src/components/LeftSidebar/Settings/MCPServersSettingsTab.tsx
+++ b/apps/agent-tars/src/renderer/src/components/LeftSidebar/Settings/MCPServersSettingsTab.tsx
@@ -76,10 +76,6 @@ export function MCPServersSettingsTab({
     serverData: MCPServerSetting,
   ) => {
     console.log('New server data:', serverData);
-    if (mcpServers.some((s) => s.name === serverData.name)) {
-      toast.error('MCP Server name already exists');
-      throw new Error('MCP Server name already exists');
-    }
     if (serverData.status === 'activate') {
       const { error } = await ipcClient.checkServerStatus(serverData);
       if (error) {
@@ -250,6 +246,7 @@ export function MCPServersSettingsTab({
         }}
         onSubmit={handleAddServer}
         initialData={editServerData}
+        mcpServerNames={mcpServers.map((s) => s.name)}
       />
       <Table removeWrapper aria-label="Example table with custom cells">
         <TableHeader columns={columns}>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -290,9 +290,6 @@ importers:
       '@monaco-editor/react':
         specifier: 4.7.0
         version: 4.7.0(monaco-editor@0.52.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@nextui-org/form':
-        specifier: 2.1.8
-        version: 2.1.8(@nextui-org/system@2.4.6(@nextui-org/theme@2.4.5(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))))(framer-motion@11.2.13(@emotion/is-prop-valid@1.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@nextui-org/theme@2.4.5(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@nextui-org/react':
         specifier: 2.4.8
         version: 2.4.8(@types/react@18.3.18)(framer-motion@11.2.13(@emotion/is-prop-valid@1.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3)))
@@ -353,6 +350,9 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
+      react-hook-form:
+        specifier: 7.46.1
+        version: 7.46.1(react@18.3.1)
       react-hot-toast:
         specifier: 2.5.2
         version: 2.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1473,7 +1473,7 @@ importers:
         version: 3.0.5(@types/debug@4.1.12)(@types/node@22.13.10)(@vitest/browser@3.0.5)(happy-dom@17.1.1)(jiti@2.4.2)(jsdom@26.0.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(msw@2.7.0(@types/node@22.13.10)(typescript@5.7.3))(sass-embedded@1.83.4)(sass@1.85.1)(tsx@4.19.2)(yaml@2.7.0)
       vitest-browser-react:
         specifier: ^0.1.1
-        version: 0.1.1(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(@vitest/browser@3.0.5(@types/node@22.13.10)(bufferutil@4.0.9)(playwright@1.50.1)(typescript@5.7.3)(utf-8-validate@6.0.5)(vite@6.2.2(@types/node@22.13.10)(jiti@2.4.2)(sass-embedded@1.83.4)(sass@1.85.1)(tsx@4.19.2)(yaml@2.7.0))(vitest@3.0.5))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vitest@3.0.5(@types/debug@4.1.12)(@types/node@22.13.10)(@vitest/browser@3.0.5)(happy-dom@17.1.1)(jiti@2.4.2)(jsdom@26.0.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(msw@2.7.0(@types/node@22.13.10)(typescript@5.7.3))(sass-embedded@1.83.4)(sass@1.85.1)(tsx@4.19.2)(yaml@2.7.0))
+        version: 0.1.1(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(@vitest/browser@3.0.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vitest@3.0.5)
 
   packages/ui-tars/shared:
     devDependencies:
@@ -3662,15 +3662,6 @@ packages:
       react: '>=18'
       react-dom: '>=18'
 
-  '@nextui-org/form@2.1.8':
-    resolution: {integrity: sha512-Xn/dUO5zDG7zukbql1MDYh4Xwe1vnIVMRTHgckbkBtXXVNqgoTU09TTfy8WOJ0pMDX4GrZSBAZ86o37O+IHbaA==}
-    deprecated: This package has been deprecated. Please use @heroui/form instead.
-    peerDependencies:
-      '@nextui-org/system': '>=2.4.0'
-      '@nextui-org/theme': '>=2.4.0'
-      react: '>=18'
-      react-dom: '>=18'
-
   '@nextui-org/framer-utils@2.0.25':
     resolution: {integrity: sha512-bhQKDg4c5Da4II4UYLKyvYagusTd62eVwPqpfUP+GHZKKZcmRaS6MQZTh4xJYbpyh298S4jRSH/AUAiN/OK3TQ==}
     peerDependencies:
@@ -4593,11 +4584,6 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
 
-  '@react-stately/form@3.1.0':
-    resolution: {integrity: sha512-E2wxNQ0QaTyDHD0nJFtTSnEH9A3bpJurwxhS4vgcUmESHgjFEMLlC9irUSZKgvOgb42GAq+fHoWBsgKeTp9Big==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
   '@react-stately/form@3.1.2':
     resolution: {integrity: sha512-sKgkV+rxeqM1lf0dCq2wWzdYa5Z0wz/MB3yxjodffy8D43PjFvUOMWpgw/752QHPGCd1XIxA3hE58Dw9FFValg==}
     peerDependencies:
@@ -4765,11 +4751,6 @@ packages:
 
   '@react-types/dialog@3.5.16':
     resolution: {integrity: sha512-2D16XjuW9fG3LkVIXu3RzUp3zcK2IZOWlAl+r5i0aLw2Q0QHyYMfGbmgvhxVeAhxhEj/57/ziSl/8rJ9pzmFnw==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  '@react-types/form@3.7.8':
-    resolution: {integrity: sha512-0wOS97/X0ijTVuIqik1lHYTZnk13QkvMTKvIEhM7c6YMU3vPiirBwLbT2kJiAdwLiymwcCkrBdDF1NTRG6kPFA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
@@ -9779,6 +9760,12 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  react-hook-form@7.46.1:
+    resolution: {integrity: sha512-0GfI31LRTBd5tqbXMGXT1Rdsv3rnvy0FjEk8Gn9/4tp6+s77T7DPZuGEpBRXOauL+NhyGT5iaXzdIM2R6F/E+w==}
+    engines: {node: '>=12.22.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18
 
   react-hot-toast@2.5.2:
     resolution: {integrity: sha512-Tun3BbCxzmXXM7C+NI4qiv6lT0uwGh4oAfeJyNOjYUejTsm35mK9iCaYLGv8cBz9L5YxZLx/2ii7zsIwPtPUdw==}
@@ -14942,19 +14929,6 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@nextui-org/form@2.1.8(@nextui-org/system@2.4.6(@nextui-org/theme@2.4.5(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))))(framer-motion@11.2.13(@emotion/is-prop-valid@1.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@nextui-org/theme@2.4.5(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@nextui-org/react-utils': 2.1.3(react@18.3.1)
-      '@nextui-org/shared-utils': 2.1.2
-      '@nextui-org/system': 2.4.6(@nextui-org/theme@2.4.5(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))))(framer-motion@11.2.13(@emotion/is-prop-valid@1.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@nextui-org/theme': 2.4.5(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3)))
-      '@react-aria/utils': 3.26.0(react@18.3.1)
-      '@react-stately/form': 3.1.0(react@18.3.1)
-      '@react-types/form': 3.7.8(react@18.3.1)
-      '@react-types/shared': 3.26.0(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-
   '@nextui-org/framer-utils@2.0.25(@nextui-org/theme@2.2.11(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.7.3))))(framer-motion@11.2.13(@emotion/is-prop-valid@1.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@nextui-org/shared-utils': 2.0.8
@@ -16601,12 +16575,6 @@ snapshots:
       '@swc/helpers': 0.5.15
       react: 18.3.1
 
-  '@react-stately/form@3.1.0(react@18.3.1)':
-    dependencies:
-      '@react-types/shared': 3.28.0(react@18.3.1)
-      '@swc/helpers': 0.5.15
-      react: 18.3.1
-
   '@react-stately/form@3.1.2(react@18.3.1)':
     dependencies:
       '@react-types/shared': 3.28.0(react@18.3.1)
@@ -16852,11 +16820,6 @@ snapshots:
   '@react-types/dialog@3.5.16(react@18.3.1)':
     dependencies:
       '@react-types/overlays': 3.8.13(react@18.3.1)
-      '@react-types/shared': 3.28.0(react@18.3.1)
-      react: 18.3.1
-
-  '@react-types/form@3.7.8(react@18.3.1)':
-    dependencies:
       '@react-types/shared': 3.28.0(react@18.3.1)
       react: 18.3.1
 
@@ -22985,6 +22948,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.18
 
+  react-hook-form@7.46.1(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+
   react-hot-toast@2.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       csstype: 3.1.3
@@ -24938,7 +24905,7 @@ snapshots:
       tsx: 4.19.3
       yaml: 2.7.0
 
-  vitest-browser-react@0.1.1(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(@vitest/browser@3.0.5(@types/node@22.13.10)(bufferutil@4.0.9)(playwright@1.50.1)(typescript@5.7.3)(utf-8-validate@6.0.5)(vite@6.2.2(@types/node@22.13.10)(jiti@2.4.2)(sass-embedded@1.83.4)(sass@1.85.1)(tsx@4.19.2)(yaml@2.7.0))(vitest@3.0.5))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vitest@3.0.5(@types/debug@4.1.12)(@types/node@22.13.10)(@vitest/browser@3.0.5)(happy-dom@17.1.1)(jiti@2.4.2)(jsdom@26.0.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(msw@2.7.0(@types/node@22.13.10)(typescript@5.7.3))(sass-embedded@1.83.4)(sass@1.85.1)(tsx@4.19.2)(yaml@2.7.0)):
+  vitest-browser-react@0.1.1(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(@vitest/browser@3.0.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vitest@3.0.5):
     dependencies:
       '@vitest/browser': 3.0.5(@types/node@22.13.10)(bufferutil@4.0.9)(playwright@1.50.1)(typescript@5.7.3)(utf-8-validate@6.0.5)(vite@6.2.2(@types/node@22.13.10)(jiti@2.4.2)(sass-embedded@1.83.4)(sass@1.85.1)(tsx@4.19.2)(yaml@2.7.0))(vitest@3.0.5)
       react: 18.3.1


### PR DESCRIPTION
Close https://github.com/bytedance/UI-TARS-desktop/issues/435
Ref: https://github.com/heroui-inc/heroui/issues/2844

This pull request includes significant updates to the `AddServerModal` component and the removal of the deprecated `@nextui-org/form` package. The most important changes involve the migration to `react-hook-form` for form handling, and the addition of new form validation logic.

### Migration to `react-hook-form`:

* [`apps/agent-tars/src/renderer/package.json`](diffhunk://#diff-ea3a409804af0e27dbbc1ed58d89cd8511633bdd3423bb454b7d6b35c1906d77R7-L10): Added `react-hook-form` as a dependency and removed the deprecated `@nextui-org/form` package.
* [`apps/agent-tars/src/renderer/src/components/LeftSidebar/Settings/AddServerModal.tsx`](diffhunk://#diff-8140b546d8d26bd4c85be59c4d9a3cd8c1acbd27d71f88ff5924b79e07aa18d2L17-R21): Replaced the use of `@nextui-org/form` with `react-hook-form` for form handling and validation. This includes using `Controller` for controlled components and `useWatch` for watching form values. [[1]](diffhunk://#diff-8140b546d8d26bd4c85be59c4d9a3cd8c1acbd27d71f88ff5924b79e07aa18d2L17-R21) [[2]](diffhunk://#diff-8140b546d8d26bd4c85be59c4d9a3cd8c1acbd27d71f88ff5924b79e07aa18d2R31-R113) [[3]](diffhunk://#diff-8140b546d8d26bd4c85be59c4d9a3cd8c1acbd27d71f88ff5924b79e07aa18d2L129-R131) [[4]](diffhunk://#diff-8140b546d8d26bd4c85be59c4d9a3cd8c1acbd27d71f88ff5924b79e07aa18d2R141-R150) [[5]](diffhunk://#diff-8140b546d8d26bd4c85be59c4d9a3cd8c1acbd27d71f88ff5924b79e07aa18d2L164-R213) [[6]](diffhunk://#diff-8140b546d8d26bd4c85be59c4d9a3cd8c1acbd27d71f88ff5924b79e07aa18d2R222-L271) [[7]](diffhunk://#diff-8140b546d8d26bd4c85be59c4d9a3cd8c1acbd27d71f88ff5924b79e07aa18d2R311-R312) [[8]](diffhunk://#diff-8140b546d8d26bd4c85be59c4d9a3cd8c1acbd27d71f88ff5924b79e07aa18d2L288-R334) [[9]](diffhunk://#diff-8140b546d8d26bd4c85be59c4d9a3cd8c1acbd27d71f88ff5924b79e07aa18d2L323-R361)

### Form validation improvements:

* [`apps/agent-tars/src/renderer/src/components/LeftSidebar/Settings/AddServerModal.tsx`](diffhunk://#diff-8140b546d8d26bd4c85be59c4d9a3cd8c1acbd27d71f88ff5924b79e07aa18d2L164-R213): Implemented new validation rules using `react-hook-form`, including custom validation for server names and URL formats. [[1]](diffhunk://#diff-8140b546d8d26bd4c85be59c4d9a3cd8c1acbd27d71f88ff5924b79e07aa18d2L164-R213) [[2]](diffhunk://#diff-8140b546d8d26bd4c85be59c4d9a3cd8c1acbd27d71f88ff5924b79e07aa18d2R222-L271)

### Additional changes:

* [`apps/agent-tars/src/renderer/src/components/LeftSidebar/Settings/MCPServersSettingsTab.tsx`](diffhunk://#diff-8d6e3769290ba7b908382745c00c94170ac800582920c5aaed4223c5abe371d4R249): Updated to pass the list of existing server names to the `AddServerModal` component for validation purposes.
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL293-L295): Removed references to the deprecated `@nextui-org/form` package and added `react-hook-form`. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL293-L295) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR353-R355) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1476-R1476) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL3665-L3673)