### PR TITLE
fix(agent-tars): set highlight div backgroundColor to transparent.

### DIFF
--- a/packages/agent-infra/browser-use/assets/buildDomTree.js
+++ b/packages/agent-infra/browser-use/assets/buildDomTree.js
@@ -37,6 +37,7 @@ window.buildDomTree = (
       container.style.width = '100%';
       container.style.height = '100%';
       container.style.zIndex = '2147483647'; // Maximum z-index value
+      container.style.backgroundColor = 'transparent';
       document.body.appendChild(container);
     }
 


### PR DESCRIPTION
## Summary

The highlighting styles are abnormal on some websites.

![image](https://github.com/user-attachments/assets/3c934126-6481-4d59-92d2-bd50d84107ab)

So I add `container.style.backgroundColor = 'transparent';` to playwright-highlight-container

## Checklist  

- [ ] Added or updated necessary tests (Optional).  
- [ ] Updated documentation to align with changes (Optional).  
- [x] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).  
- [x] My change does not involve the above items. 
