### PR TITLE
fix: the click event of the modal close button becomes ineffective

### DIFF
--- a/apps/agent-tars/src/renderer/src/components/LeftSidebar/Settings/SettingsModal.module.scss
+++ b/apps/agent-tars/src/renderer/src/components/LeftSidebar/Settings/SettingsModal.module.scss
@@ -1,0 +1,5 @@
+.settingsModal {
+    button[aria-label="Close"] {
+        -webkit-app-region: no-drag,
+    }
+}

--- a/apps/agent-tars/src/renderer/src/components/LeftSidebar/Settings/SettingsModal.tsx
+++ b/apps/agent-tars/src/renderer/src/components/LeftSidebar/Settings/SettingsModal.tsx
@@ -24,6 +24,7 @@ import {
   FiHelpCircle,
   FiRefreshCw,
 } from 'react-icons/fi';
+import styles from './SettingsModal.module.scss';
 
 interface SettingsModalProps {
   isOpen: boolean;
@@ -80,7 +81,7 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
       size="full"
       scrollBehavior="outside"
       classNames={{
-        base: 'h-[100vh] max-h-[100vh]',
+        base: `${styles.settingsModal} h-[100vh] max-h-[100vh]`,
         body: 'p-0 h-[calc(100vh-10rem)] overflow-hidden',
         backdrop: 'bg-black/50 backdrop-blur-sm',
       }}


### PR DESCRIPTION
## Summary

The click event of the modal close button becomes ineffective. It is affected by the `-webkit-app-region: drag` property, and this situation occurs when the width exceeds a certain value.

![20250412135831_rec_](https://github.com/user-attachments/assets/5b635006-de38-4b63-b98f-1742b7d4611a)

