### PR TITLE
fix(ui-tars): support `nut-js` hotkeys like `Escape` by ignoring lettercase

### DIFF
--- a/packages/ui-tars/operators/nut-js/src/index.ts
+++ b/packages/ui-tars/operators/nut-js/src/index.ts
@@ -222,40 +222,38 @@ export class NutJSOperator extends Operator {
             process.platform === 'darwin' ? Key.LeftCmd : Key.LeftControl;
           const keyMap: Record<string, Key> = {
             return: Key.Enter,
-            enter: Key.Enter,
-            backspace: Key.Backspace,
-            delete: Key.Delete,
             ctrl: platformCtrlKey,
             shift: Key.LeftShift,
             alt: Key.LeftAlt,
-            space: Key.Space,
             'page down': Key.PageDown,
-            pagedown: Key.PageDown,
             'page up': Key.PageUp,
-            pageup: Key.PageUp,
             meta: platformCommandKey,
             win: platformCommandKey,
             command: platformCommandKey,
             cmd: platformCommandKey,
             comma: Key.Comma,
             ',': Key.Comma,
-            up: Key.Up,
-            down: Key.Down,
-            left: Key.Left,
-            right: Key.Right,
             arrowup: Key.Up,
             arrowdown: Key.Down,
             arrowleft: Key.Left,
             arrowright: Key.Right,
           };
 
+          const lowercaseKeyMap = Object.fromEntries(
+            Object.entries(Key).map(([k, v]) => [k.toLowerCase(), v]),
+          ) as {
+            [K in keyof typeof Key as Lowercase<K>]: (typeof Key)[K];
+          };
+
           const keys = keyStr
             .split(/[\s+]/)
+            .map((k) => k.toLowerCase())
             .map(
               (k) =>
-                keyMap[k.toLowerCase()] ||
-                Key[k.toUpperCase() as keyof typeof Key],
-            );
+                keyMap[k as keyof typeof keyMap] ??
+                lowercaseKeyMap[k as Lowercase<keyof typeof Key>],
+            )
+            .filter(Boolean);
           logger.info('[NutjsOperator] hotkey: ', keys);
           await keyboard.pressKey(...keys);
           await keyboard.releaseKey(...keys.reverse());

--- a/packages/ui-tars/operators/nut-js/src/index.ts
+++ b/packages/ui-tars/operators/nut-js/src/index.ts
@@ -231,7 +231,6 @@ export class NutJSOperator extends Operator {
             win: platformCommandKey,
             command: platformCommandKey,
             cmd: platformCommandKey,
-            comma: Key.Comma,
             ',': Key.Comma,
             arrowup: Key.Up,
             arrowdown: Key.Down,


### PR DESCRIPTION
<!--------------------------------------------------------------------------------
    Thank you for submitting a pull request!

    We appreciate the time and effort you have invested in making these changes. Please 
    ensure that you provide enough information to allow others to review your pull request 
    effectively, so please DO NOT delete this template.

    If you're new to contributing, learn more about contributing here:
    https://github.com/bytedance/UI-TARS-desktop/blob/main/CONTRIBUTING.md.  
---------------------------------------------------------------------------------->

## Summary
Related to: #530.

I noticed the `NutJSOperator` cannot hit the `Escape` key. This is because `Key[k.toUpperCase()]` will only match simple keys, and not other `nut-js` keys like `Escape` or `LeftBracket`, for example. Additionally, `Key.Escape = 0`, but `0` is falsey.

I've reworked the matching logic to match keys completely ignoring letter casing and to use the `??` operator.

<!--------------------------------------------------------------------------------
    Can you explain the reasoning behind implementing this change?  
    What problem or issue does this pull request resolve?  

    It would be helpful to include relevant context, such as GitHub issues 
    (e.g., Close: #xxx) or related discussions.

    If updating the UI, please include a **before/after screenshot** for visibility.
    Thank you for reading. Next, start describing your Summary on the next line
    after the comment ends. 👇🏻
---------------------------------------------------------------------------------->



## Checklist  

<!--  Before submitting the pull request, ensure the following items are checked: -->

- [ ] Added or updated necessary tests (Optional).  
- [ ] Updated documentation to align with changes (Optional).  
- [x] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).  
- [ ] My change does not involve the above items. 
