### PR TITLE
feat(browser-search): add sogou search engine

### DIFF
--- a/apps/agent-tars/src/renderer/src/components/LeftSidebar/Settings/SearchSettingsTab.tsx
+++ b/apps/agent-tars/src/renderer/src/components/LeftSidebar/Settings/SearchSettingsTab.tsx
@@ -363,6 +363,7 @@ export function SearchSettingsTab({
             {/* <SelectItem key="bing">Bing</SelectItem> */}
             <SelectItem key="google">Google</SelectItem>
             <SelectItem key="baidu">Baidu</SelectItem>
+            <SelectItem key="sogou">Sogou</SelectItem>
           </Select>
 
           <Switch

--- a/packages/agent-infra/search/browser-search/src/engines/get-search-engine.ts
+++ b/packages/agent-infra/search/browser-search/src/engines/get-search-engine.ts
@@ -1,12 +1,13 @@
 import { GoogleSearchEngine } from './google-engine';
 import { BingSearchEngine } from './bing-engine';
 import { BaiduSearchEngine } from './baidu-engine';
+import { SogouSearchEngine } from './sogou-engine';
 import type { LocalBrowserSearchEngine, SearchEngineAdapter } from '../types';
 
 /**
  * Factory function to get the appropriate search engine adapter instance.
  *
- * @param engine - The search engine identifier ('google', 'bing', or 'baidu')
+ * @param engine - The search engine identifier ('google', 'bing', 'baidu', or 'sogou')
  * @returns An instance of the requested search engine adapter
  */
 export function getSearchEngine(
@@ -19,6 +20,8 @@ export function getSearchEngine(
       return new BingSearchEngine();
     case 'baidu':
       return new BaiduSearchEngine();
+    case 'sogou':
+      return new SogouSearchEngine();
     default:
       return new GoogleSearchEngine();
   }

--- a/packages/agent-infra/search/browser-search/src/engines/index.ts
+++ b/packages/agent-infra/search/browser-search/src/engines/index.ts
@@ -6,4 +6,5 @@
 export * from './google-engine';
 export * from './bing-engine';
 export * from './baidu-engine';
+export * from './sogou-engine';
 export { getSearchEngine } from './get-search-engine';

--- a/packages/agent-infra/search/browser-search/src/engines/sogou-engine.ts
+++ b/packages/agent-infra/search/browser-search/src/engines/sogou-engine.ts
@@ -1,0 +1,125 @@
+import type { Page } from '@agent-infra/browser';
+import type { SearchEngineAdapter, SearchResult } from '../types';
+
+export class SogouSearchEngine implements SearchEngineAdapter {
+  /**
+   * Generates a Sogou search URL based on the provided query and options.
+   *
+   * @param query - The search query string
+   * @param options - Search configuration options
+   * @param options.count - Number of search results to request (default: 10)
+   * @param options.excludeDomains - Array of domain names to exclude from search results
+   * @returns Formatted Sogou search URL as a string
+   */
+  getSearchUrl(
+    query: string,
+    options: {
+      count?: number;
+      excludeDomains?: string[];
+    },
+  ): string {
+    const { count = 10, excludeDomains = [] } = options;
+
+    const excludeDomainsQuery =
+      excludeDomains && excludeDomains.length > 0
+        ? excludeDomains.map((domain) => `-site:${domain}`).join(' ')
+        : '';
+
+    const searchParams = new URLSearchParams({
+      query: `${excludeDomainsQuery ? `${excludeDomainsQuery} ` : ''}${query}`,
+      num: `${count}`,
+    });
+
+    return `https://www.sogou.com/web?${searchParams.toString()}`;
+  }
+
+  /**
+   * !NOTE: This function runs in the context of the browser page, not Node.js
+   * 
+   * Extract search results from Sogou search page.
+   * @param window - window
+   * @returns Search results extracted from the page
+   */
+  extractSearchResults(window: Window): SearchResult[] {
+    const links: SearchResult[] = [];
+    const document = window.document;
+
+    const isValidUrl = (url: string) => {
+      try {
+        new URL(url);
+        return true;
+      } catch (error) {
+        return false;
+      }
+    };
+
+    const BaseUrl = 'https://www.sogou.com';
+    
+    const SELECTOR = {
+      results: '.results .vrwrap',
+      resultTitle: '.vr-title',
+      resultLink: '.vr-title > a',
+      resultSnippet: ['.star-wiki', '.fz-mid', '.attribute-centent'],
+      resultSnippetExcluded: ['.text-lightgray', '.zan-box', '.tag-website'],
+      related: '#main .vrwrap.middle-better-hintBox .hint-mid',
+    };
+
+    try {
+      const elements = document.querySelectorAll(SELECTOR.results);
+      elements.forEach((element) => {
+        const titleEl = element.querySelector(SELECTOR.resultTitle);
+        let url = element.querySelector(SELECTOR.resultLink)?.getAttribute('href');
+
+        // Extract snippets
+        const snippets = SELECTOR.resultSnippet.map((selector) => {
+          const cloneElement = element.cloneNode(true) as HTMLElement;
+          // remove excluded elements
+          SELECTOR.resultSnippetExcluded.forEach((excludedSelector) => {
+            const el = cloneElement.querySelector(excludedSelector);
+            el?.remove();
+          });
+          // get the text content of the element
+          const el = cloneElement.querySelector(selector);
+          return el?.textContent?.trim() || '';
+        });
+
+        const snippet = snippets
+          .filter(Boolean)
+          .join(' ')
+          .replace(/\s+/g, ' ')
+          .trim();
+
+        // if the url is like '/xxxx', add the base url
+        if (!url?.includes('http')) url = `${BaseUrl}${url}`;
+
+        if (!url?.trim() || !isValidUrl(url)) return;
+
+        const item: SearchResult = {
+          title: titleEl?.textContent?.trim() || '',
+          url,
+          snippet,
+          content: '',
+        };
+
+        if (!item.title || !item.url) return;
+
+        links.push(item);
+      });
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      console.error('Error extracting search results from Sogou:', msg);
+    }
+
+    return links;
+  }
+
+  /**
+  * Waits for Sogou search results to load completely.
+  *
+  * @param page - The Puppeteer page object
+  * @returns Promise that resolves when search results are loaded
+  */
+  async waitForSearchResults(page: Page): Promise<void> {
+    await page.waitForSelector('#pagebar_container');
+  }
+}

--- a/packages/agent-infra/shared/src/agent-tars-types/search.ts
+++ b/packages/agent-infra/shared/src/agent-tars-types/search.ts
@@ -24,7 +24,7 @@ export enum SearchProvider {
   SearXNG = 'searxng',
 }
 
-export type LocalBrowserSearchEngine = 'google' | 'bing' | 'baidu';
+export type LocalBrowserSearchEngine = 'google' | 'bing' | 'baidu' | 'sogou';
 
 export interface SearchSettings {
   provider: SearchProvider;


### PR DESCRIPTION
browser-search: add Sogou search engine.

Example of returned result:

```ts
{
  title: 'UI-TARS-desktop/CONTRIBUTING.md at main · bytedance/UI-TARS-...',
  url: 'https://www.sogou.com/link?url=hedJjaC291MuovqUW6cN1ma_85f9WHYRG8g_LUqhaba655l_FzkR2_ILhpWJFprBQKqCTDjEZrZE-ib8ISenP-XxOE5J3fXM',
  snippet: "about what you're running into. Provide project and platform versions (nodejs, npm, etc), ... cd ui-tars-desktop Development Install dependencies $ pnpm install Run the application ...",
  content: ''
},
{
  title: '小米公布SU7高速爆燃事件细节',
  url: 'https://view.inews.qq.com/a/20250401A05RUU00?scene=qqsearch&qudao=qbsearch_news&query=%E5%B0%8F%E7%B1%B3SU7%E7%9A%84%E4%BA%8B%E6%95%85%E8%BF%9B%E5%B1%95',
  snippet: '4月1日，小米公司发言人微博发文公布“小米SU7爆燃致三人死亡”信息摘要：已提交车辆行驶数据及系统运行信息，全力配合警方工作。 小米SU7事故引发热议 专题',
  content: ''
}
```