### PR TITLE
fix(browser): where the browser does not relaunch after being manually closed

### DIFF
--- a/packages/agent-infra/browser/src/base-browser.ts
+++ b/packages/agent-infra/browser/src/base-browser.ts
@@ -56,6 +56,27 @@ export abstract class BaseBrowser implements BrowserInterface {
   }
 
   /**
+   * Check if the browser instance is active and responding
+   * @returns {Promise<boolean>} True if browser is active, false otherwise
+   */
+  async isBrowserAlive(): Promise<boolean> {
+    if (!this.browser) {
+      return false;
+    }
+
+    try {
+      // Try to get browser version to check if it's still responding
+      const version = await this.browser.version();
+      this.logger.info('Browser version:', version);
+      return true;
+    } catch (error) {
+      this.logger.warn('Browser instance is no longer active:', error);
+      this.browser = null;
+      return false;
+    }
+  }
+
+  /**
    * Get the underlying Puppeteer browser instance
    * @throws Error if browser is not launched
 
@@ -177,6 +198,7 @@ export abstract class BaseBrowser implements BrowserInterface {
       this.logger.error('No active browser');
       throw new Error('Browser not launched');
     }
+
     const page = await this.browser.newPage();
     return page;
   }

--- a/packages/ui-tars/operators/browser-operator/src/browser-operator.ts
+++ b/packages/ui-tars/operators/browser-operator/src/browser-operator.ts
@@ -544,19 +544,27 @@ export class DefaultBrowserOperator extends BrowserOperator {
     isCallUser = false,
     searchEngine = 'google' as SearchEngine,
   ): Promise<DefaultBrowserOperator> {
+    if (!this.logger) {
+      this.logger = new ConsoleLogger('[DefaultBrowserOperator]');
+    }
+
+    if (this.browser) {
+      const isAlive = await this.browser.isBrowserAlive();
+      if (!isAlive) {
+        this.browser = null;
+        this.instance = null;
+      }
+    }
+
+    if (!this.browser) {
+      this.browser = new LocalBrowser({ logger: this.logger });
+      await this.browser.launch({
+        executablePath: this.browserPath,
+        browserType: this.browserType,
+      });
+    }
+
     if (!this.instance) {
-      if (!this.logger) {
-        this.logger = new ConsoleLogger('[DefaultBrowserOperator]');
-      }
-
-      if (!this.browser) {
-        this.browser = new LocalBrowser({ logger: this.logger });
-        await this.browser.launch({
-          executablePath: this.browserPath,
-          browserType: this.browserType,
-        });
-      }
-
       this.instance = new DefaultBrowserOperator({
         browser: this.browser,
         browserType: this.browserType,


### PR DESCRIPTION
## Summary

In UI-TARS-Desktop, when the  `Browser Operator` mode is selected, if the user manually closes the browser instance launched by the app, the interface will freeze and fail to execute tasks during the second use of the `Browser Operator`.

This fix ensures that before each execution of the `Browser Operator`, the app checks whether the Browser instance exists. If it does not, a new browser instance will be launched.


## Checklist  

- [ ] Added or updated necessary tests (Optional).  
- [ ] Updated documentation to align with changes (Optional).  
- [x] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).  
- [x] My change does not involve the above items. 
