### PR TITLE
fix(agent-tars): execute write_file event always logger file error

### DIFF
--- a/apps/agent-tars/src/main/ipcRoutes/filesystem.ts
+++ b/apps/agent-tars/src/main/ipcRoutes/filesystem.ts
@@ -38,6 +38,10 @@ export const fileSystemRoute = t.router({
     .input<{ filePath: string }>()
     .handle(async ({ input }) => {
       try {
+        const exists = await fs.pathExists(input.filePath);
+        if (!exists) {
+          return null;
+        }
         const content = await fs.readFile(input.filePath, 'utf8');
         return content;
       } catch (error) {


### PR DESCRIPTION
## Summary

- Close: #370

When executing write_file, the file is always read directly. Since the corresponding file does not exist in most cases, the logger records an error. In the current scenario, it should not be considered an error. You can first determine whether it does not exist and directly return null to originalFileContent

执行write_file的时候，总是直接读取文件，由于大部分情况下不存在对应文件导致logger记录错误，在当前场景下不应该算错误，可以先判断不存在直接return null，给到originalFileContent

## Checklist  

<!--  Before submitting the pull request, ensure the following items are checked: -->

- [ ] Added or updated necessary tests (Optional).  
- [ ] Updated documentation to align with changes (Optional).  
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).  
- [ ] My change does not involve the above items. 
