### PR TITLE
fix(browser-mcp): element index validation to properly handle zero index in browser tools

### DIFF
--- a/packages/agent-infra/mcp-servers/browser/src/server.ts
+++ b/packages/agent-infra/mcp-servers/browser/src/server.ts
@@ -594,7 +594,7 @@ const handleToolCall: Client['callTool'] = async ({
       }
     },
     browser_click: async (args) => {
-      if (!args.index) {
+      if ((args.index ?? -1) < 0) {
         return {
           content: [{ type: 'text', text: 'No index provided' }],
           isError: true,


### PR DESCRIPTION
<!--------------------------------------------------------------------------------
    Thank you for submitting a pull request!

    We appreciate the time and effort you have invested in making these changes. Please 
    ensure that you provide enough information to allow others to review your pull request 
    effectively, so please DO NOT delete this template.

    If you're new to contributing, learn more about contributing here:
    https://github.com/bytedance/UI-TARS-desktop/blob/main/CONTRIBUTING.md.  
---------------------------------------------------------------------------------->
Here's the updated PR message with additional justification:

## Issue
close #566

## Description
This PR fixes an issue where the browser-click method in the browser-use MCP server was failing to handle DOM elements with index 0. The previous implementation used a logical NOT check (`!args.index`), which treated index 0 as falsy, thus rejecting valid requests to interact with elements at index 0.

## Root Cause Analysis
The root issue was identified in the interaction between two components:

1. In `packages/agent-infra/browser-use/assets/buildDomTree.js` (line 22), the highlight indexing starts from 0:
```javascript
const { doHighlightElements, focusHighlightIndex, viewportExpansion } = args;
  let highlightIndex = 0; // Reset highlight index
```
and in line 680, this code increse from index 0. 
```javascript
if (isInteractive && isVisible && isTop) {
  nodeData.highlightIndex = highlightIndex++;
  if (doHighlightElements) {
    if (focusHighlightIndex >= 0) {
      if (focusHighlightIndex === nodeData.highlightIndex) {
        highlightElement(node, nodeData.highlightIndex, parentIframe);
      }
    } else {
      highlightElement(node, nodeData.highlightIndex, parentIframe);
    }
  }
}
```

2. However, in the browser-click handler, the condition `!args.index` would evaluate to `true` when index is 0, causing the method to incorrectly return an error for valid index 0 elements.

## Changes
- Updated the condition in browser-click method from `!args.index` to `(args.index ?? -1) < 0`
- This change ensures that only truly missing indices (undefined or null) will trigger the "No index provided" error
- Index 0 will now be properly processed as a valid element reference

## Testing
Verified that the browser-click method now correctly handles DOM elements with index 0, allowing agents to interact with single-element selections where the index is 0.

<!--------------------------------------------------------------------------------
    Can you explain the reasoning behind implementing this change?  
    What problem or issue does this pull request resolve?  

    It would be helpful to include relevant context, such as GitHub issues 
    (e.g., Close: #xxx) or related discussions.

    If updating the UI, please include a **before/after screenshot** for visibility.
    Thank you for reading. Next, start describing your Summary on the next line
    after the comment ends. 👇🏻
---------------------------------------------------------------------------------->



## Checklist  

<!--  Before submitting the pull request, ensure the following items are checked: -->

- [ ] Added or updated necessary tests (Optional).  
- [ ] Updated documentation to align with changes (Optional).  
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).  
- [x] My change does not involve the above items. 
