### PR TITLE
fix(ui-tars): fix the issue where the widget disappears in release mode

### DIFF
--- a/apps/ui-tars/src/main/window/ScreenMarker.ts
+++ b/apps/ui-tars/src/main/window/ScreenMarker.ts
@@ -7,7 +7,7 @@
  * found in https://github.com/web-infra-dev/midscene/blob/main/LICENSE
  *
  */
-import { BrowserWindow, ipcMain, screen, app } from 'electron';
+import { BrowserWindow, screen, app } from 'electron';
 
 import { PredictionParsed, Conversation } from '@ui-tars/shared/types';
 
@@ -16,7 +16,6 @@ import { logger } from '@main/logger';
 
 import { AppUpdater } from '@main/utils/updateApp';
 import { setOfMarksOverlays } from '@main/shared/setOfMarks';
-import { server } from '@main/ipcRoutes';
 import path from 'path';
 import MenuBuilder from '../menu';
 import { windowManager } from '../services/windowManager';
@@ -193,11 +192,6 @@ class ScreenMarker {
     menuBuilder.buildMenu();
 
     windowManager.registerWindow(this.widgetWindow);
-
-    // 监听来自渲染进程的点击事件
-    ipcMain.once('pause-button-clicked', async () => {
-      await server.stopRun();
-    });
   }
 
   // show Screen Marker in screen for prediction

--- a/apps/ui-tars/src/renderer/src/pages/widget/index.tsx
+++ b/apps/ui-tars/src/renderer/src/pages/widget/index.tsx
@@ -68,6 +68,10 @@ const Widget = () => {
 
     console.log('lastMessage', lastMessage);
 
+    if (!lastMessage) {
+      return;
+    }
+
     if (lastMessage.from === 'human') {
       if (!lastMessage.screenshotBase64) {
         setActions([
@@ -103,8 +107,9 @@ const Widget = () => {
           thought: item.thought,
         };
       }) || [];
+
     setActions(ac);
-  }, [messages]);
+  }, [messages.length]);
 
   const [isPaused, setIsPaused] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
@@ -191,7 +196,7 @@ const Widget = () => {
                 {!!action.thought && (
                   <>
                     <div className="text-lg font-medium mt-2">Thought</div>
-                    <div className="text-gray-500 text-sm break-all">
+                    <div className="text-gray-500 text-sm break-all mb-4">
                       {action.thought}
                     </div>
                   </>


### PR DESCRIPTION
## Summary

If `lastMessage` is undefined, it causes the widget UI to crash. Additionally, since the `BrowserWindow` transparency attribute is enabled, the crash manifests as the window disappearing (instead of the typical white screen).

## Checklist  

<!--  Before submitting the pull request, ensure the following items are checked: -->

- [ ] Added or updated necessary tests (Optional).  
- [ ] Updated documentation to align with changes (Optional).  
- [x] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).  
- [x] My change does not involve the above items. 
