### PR TITLE
Add uiTarsVerison in Basic Usage to click(w,h) correctly.

### DIFF
--- a/packages/ui-tars/sdk/README.md
+++ b/packages/ui-tars/sdk/README.md
@@ -114,6 +114,7 @@ Basic usage is largely derived from package `@ui-tars/sdk`, here's a basic examp
 ```ts
 import { GUIAgent } from '@ui-tars/sdk';
 import { NutJSOperator } from '@ui-tars/operator-nut-js';
+import { UITarsModelVersion } from '@ui-tars/shared/constants';
 
 const guiAgent = new GUIAgent({
   model: {
@@ -128,6 +129,7 @@ const guiAgent = new GUIAgent({
   onError: ({ data, error }) => {
     console.error(error, data);
   },
+  uiTarsVersion: UITarsModelVersion.V1_5,
 });
 
 await guiAgent.run('send "hello world" to x.com');


### PR DESCRIPTION
<!--------------------------------------------------------------------------------
    Thank you for submitting a pull request!

    We appreciate the time and effort you have invested in making these changes. Please 
    ensure that you provide enough information to allow others to review your pull request 
    effectively, so please DO NOT delete this template.

    If you're new to contributing, learn more about contributing here:
    https://github.com/bytedance/UI-TARS-desktop/blob/main/CONTRIBUTING.md.  
---------------------------------------------------------------------------------->

## Summary

<!--------------------------------------------------------------------------------
    Can you explain the reasoning behind implementing this change?  
    What problem or issue does this pull request resolve?  

    It would be helpful to include relevant context, such as GitHub issues 
    (e.g., Close: #xxx) or related discussions.

    If updating the UI, please include a **before/after screenshot** for visibility.
    Thank you for reading. Next, start describing your Summary on the next line
    after the comment ends. 👇🏻
---------------------------------------------------------------------------------->
Currently, the default version of UI-TARS model is 1.0 ! 
Therefore, invoking UI-TARS-1.5 without uiTarsVersion in GUIAgent causes issues
#590 
#591 

I will offer test case soon.

## Checklist  

<!--  Before submitting the pull request, ensure the following items are checked: -->

- [ ] Added or updated necessary tests (Optional).  
- [x] Updated documentation to align with changes (Optional).  
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).  
- [ ] My change does not involve the above items. 
