### PR TITLE
refactor(agent-tars): merge redundant setting constants across threads

### DIFF
--- a/apps/agent-tars/src/main/store/setting.ts
+++ b/apps/agent-tars/src/main/store/setting.ts
@@ -4,51 +4,10 @@
  */
 import { BrowserWindow } from 'electron';
 import ElectronStore from 'electron-store';
-import {
-  ModelProvider,
-  ModelSettings,
-  SearchProvider,
-  SearchSettings,
-  FileSystemSettings,
-  AppSettings,
-  MCPSettings,
-} from '@agent-infra/shared';
+import { AppSettings } from '@agent-infra/shared';
 import { logger } from '@main/utils/logger';
 import { maskSensitiveData } from '@main/utils/maskSensitiveData';
-
-const DEFAULT_MODEL_SETTINGS: ModelSettings = {
-  provider: ModelProvider.OPENAI,
-  model: 'gpt-4o',
-  apiKey: '',
-  apiVersion: '',
-  endpoint: '',
-};
-
-const DEFAULT_FILESYSTEM_SETTINGS: FileSystemSettings = {
-  availableDirectories: [],
-};
-
-const DEFAULT_SEARCH_SETTINGS: SearchSettings = {
-  provider: SearchProvider.BrowserSearch,
-  providerConfig: {
-    count: 10,
-    engine: 'google',
-    needVisitedUrls: false,
-  },
-  apiKey: '',
-};
-
-const DEFAULT_MCP_SERVERS_SETTINGS: MCPSettings = {
-  mcpServers: [],
-};
-
-export const DEFAULT_SETTING: AppSettings = {
-  model: DEFAULT_MODEL_SETTINGS,
-  fileSystem: DEFAULT_FILESYSTEM_SETTINGS,
-  search: DEFAULT_SEARCH_SETTINGS,
-  mcp: DEFAULT_MCP_SERVERS_SETTINGS,
-};
-
+import { DEFAULT_SETTINGS } from '@shared/constants';
 export class SettingStore {
   private static instance: ElectronStore<AppSettings>;
 
@@ -56,7 +15,7 @@ export class SettingStore {
     if (!SettingStore.instance) {
       SettingStore.instance = new ElectronStore<AppSettings>({
         name: 'agent_tars.setting',
-        defaults: DEFAULT_SETTING,
+        defaults: DEFAULT_SETTINGS,
       });
 
       SettingStore.instance.onDidAnyChange((newValue, oldValue) => {
@@ -99,7 +58,7 @@ export class SettingStore {
   }
 
   public static clear(): void {
-    SettingStore.getInstance().set(DEFAULT_SETTING);
+    SettingStore.getInstance().set(DEFAULT_SETTINGS);
   }
 
   public static openInEditor(): void {

--- a/apps/agent-tars/src/renderer/src/components/LeftSidebar/Settings/useAppSettings.ts
+++ b/apps/agent-tars/src/renderer/src/components/LeftSidebar/Settings/useAppSettings.ts
@@ -1,53 +1,22 @@
 import { useEffect, useRef } from 'react';
 import {
   AppSettings,
-  FileSystemSettings,
   ModelSettings,
   ModelProvider,
   SearchSettings,
-  MCPSettings,
   SearchProvider,
 } from '@agent-infra/shared';
 import { ipcClient } from '@renderer/api';
 import { isReportHtmlMode } from '@renderer/constants';
 import { atom, useAtom } from 'jotai';
 import toast from 'react-hot-toast';
-
-/**
- * FIXME: Merge inconsistent settings between main and renderer threads.
- */
-const DEFAULT_MODEL_SETTINGS: ModelSettings = {
-  provider: ModelProvider.ANTHROPIC,
-  model: 'claude-3-7-sonnet-latest',
-  apiKey: '',
-  apiVersion: '',
-  endpoint: '',
-};
-
-const DEFAULT_FILESYSTEM_SETTINGS: FileSystemSettings = {
-  availableDirectories: [],
-};
-
-const DEFAULT_SEARCH_SETTINGS: SearchSettings = {
-  provider: SearchProvider.BrowserSearch,
-  providerConfig: {
-    count: 10,
-    engine: 'google',
-    needVisitedUrls: false,
-  },
-  apiKey: '',
-};
-
-const DEFAULT_MCP_SETTINGS: MCPSettings = {
-  mcpServers: [],
-};
-
-export const DEFAULT_SETTINGS: AppSettings = {
-  model: DEFAULT_MODEL_SETTINGS,
-  fileSystem: DEFAULT_FILESYSTEM_SETTINGS,
-  search: DEFAULT_SEARCH_SETTINGS,
-  mcp: DEFAULT_MCP_SETTINGS,
-};
+import {
+  DEFAULT_SETTINGS,
+  DEFAULT_MODEL_SETTINGS,
+  DEFAULT_FILESYSTEM_SETTINGS,
+  DEFAULT_SEARCH_SETTINGS,
+  DEFAULT_MCP_SETTINGS,
+} from '@shared/constants';
 
 export const appSettingsAtom = atom<AppSettings>(DEFAULT_SETTINGS);
 

--- a/apps/agent-tars/src/shared/constants.ts
+++ b/apps/agent-tars/src/shared/constants.ts
@@ -1,0 +1,42 @@
+import {
+  AppSettings,
+  FileSystemSettings,
+  ModelSettings,
+  ModelProvider,
+  SearchSettings,
+  MCPSettings,
+  SearchProvider,
+} from '@agent-infra/shared';
+
+export const DEFAULT_MODEL_SETTINGS: ModelSettings = {
+  provider: ModelProvider.ANTHROPIC,
+  model: 'claude-3-7-sonnet-latest',
+  apiKey: '',
+  apiVersion: '',
+  endpoint: '',
+};
+
+export const DEFAULT_FILESYSTEM_SETTINGS: FileSystemSettings = {
+  availableDirectories: [],
+};
+
+export const DEFAULT_SEARCH_SETTINGS: SearchSettings = {
+  provider: SearchProvider.BrowserSearch,
+  providerConfig: {
+    count: 10,
+    engine: 'google',
+    needVisitedUrls: false,
+  },
+  apiKey: '',
+};
+
+export const DEFAULT_MCP_SETTINGS: MCPSettings = {
+  mcpServers: [],
+};
+
+export const DEFAULT_SETTINGS: AppSettings = {
+  model: DEFAULT_MODEL_SETTINGS,
+  fileSystem: DEFAULT_FILESYSTEM_SETTINGS,
+  search: DEFAULT_SEARCH_SETTINGS,
+  mcp: DEFAULT_MCP_SETTINGS,
+};

--- a/apps/agent-tars/tsconfig.node.json
+++ b/apps/agent-tars/tsconfig.node.json
@@ -1,10 +1,22 @@
 {
-  "extends": ["@electron-toolkit/tsconfig/tsconfig.node.json", "./tsconfig.base.json"],
-  "include": ["electron.vite.config.*", "src/main/**/*", "forge.config.ts", "src/preload/**/*", "app/electron.vite.config.ts"],
+  "extends": [
+    "@electron-toolkit/tsconfig/tsconfig.node.json",
+    "./tsconfig.base.json"
+  ],
+  "include": [
+    "electron.vite.config.*",
+    "src/main/**/*",
+    "forge.config.ts",
+    "src/preload/**/*",
+    "src/shared/**/*",
+    "app/electron.vite.config.ts"
+  ],
   "compilerOptions": {
     "composite": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
-    "types": ["electron-vite/node"]
+    "types": [
+      "electron-vite/node"
+    ]
   }
 }


### PR DESCRIPTION
## Summary

When completing the setting-related work, we found that there are many redundant constants, which triggered some hidden bugs, such as different search default values.

This PR merges it.