### PR TITLE
fixed page blinking caused by viewport changes when executing screenshot in Puppeteer

### DIFF
--- a/packages/agent-infra/browser/src/local-browser.ts
+++ b/packages/agent-infra/browser/src/local-browser.ts
@@ -39,6 +39,9 @@ export class LocalBrowser extends BaseBrowser {
       defaultViewport: {
         width: viewportWidth,
         height: viewportHeight,
+        // Setting this value to 0 will reset this value to the system default.
+        // This parameter combined with `captureBeyondViewport: false`, will resolve the screenshot blinking issue.
+        deviceScaleFactor: 0,
       },
       args: [
         '--no-sandbox',

--- a/packages/ui-tars/operators/browser-operator/src/browser-operator.ts
+++ b/packages/ui-tars/operators/browser-operator/src/browser-operator.ts
@@ -141,7 +141,11 @@ export class BrowserOperator extends Operator {
       // Take screenshot
       await this.uiHelper.cleanupTemporaryVisuals();
       const buffer = await page.screenshot({
+        // https://github.com/puppeteer/puppeteer/issues/7043
+        captureBeyondViewport: false,
         encoding: 'base64',
+        type: 'jpeg',
+        quality: 75,
         fullPage: false, // Capture only the visible area
       });
 


### PR DESCRIPTION
## Summary

When using Puppeteer's `Page.screenshot` for capturing screenshots, viewport changes can occur, resulting in a visual effect where the page briefly flickers:

https://github.com/user-attachments/assets/1257fe6d-098f-4536-a947-b4579830d873


After reviewing [GitHub Issue #7043](https://github.com/puppeteer/puppeteer/issues/7043), it was found that setting `captureBeyondViewport: false` did not resolve the issue.

Further investigation into [StackOverflow: puppeteer-page-screenshot-resizes-viewport](https://stackoverflow.com/questions/68059664/puppeteer-page-screenshot-resizes-viewport) revealed that setting `defaultViewport: null` effectively addresses the problem. However, we have specific requirements to set `width` and `height`, so this approach is not ideal for our use case.

Based on our analysis, the root cause seems to be related to `defaultViewport.deviceScaleFactor`. When left at its default value of `1`, it can lead to inconsistencies in `deviceScaleFactor`, indirectly causing the screenshot flickering issue.

Referring to the [Puppeteer viewport API documentation](https://pptr.dev/api/puppeteer.viewport), we discovered that setting `deviceScaleFactor` to `0` resets it to the system default. Testing this approach confirmed that it effectively resolves the problem.

### Final Solution:

Set `defaultViewport.deviceScaleFactor` to `0` and `captureBeyondViewport` to `false`. This combination eliminates the viewport flickering issue during screenshot operations.



## Checklist  

<!--  Before submitting the pull request, ensure the following items are checked: -->

- [ ] Added or updated necessary tests (Optional).  
- [x] Updated documentation to align with changes (Optional).  
- [x] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).  
- [x] My change does not involve the above items. 
