### PR TITLE
fix(agent-tars): share reporter not work

### DIFF
--- a/apps/agent-tars/src/renderer/src/components/ChatUI/index.tsx
+++ b/apps/agent-tars/src/renderer/src/components/ChatUI/index.tsx
@@ -90,7 +90,7 @@ export function OpenAgentChatUI() {
     init();
   }, [currentSessionId]);
 
-  if (!currentSessionId) {
+  if (!isReportHtmlMode && !currentSessionId) {
     return <WelcomeScreen />;
   }
 


### PR DESCRIPTION
There is only one Welcome page when clicking to share.

<img width="821" alt="image" src="https://github.com/user-attachments/assets/d0e13d26-21e2-4e32-92d8-76c78bd78b9d" />
