### PR TITLE
fix(electron-updater): agent-tars update bug

### DIFF
--- a/apps/agent-tars/dev-app-update.yml
+++ b/apps/agent-tars/dev-app-update.yml
@@ -1,4 +1,4 @@
-provider: github
-owner: agent-infra
-repo: agent-tars-website
+provider: custom
+owner: bytedance
+repo: UI-TARS-desktop
 updaterCacheDirName: agent-tars-updater

--- a/apps/agent-tars/dev-app-update.yml
+++ b/apps/agent-tars/dev-app-update.yml
@@ -1,4 +1,4 @@
 provider: github
-owner: bytedance
-repo: UI-TARS-desktop
+owner: agent-infra
+repo: agent-tars-website
 updaterCacheDirName: agent-tars-updater

--- a/apps/agent-tars/forge.config.ts
+++ b/apps/agent-tars/forge.config.ts
@@ -188,7 +188,7 @@ const config: ForgeConfig = {
     {
       name: '@electron-forge/publisher-github',
       config: {
-        repository: { owner: 'bytedance', name: 'ui-tars-desktop' },
+        repository: { owner: 'agent-infra', name: 'agent-tars-website' },
         draft: true,
         force: true,
         generateReleaseNotes: true,

--- a/apps/agent-tars/forge.config.ts
+++ b/apps/agent-tars/forge.config.ts
@@ -188,7 +188,7 @@ const config: ForgeConfig = {
     {
       name: '@electron-forge/publisher-github',
       config: {
-        repository: { owner: 'agent-infra', name: 'agent-tars-website' },
+        repository: { owner: 'bytedance', name: 'UI-TARS-desktop' },
         draft: true,
         force: true,
         generateReleaseNotes: true,

--- a/apps/agent-tars/package.json
+++ b/apps/agent-tars/package.json
@@ -49,6 +49,8 @@
     "@agent-infra/mcp-server-browser": "workspace:*"
   },
   "devDependencies": {
+    "semver": "7.7.2",
+    "builder-util-runtime": "9.3.1",
     "jsonrepair": "3.12.0",
     "serialize-javascript": "6.0.2",
     "@modelcontextprotocol/sdk": "^1.11.2",

--- a/apps/agent-tars/package.json
+++ b/apps/agent-tars/package.json
@@ -55,7 +55,7 @@
     "@electron-toolkit/preload": "^3.0.1",
     "@electron-toolkit/utils": "^4.0.0",
     "@electron/asar": "^3.2.18",
-    "electron-updater": "^6.3.9",
+    "electron-updater": "^6.6.2",
     "openai": "^4.86.2",
     "dotenv": "16.4.7",
     "@agent-infra/mcp-shared": "workspace:*",

--- a/apps/agent-tars/package.json
+++ b/apps/agent-tars/package.json
@@ -105,13 +105,6 @@
     "vite-plugin-singlefile": "2.2.0"
   },
   "build": {
-    "publish": [
-      {
-        "provider": "github",
-        "owner": "bytedance",
-        "repo": "UI-TARS-desktop"
-      }
-    ],
     "electronDownload": {
       "mirror": "https://npmmirror.com/mirrors/electron/"
     }

--- a/apps/agent-tars/resources/app-update.yml
+++ b/apps/agent-tars/resources/app-update.yml
@@ -1,3 +1,3 @@
-provider: github
-owner: agent-infra
-repo: agent-tars-website
+provider: custom
+owner: bytedance
+repo: UI-TARS-desktop

--- a/apps/agent-tars/resources/app-update.yml
+++ b/apps/agent-tars/resources/app-update.yml
@@ -1,3 +1,3 @@
 provider: github
-owner: bytedance
-repo: UI-TARS-desktop
+owner: agent-infra
+repo: agent-tars-website

--- a/apps/agent-tars/src/main/electron-updater/GitHubProvider.ts
+++ b/apps/agent-tars/src/main/electron-updater/GitHubProvider.ts
@@ -1,0 +1,192 @@
+import {
+  CancellationToken,
+  GithubOptions,
+  HttpError,
+  newError,
+  ReleaseNoteInfo,
+  UpdateInfo,
+  XElement,
+} from 'builder-util-runtime';
+import * as semver from 'semver';
+import { URL } from 'url';
+import { AppUpdater, ResolvedUpdateFileInfo } from 'electron-updater';
+import {
+  getChannelFilename,
+  newUrlFromBase,
+  extractTagFromGithubDownloadURL,
+} from './util';
+import {
+  parseUpdateInfo,
+  resolveFiles,
+  ProviderRuntimeOptions,
+} from 'electron-updater/out/providers/Provider';
+import { BaseGitHubProvider } from 'electron-updater/out/providers/GitHubProvider';
+
+interface GithubUpdateInfo extends UpdateInfo {
+  tag: string;
+}
+
+export class CustomGitHubProvider extends BaseGitHubProvider<GithubUpdateInfo> {
+  constructor(
+    protected readonly options: GithubOptions,
+    private readonly updater: AppUpdater,
+    runtimeOptions: ProviderRuntimeOptions,
+  ) {
+    super(options, 'github.com', runtimeOptions);
+  }
+
+  private get channel(): string {
+    const result = this.updater.channel || this.options.channel;
+    return result == null
+      ? this.getDefaultChannelName()
+      : this.getCustomChannelName(result);
+  }
+
+  async getLatestVersion(): Promise<GithubUpdateInfo> {
+    const cancellationToken = new CancellationToken();
+
+    let tag: string | null = null;
+    try {
+      const requestOptions = this.createRequestOptions(
+        new URL('https://formulae.brew.sh/api/cask/agent-tars.json'),
+      );
+      const result = JSON.parse(
+        (await this.executor.request(requestOptions, cancellationToken)) || '',
+      );
+
+      // @ts-ignore
+      if (result?.url) {
+        // @ts-ignore
+        tag = extractTagFromGithubDownloadURL(result.url);
+      }
+      console.log('tag', tag);
+    } catch (e: any) {
+      throw newError(
+        `Cannot parse releases feed: ${e.stack || e.message}`,
+        'ERR_UPDATER_INVALID_RELEASE_FEED',
+      );
+    }
+
+    if (tag == null) {
+      throw newError(
+        `No published versions on GitHub`,
+        'ERR_UPDATER_NO_PUBLISHED_VERSIONS',
+      );
+    }
+
+    let rawData: string;
+    let channelFile = '';
+    let channelFileUrl: any = '';
+    const fetchData = async (channelName: string) => {
+      channelFile = getChannelFilename(channelName);
+      channelFileUrl = newUrlFromBase(
+        this.getBaseDownloadPath(String(tag), channelFile),
+        this.baseUrl,
+      );
+      const requestOptions = this.createRequestOptions(channelFileUrl);
+      try {
+        return (await this.executor.request(
+          requestOptions,
+          cancellationToken,
+        ))!;
+      } catch (e: any) {
+        if (e instanceof HttpError && e.statusCode === 404) {
+          throw newError(
+            `Cannot find ${channelFile} in the latest release artifacts (${channelFileUrl}): ${e.stack || e.message}`,
+            'ERR_UPDATER_CHANNEL_FILE_NOT_FOUND',
+          );
+        }
+        throw e;
+      }
+    };
+
+    try {
+      let channel = this.channel;
+      if (this.updater.allowPrerelease && semver.prerelease(tag)?.[0]) {
+        channel = this.getCustomChannelName(
+          String(semver.prerelease(tag)?.[0]),
+        );
+      }
+      rawData = await fetchData(channel);
+    } catch (e: any) {
+      if (this.updater.allowPrerelease) {
+        // Allow fallback to `latest.yml`
+        rawData = await fetchData(this.getDefaultChannelName());
+      } else {
+        throw e;
+      }
+    }
+
+    const result = parseUpdateInfo(rawData, channelFile, channelFileUrl);
+
+    if (result.releaseNotes == null || result.releaseName == null) {
+      const requestOptions = this.createRequestOptions(
+        new URL(
+          `https://api.github.com/repos/bytedance/UI-TARS-Desktop/releases/tags/${tag}`,
+        ),
+      );
+      const releaseInfo = JSON.parse(
+        (await this.executor.request(requestOptions, cancellationToken)) || '',
+      );
+
+      result.releaseName = result.releaseName || releaseInfo.name;
+      result.releaseNotes = result.releaseNotes || releaseInfo.body;
+    }
+    console.log('resultresult', result);
+    return {
+      tag: tag,
+      ...result,
+    };
+  }
+
+  private get basePath(): string {
+    return `/${this.options.owner}/${this.options.repo}/releases`;
+  }
+
+  resolveFiles(updateInfo: GithubUpdateInfo): Array<ResolvedUpdateFileInfo> {
+    // still replace space to - due to backward compatibility
+    return resolveFiles(updateInfo, this.baseUrl, (p) =>
+      this.getBaseDownloadPath(updateInfo.tag, p.replace(/ /g, '-')),
+    );
+  }
+
+  private getBaseDownloadPath(tag: string, fileName: string): string {
+    return `${this.basePath}/download/${tag}/${fileName}`;
+  }
+}
+
+interface GithubReleaseInfo {
+  readonly tag_name: string;
+}
+
+function getNoteValue(parent: XElement): string {
+  const result = parent.elementValueOrEmpty('content');
+  // GitHub reports empty notes as <content>No content.</content>
+  return result === 'No content.' ? '' : result;
+}
+
+export function computeReleaseNotes(
+  currentVersion: semver.SemVer,
+  isFullChangelog: boolean,
+  feed: XElement,
+  latestRelease: any,
+): string | Array<ReleaseNoteInfo> | null {
+  if (!isFullChangelog) {
+    return getNoteValue(latestRelease);
+  }
+
+  const releaseNotes: Array<ReleaseNoteInfo> = [];
+  for (const release of feed.getElements('entry')) {
+    // noinspection TypeScriptValidateJSTypes
+    const versionRelease = /\/tag\/v?([^/]+)$/.exec(
+      release.element('link').attribute('href'),
+    )![1];
+    if (semver.lt(currentVersion, versionRelease)) {
+      releaseNotes.push({
+        version: versionRelease,
+        note: getNoteValue(release),
+      });
+    }
+  }
+  return releaseNotes.sort((a, b) => semver.rcompare(a.version, b.version));
+}

--- a/apps/agent-tars/src/main/electron-updater/util.ts
+++ b/apps/agent-tars/src/main/electron-updater/util.ts
@@ -1,0 +1,29 @@
+// if baseUrl path doesn't ends with /, this path will be not prepended to passed pathname for new URL(input, base)
+import { URL } from 'url';
+
+// addRandomQueryToAvoidCaching is false by default because in most cases URL already contains version number,
+// so, it makes sense only for Generic Provider for channel files
+export function newUrlFromBase(
+  pathname: string,
+  baseUrl: URL,
+  addRandomQueryToAvoidCaching = false,
+): URL {
+  const result = new URL(pathname, baseUrl);
+  // search is not propagated (search is an empty string if not specified)
+  const search = baseUrl.search;
+  if (search != null && search.length !== 0) {
+    result.search = search;
+  } else if (addRandomQueryToAvoidCaching) {
+    result.search = `noCache=${Date.now().toString(32)}`;
+  }
+  return result;
+}
+
+export function getChannelFilename(channel: string): string {
+  return `${channel}.yml`;
+}
+
+export function extractTagFromGithubDownloadURL(url: string) {
+  const match = url.match(/\/download\/([^/]+)\//);
+  return match ? match[1] : null;
+}

--- a/apps/agent-tars/src/main/utils/updateApp.ts
+++ b/apps/agent-tars/src/main/utils/updateApp.ts
@@ -5,6 +5,7 @@ import {
   AppUpdater as ElectronAppUpdater,
   autoUpdater,
 } from 'electron-updater';
+import { CustomGitHubProvider } from '@main/electron-updater/GitHubProvider';
 
 export class AppUpdater {
   autoUpdater: ElectronAppUpdater = autoUpdater;
@@ -18,6 +19,15 @@ export class AppUpdater {
   constructor(mainWindow: BrowserWindow) {
     autoUpdater.logger = logger;
     autoUpdater.autoDownload = false;
+
+    autoUpdater.setFeedURL({
+      // hack for custom provider
+      provider: 'custom' as 'github',
+      owner: 'bytedance',
+      repo: 'UI-TARS-desktop',
+      // @ts-expect-error hack for custom provider
+      updateProvider: CustomGitHubProvider,
+    });
 
     autoUpdater.on('error', (error) => {
       logger.error('Update_Error', error);

--- a/apps/ui-tars/dev-app-update.yml
+++ b/apps/ui-tars/dev-app-update.yml
@@ -1,3 +1,0 @@
-provider: generic
-url: https://example.com/auto-updates
-updaterCacheDirName: ui-tars-updater

--- a/apps/ui-tars/package.json
+++ b/apps/ui-tars/package.json
@@ -36,13 +36,6 @@
     "publish": "npm run build && electron-forge publish"
   },
   "build": {
-    "publish": [
-      {
-        "provider": "github",
-        "owner": "bytedance",
-        "repo": "UI-TARS-desktop"
-      }
-    ],
     "electronDownload": {
       "mirror": "https://npmmirror.com/mirrors/electron/"
     }
@@ -123,7 +116,7 @@
     "ts-node": "^10.9.2",
     "tsx": "^4.19.2",
     "typescript": "^5.7.2",
-    "update-electron-app": "^3.1.0",
+    "electron-updater": "^6.6.2",
     "vite": "^6.1.0",
     "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^3.0.8",

--- a/apps/ui-tars/resources/app-update.yml
+++ b/apps/ui-tars/resources/app-update.yml
@@ -1,3 +1,3 @@
-provider: github
-owner: bytedance
-repo: UI-TARS-desktop
+provider: custom
+owner: ycjcl868
+repo: test-electron-update

--- a/apps/ui-tars/src/main/electron-updater/GitHubProvider.ts
+++ b/apps/ui-tars/src/main/electron-updater/GitHubProvider.ts
@@ -1,0 +1,293 @@
+/**
+ * The following code is modified based on
+ * https://github.com/electron-userland/electron-builder/blob/master/packages/electron-updater/src/providers/GitHubProvider.ts
+ *
+ * The MIT License (MIT)
+ * Copyright (c) 2015 Loopline Systems
+ * https://github.com/electron-userland/electron-builder/blob/master/LICENSE
+ */
+
+import {
+  CancellationToken,
+  GithubOptions,
+  HttpError,
+  newError,
+  parseXml,
+  ReleaseNoteInfo,
+  UpdateInfo,
+  XElement,
+} from 'builder-util-runtime';
+import * as semver from 'semver';
+import { URL } from 'url';
+import { BaseGitHubProvider } from 'electron-updater/out/providers/GitHubProvider';
+import { AppUpdater, ResolvedUpdateFileInfo } from 'electron-updater';
+import { getChannelFilename, newUrlFromBase } from './utils';
+import type { ProviderRuntimeOptions } from 'electron-updater/out/providers/Provider';
+import {
+  parseUpdateInfo,
+  resolveFiles,
+} from 'electron-updater/out/providers/Provider';
+
+const hrefRegExp = /\/tag\/([^/]+)$/;
+
+interface GithubUpdateInfo extends UpdateInfo {
+  tag: string;
+}
+
+export class GitHubProvider extends BaseGitHubProvider<GithubUpdateInfo> {
+  constructor(
+    protected readonly options: GithubOptions,
+    private readonly updater: AppUpdater,
+    runtimeOptions: ProviderRuntimeOptions,
+  ) {
+    super(options, 'github.com', runtimeOptions);
+  }
+
+  private get channel(): string {
+    const result = this.updater.channel || this.options.channel;
+    return result == null
+      ? this.getDefaultChannelName()
+      : this.getCustomChannelName(result);
+  }
+
+  async getLatestVersion(): Promise<GithubUpdateInfo> {
+    const cancellationToken = new CancellationToken();
+
+    const feedXml: string = (await this.httpRequest(
+      newUrlFromBase(`${this.basePath}.atom`, this.baseUrl),
+      {
+        accept: 'application/xml, application/atom+xml, text/xml, */*',
+      },
+      cancellationToken,
+    ))!;
+
+    const feed = parseXml(feedXml);
+    // noinspection TypeScriptValidateJSTypes
+    let latestRelease = feed.element(
+      'entry',
+      false,
+      `No published versions on GitHub`,
+    );
+    let tag: string | null = null;
+    try {
+      if (this.updater.allowPrerelease) {
+        const currentChannel =
+          this.updater?.channel ||
+          (semver.prerelease(this.updater.currentVersion)?.[0] as string) ||
+          null;
+
+        if (currentChannel === null) {
+          // noinspection TypeScriptValidateJSTypes
+          tag = hrefRegExp.exec(
+            latestRelease.element('link').attribute('href'),
+          )![1];
+        } else {
+          for (const element of feed.getElements('entry')) {
+            // noinspection TypeScriptValidateJSTypes
+            const hrefElement = hrefRegExp.exec(
+              element.element('link').attribute('href'),
+            )!;
+
+            // If this is null then something is wrong and skip this release
+            if (hrefElement === null) continue;
+
+            // This Release's Tag
+            const hrefTag = hrefElement[1];
+            //Get Channel from this release's tag
+            const hrefChannel =
+              (semver.prerelease(hrefTag)?.[0] as string) || null;
+
+            const shouldFetchVersion =
+              !currentChannel || ['alpha', 'beta'].includes(currentChannel);
+            const isCustomChannel =
+              hrefChannel !== null &&
+              !['alpha', 'beta'].includes(String(hrefChannel));
+            // Allow moving from alpha to beta but not down
+            const channelMismatch =
+              currentChannel === 'beta' && hrefChannel === 'alpha';
+
+            if (shouldFetchVersion && !isCustomChannel && !channelMismatch) {
+              tag = hrefTag;
+              break;
+            }
+
+            const isNextPreRelease =
+              hrefChannel && hrefChannel === currentChannel;
+            if (isNextPreRelease) {
+              tag = hrefTag;
+              break;
+            }
+          }
+        }
+      } else {
+        tag = await this.getLatestTagName(cancellationToken);
+        for (const element of feed.getElements('entry')) {
+          // noinspection TypeScriptValidateJSTypes
+          if (
+            hrefRegExp.exec(element.element('link').attribute('href'))![1] ===
+            tag
+          ) {
+            latestRelease = element;
+            break;
+          }
+        }
+      }
+    } catch (e: any) {
+      throw newError(
+        `Cannot parse releases feed: ${e.stack || e.message},\nXML:\n${feedXml}`,
+        'ERR_UPDATER_INVALID_RELEASE_FEED',
+      );
+    }
+
+    if (tag == null) {
+      throw newError(
+        `No published versions on GitHub`,
+        'ERR_UPDATER_NO_PUBLISHED_VERSIONS',
+      );
+    }
+
+    let rawData: string;
+    let channelFile = '';
+    let channelFileUrl: any = '';
+    const fetchData = async (channelName: string) => {
+      channelFile = getChannelFilename(channelName);
+      channelFileUrl = newUrlFromBase(
+        this.getBaseDownloadPath(String(tag), channelFile),
+        this.baseUrl,
+      );
+      const requestOptions = this.createRequestOptions(channelFileUrl);
+      try {
+        return (await this.executor.request(
+          requestOptions,
+          cancellationToken,
+        ))!;
+      } catch (e: any) {
+        if (e instanceof HttpError && e.statusCode === 404) {
+          throw newError(
+            `Cannot find ${channelFile} in the latest release artifacts (${channelFileUrl}): ${e.stack || e.message}`,
+            'ERR_UPDATER_CHANNEL_FILE_NOT_FOUND',
+          );
+        }
+        throw e;
+      }
+    };
+
+    try {
+      let channel = this.channel;
+      if (this.updater.allowPrerelease && semver.prerelease(tag)?.[0]) {
+        channel = this.getCustomChannelName(
+          String(semver.prerelease(tag)?.[0]),
+        );
+      }
+      rawData = await fetchData(channel);
+    } catch (e: any) {
+      if (this.updater.allowPrerelease) {
+        // Allow fallback to `latest.yml`
+        rawData = await fetchData(this.getDefaultChannelName());
+      } else {
+        throw e;
+      }
+    }
+
+    const result = parseUpdateInfo(rawData, channelFile, channelFileUrl);
+    if (result.releaseName == null) {
+      result.releaseName = latestRelease.elementValueOrEmpty('title');
+    }
+
+    if (result.releaseNotes == null) {
+      result.releaseNotes = computeReleaseNotes(
+        this.updater.currentVersion,
+        this.updater.fullChangelog,
+        feed,
+        latestRelease,
+      );
+    }
+    return {
+      tag: tag,
+      ...result,
+    };
+  }
+
+  private async getLatestTagName(
+    cancellationToken: CancellationToken,
+  ): Promise<string | null> {
+    const options = this.options;
+    // do not use API for GitHub to avoid limit, only for custom host or GitHub Enterprise
+    const url =
+      options.host == null || options.host === 'github.com'
+        ? newUrlFromBase(`${this.basePath}/latest`, this.baseUrl)
+        : new URL(
+            `${this.computeGithubBasePath(`/repos/${options.owner}/${options.repo}/releases`)}/latest`,
+            this.baseApiUrl,
+          );
+    try {
+      const rawData = await this.httpRequest(
+        url,
+        { Accept: 'application/json' },
+        cancellationToken,
+      );
+      if (rawData == null) {
+        return null;
+      }
+
+      const releaseInfo: GithubReleaseInfo = JSON.parse(rawData);
+      return releaseInfo.tag_name;
+    } catch (e: any) {
+      throw newError(
+        `Unable to find latest version on GitHub (${url}), please ensure a production release exists: ${e.stack || e.message}`,
+        'ERR_UPDATER_LATEST_VERSION_NOT_FOUND',
+      );
+    }
+  }
+
+  private get basePath(): string {
+    return `/${this.options.owner}/${this.options.repo}/releases`;
+  }
+
+  resolveFiles(updateInfo: GithubUpdateInfo): Array<ResolvedUpdateFileInfo> {
+    // still replace space to - due to backward compatibility
+    return resolveFiles(updateInfo, this.baseUrl, (p) =>
+      this.getBaseDownloadPath(updateInfo.tag, p.replace(/ /g, '-')),
+    );
+  }
+
+  private getBaseDownloadPath(tag: string, fileName: string): string {
+    return `${this.basePath}/download/${tag}/${fileName}`;
+  }
+}
+
+interface GithubReleaseInfo {
+  readonly tag_name: string;
+}
+
+function getNoteValue(parent: XElement): string {
+  const result = parent.elementValueOrEmpty('content');
+  // GitHub reports empty notes as <content>No content.</content>
+  return result === 'No content.' ? '' : result;
+}
+
+export function computeReleaseNotes(
+  currentVersion: semver.SemVer,
+  isFullChangelog: boolean,
+  feed: XElement,
+  latestRelease: any,
+): string | Array<ReleaseNoteInfo> | null {
+  if (!isFullChangelog) {
+    return getNoteValue(latestRelease);
+  }
+
+  const releaseNotes: Array<ReleaseNoteInfo> = [];
+  for (const release of feed.getElements('entry')) {
+    // noinspection TypeScriptValidateJSTypes
+    const versionRelease = /\/tag\/v?([^/]+)$/.exec(
+      release.element('link').attribute('href'),
+    )![1];
+    if (semver.lt(currentVersion, versionRelease)) {
+      releaseNotes.push({
+        version: versionRelease,
+        note: getNoteValue(release),
+      });
+    }
+  }
+  return releaseNotes.sort((a, b) => semver.rcompare(a.version, b.version));
+}

--- a/apps/ui-tars/src/main/electron-updater/index.ts
+++ b/apps/ui-tars/src/main/electron-updater/index.ts
@@ -1,0 +1,5 @@
+/**
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+export * from './GitHubProvider';

--- a/apps/ui-tars/src/main/electron-updater/utils.ts
+++ b/apps/ui-tars/src/main/electron-updater/utils.ts
@@ -1,0 +1,33 @@
+/**
+ * The following code is modified based on
+ * https://github.com/electron-userland/electron-builder/blob/master/packages/electron-updater/src/util.ts
+ *
+ * The MIT License (MIT)
+ * Copyright (c) 2015 Loopline Systems
+ * https://github.com/electron-userland/electron-builder/blob/master/LICENSE
+ */
+
+// if baseUrl path doesn't ends with /, this path will be not prepended to passed pathname for new URL(input, base)
+import { URL } from 'url';
+
+// addRandomQueryToAvoidCaching is false by default because in most cases URL already contains version number,
+// so, it makes sense only for Generic Provider for channel files
+export function newUrlFromBase(
+  pathname: string,
+  baseUrl: URL,
+  addRandomQueryToAvoidCaching = false,
+): URL {
+  const result = new URL(pathname, baseUrl);
+  // search is not propagated (search is an empty string if not specified)
+  const search = baseUrl.search;
+  if (search != null && search.length !== 0) {
+    result.search = search;
+  } else if (addRandomQueryToAvoidCaching) {
+    result.search = `noCache=${Date.now().toString(32)}`;
+  }
+  return result;
+}
+
+export function getChannelFilename(channel: string): string {
+  return `${channel}.yml`;
+}

--- a/apps/ui-tars/src/main/main.ts
+++ b/apps/ui-tars/src/main/main.ts
@@ -46,6 +46,12 @@ if (squirrelStartup) {
   app.quit();
 }
 
+Object.defineProperty(app, 'isPackaged', {
+  get() {
+    return true;
+  },
+});
+
 logger.debug('[env]', env);
 
 ElectronStore.initRenderer();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -207,6 +207,9 @@ importers:
       bufferutil:
         specifier: 4.0.9
         version: 4.0.9
+      builder-util-runtime:
+        specifier: 9.3.1
+        version: 9.3.1
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -249,6 +252,9 @@ importers:
       sass:
         specifier: 1.85.1
         version: 1.85.1
+      semver:
+        specifier: 7.7.2
+        version: 7.7.2
       serialize-javascript:
         specifier: 6.0.2
         version: 6.0.2
@@ -1437,31 +1443,6 @@ importers:
       '@electron-forge/shared-types':
         specifier: ^7.8.0
         version: 7.8.0
-      '@rslib/core':
-        specifier: ^0.5.4
-        version: 0.5.4(typescript@5.7.3)
-      tsx:
-        specifier: ^4.19.2
-        version: 4.19.3
-      typescript:
-        specifier: ^5.7.2
-        version: 5.7.3
-      vitest:
-        specifier: ^3.0.2
-        version: 3.0.8(@types/debug@4.1.12)(@types/node@22.13.10)(happy-dom@17.1.1)(jiti@2.4.2)(jsdom@26.0.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(lightningcss@1.29.2)(msw@2.7.0(@types/node@22.13.10)(typescript@5.7.3))(sass-embedded@1.83.4)(sass@1.85.1)(tsx@4.19.3)(yaml@2.7.0)
-
-  packages/common/electron-updater:
-    dependencies:
-      builder-util-runtime:
-        specifier: 9.3.1
-        version: 9.3.1
-      electron-updater:
-        specifier: ^6.6.2
-        version: 6.6.2
-      semver:
-        specifier: 7.7.2
-        version: 7.7.2
-    devDependencies:
       '@rslib/core':
         specifier: ^0.5.4
         version: 0.5.4(typescript@5.7.3)
@@ -11445,11 +11426,6 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
-  semver@7.7.1:
-    resolution: {integrity: sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   semver@7.7.2:
     resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
     engines: {node: '>=10'}
@@ -14221,7 +14197,7 @@ snapshots:
       debug: 4.4.0
       fs-extra: 10.1.0
       listr2: 7.0.2
-      semver: 7.7.1
+      semver: 7.7.2
     transitivePeerDependencies:
       - bluebird
       - encoding
@@ -19747,7 +19723,7 @@ snapshots:
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare-lite: 1.4.0
-      semver: 7.7.1
+      semver: 7.7.2
       tsutils: 3.21.0(typescript@5.7.3)
     optionalDependencies:
       typescript: 5.7.3
@@ -21334,7 +21310,7 @@ snapshots:
   electron-devtools-installer@3.2.1:
     dependencies:
       rimraf: 3.0.2
-      semver: 7.7.1
+      semver: 7.7.2
       tslib: 2.8.1
       unzip-crx-3: 0.2.0
 
@@ -21441,7 +21417,7 @@ snapshots:
       lazy-val: 1.0.5
       lodash.escaperegexp: 4.1.2
       lodash.isequal: 4.5.0
-      semver: 7.7.1
+      semver: 7.7.2
       tiny-typed-emitter: 2.1.0
     transitivePeerDependencies:
       - supports-color
@@ -21454,7 +21430,7 @@ snapshots:
       lazy-val: 1.0.5
       lodash.escaperegexp: 4.1.2
       lodash.isequal: 4.5.0
-      semver: 7.7.1
+      semver: 7.7.2
       tiny-typed-emitter: 2.1.0
     transitivePeerDependencies:
       - supports-color
@@ -25822,8 +25798,6 @@ snapshots:
 
   semver@6.3.1: {}
 
-  semver@7.7.1: {}
-
   semver@7.7.2: {}
 
   send@0.19.0:
@@ -25949,7 +25923,7 @@ snapshots:
     dependencies:
       color: 4.2.3
       detect-libc: 2.0.3
-      semver: 7.7.1
+      semver: 7.7.2
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.33.3
       '@img/sharp-darwin-x64': 0.33.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -226,8 +226,8 @@ importers:
         specifier: ^10.0.0
         version: 10.0.1
       electron-updater:
-        specifier: ^6.3.9
-        version: 6.3.9
+        specifier: ^6.6.2
+        version: 6.6.2
       electron-vite:
         specifier: ^3.0.0
         version: 3.0.0(vite@6.2.2(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2)(sass-embedded@1.83.4)(sass@1.85.1)(tsx@4.19.3)(yaml@2.7.0))
@@ -563,6 +563,9 @@ importers:
       electron-store:
         specifier: ^10.0.0
         version: 10.0.1
+      electron-updater:
+        specifier: ^6.6.2
+        version: 6.6.2
       electron-vite:
         specifier: ^3.0.0
         version: 3.0.0(vite@6.2.2(@types/node@20.17.17)(jiti@2.4.2)(lightningcss@1.29.2)(sass-embedded@1.83.4)(sass@1.85.1)(tsx@4.19.2)(yaml@2.7.0))
@@ -602,9 +605,6 @@ importers:
       typescript:
         specifier: ^5.7.2
         version: 5.7.3
-      update-electron-app:
-        specifier: ^3.1.0
-        version: 3.1.1
       vite:
         specifier: ^6.1.0
         version: 6.2.2(@types/node@20.17.17)(jiti@2.4.2)(lightningcss@1.29.2)(sass-embedded@1.83.4)(sass@1.85.1)(tsx@4.19.2)(yaml@2.7.0)
@@ -1437,6 +1437,31 @@ importers:
       '@electron-forge/shared-types':
         specifier: ^7.8.0
         version: 7.8.0
+      '@rslib/core':
+        specifier: ^0.5.4
+        version: 0.5.4(typescript@5.7.3)
+      tsx:
+        specifier: ^4.19.2
+        version: 4.19.3
+      typescript:
+        specifier: ^5.7.2
+        version: 5.7.3
+      vitest:
+        specifier: ^3.0.2
+        version: 3.0.8(@types/debug@4.1.12)(@types/node@22.13.10)(happy-dom@17.1.1)(jiti@2.4.2)(jsdom@26.0.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(lightningcss@1.29.2)(msw@2.7.0(@types/node@22.13.10)(typescript@5.7.3))(sass-embedded@1.83.4)(sass@1.85.1)(tsx@4.19.3)(yaml@2.7.0)
+
+  packages/common/electron-updater:
+    dependencies:
+      builder-util-runtime:
+        specifier: 9.3.1
+        version: 9.3.1
+      electron-updater:
+        specifier: ^6.6.2
+        version: 6.6.2
+      semver:
+        specifier: 7.7.2
+        version: 7.7.2
+    devDependencies:
       '@rslib/core':
         specifier: ^0.5.4
         version: 0.5.4(typescript@5.7.3)
@@ -7237,6 +7262,10 @@ packages:
     resolution: {integrity: sha512-6p/gfG1RJSQeIbz8TK5aPNkoztgY1q5TgmGFMAXcY8itsGW6Y2ld1ALsZ5UJn8rog7hKF3zHx5iQbNQ8uLcRlw==}
     engines: {node: '>=12.0.0'}
 
+  builder-util-runtime@9.3.1:
+    resolution: {integrity: sha512-2/egrNDDnRaxVwK3A+cJq6UOlqOdedGA7JPqCeJjN2Zjk1/QB/6QUi3b714ScIGS7HafFXTyzJEOr5b44I3kvQ==}
+    engines: {node: '>=12.0.0'}
+
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
@@ -7964,6 +7993,9 @@ packages:
   electron-updater@6.3.9:
     resolution: {integrity: sha512-2PJNONi+iBidkoC5D1nzT9XqsE8Q1X28Fn6xRQhO3YX8qRRyJ3mkV4F1aQsuRnYPqq6Hw+E51y27W75WgDoofw==}
 
+  electron-updater@6.6.2:
+    resolution: {integrity: sha512-Cr4GDOkbAUqRHP5/oeOmH/L2Bn6+FQPxVLZtPbcmKZC63a1F3uu5EefYOssgZXG3u/zBlubbJ5PJdITdMVggbw==}
+
   electron-util@0.17.2:
     resolution: {integrity: sha512-4Kg/aZxJ2BZklgyfH86px/D2GyROPyIcnAZar+7KiNmKI2I5l09pwQTP7V95zM3FVhgDQwV9iuJta5dyEvuWAw==}
 
@@ -8680,9 +8712,6 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
-  github-url-to-object@4.0.6:
-    resolution: {integrity: sha512-NaqbYHMUAlPcmWFdrAB7bcxrNIiiJWJe8s/2+iOc9vlcHlwHqSGrPk+Yi3nu6ebTwgsZEa7igz+NH2vEq3gYwQ==}
-
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -9222,9 +9251,6 @@ packages:
   is-unicode-supported@0.1.0:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
     engines: {node: '>=10'}
-
-  is-url@1.2.4:
-    resolution: {integrity: sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==}
 
   is-weakmap@2.0.2:
     resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
@@ -11424,6 +11450,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.7.2:
+    resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   send@0.19.0:
     resolution: {integrity: sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==}
     engines: {node: '>= 0.8.0'}
@@ -12306,9 +12337,6 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
-
-  update-electron-app@3.1.1:
-    resolution: {integrity: sha512-7duRr6sYn014tifhKgT/5i8N+6xLzmJVJ8hVtNrHXlIDNP6QbRe6VxZ1hSi2UH5oJPzhor/PH7yKU9em5xjRzQ==}
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -13822,7 +13850,7 @@ snapshots:
       outdent: 0.5.0
       prettier: 2.8.8
       resolve-from: 5.0.0
-      semver: 7.7.1
+      semver: 7.7.2
 
   '@changesets/assemble-release-plan@6.0.5':
     dependencies:
@@ -13831,7 +13859,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.1
       '@changesets/types': 6.0.0
       '@manypkg/get-packages': 1.1.3
-      semver: 7.7.1
+      semver: 7.7.2
 
   '@changesets/changelog-git@0.2.0':
     dependencies:
@@ -13864,7 +13892,7 @@ snapshots:
       package-manager-detector: 0.2.9
       picocolors: 1.1.1
       resolve-from: 5.0.0
-      semver: 7.7.1
+      semver: 7.7.2
       spawndamnit: 3.0.1
       term-size: 2.2.1
 
@@ -13887,7 +13915,7 @@ snapshots:
       '@changesets/types': 6.0.0
       '@manypkg/get-packages': 1.1.3
       picocolors: 1.1.1
-      semver: 7.7.1
+      semver: 7.7.2
 
   '@changesets/get-release-plan@4.0.6':
     dependencies:
@@ -14014,7 +14042,7 @@ snapshots:
   '@commitlint/is-ignored@19.7.1':
     dependencies:
       '@commitlint/types': 19.5.0
-      semver: 7.7.1
+      semver: 7.7.2
 
   '@commitlint/lint@19.7.1':
     dependencies:
@@ -14209,7 +14237,7 @@ snapshots:
       find-up: 5.0.0
       fs-extra: 10.1.0
       log-symbols: 4.1.0
-      semver: 7.7.1
+      semver: 7.7.2
     transitivePeerDependencies:
       - bluebird
       - supports-color
@@ -14245,7 +14273,7 @@ snapshots:
       log-symbols: 4.1.0
       node-fetch: 2.7.0(encoding@0.1.13)
       rechoir: 0.8.0
-      semver: 7.7.1
+      semver: 7.7.2
       source-map-support: 0.5.21
       sudo-prompt: 9.2.1
       username: 5.1.0
@@ -14567,7 +14595,7 @@ snapshots:
       make-fetch-happen: 10.2.1
       nopt: 6.0.0
       proc-log: 2.0.1
-      semver: 7.7.1
+      semver: 7.7.2
       tar: 6.2.1
       which: 2.0.2
     transitivePeerDependencies:
@@ -14612,7 +14640,7 @@ snapshots:
       plist: 3.1.0
       resedit: 2.0.3
       resolve: 1.22.10
-      semver: 7.7.1
+      semver: 7.7.2
       yargs-parser: 21.1.1
     transitivePeerDependencies:
       - supports-color
@@ -14630,7 +14658,7 @@ snapshots:
       node-api-version: 0.2.0
       ora: 5.4.1
       read-binary-file-arch: 1.0.6
-      semver: 7.7.1
+      semver: 7.7.2
       tar: 6.2.1
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -16883,7 +16911,7 @@ snapshots:
   '@npmcli/fs@2.1.2':
     dependencies:
       '@gar/promisify': 1.1.3
-      semver: 7.7.1
+      semver: 7.7.2
 
   '@npmcli/move-file@2.0.1':
     dependencies:
@@ -17077,7 +17105,7 @@ snapshots:
       extract-zip: 2.0.1
       progress: 2.0.3
       proxy-agent: 6.5.0
-      semver: 7.7.1
+      semver: 7.7.2
       tar-fs: 3.0.8
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -17090,7 +17118,7 @@ snapshots:
       extract-zip: 2.0.1
       progress: 2.0.3
       proxy-agent: 6.5.0
-      semver: 7.7.1
+      semver: 7.7.2
       tar-fs: 3.0.8
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -19814,7 +19842,7 @@ snapshots:
       debug: 4.4.0
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.7.1
+      semver: 7.7.2
       tsutils: 3.21.0(typescript@5.7.3)
     optionalDependencies:
       typescript: 5.7.3
@@ -19829,7 +19857,7 @@ snapshots:
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.5
-      semver: 7.7.1
+      semver: 7.7.2
       ts-api-utils: 1.4.3(typescript@5.7.3)
     optionalDependencies:
       typescript: 5.7.3
@@ -19846,7 +19874,7 @@ snapshots:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.7.3)
       eslint: 8.57.1
       eslint-scope: 5.1.1
-      semver: 7.7.1
+      semver: 7.7.2
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -20672,6 +20700,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  builder-util-runtime@9.3.1:
+    dependencies:
+      debug: 4.4.0
+      sax: 1.4.1
+    transitivePeerDependencies:
+      - supports-color
+
   bytes@3.1.2: {}
 
   cac@6.7.14: {}
@@ -20953,7 +20988,7 @@ snapshots:
       dot-prop: 9.0.0
       env-paths: 3.0.0
       json-schema-typed: 8.0.1
-      semver: 7.7.1
+      semver: 7.7.2
       uint8array-extras: 1.4.0
 
   console-table-printer@2.12.1:
@@ -21312,7 +21347,7 @@ snapshots:
       glob: 7.2.3
       lodash: 4.17.21
       parse-author: 2.0.0
-      semver: 7.7.1
+      semver: 7.7.2
       tmp-promise: 3.0.3
     optionalDependencies:
       '@types/fs-extra': 9.0.13
@@ -21401,6 +21436,19 @@ snapshots:
   electron-updater@6.3.9:
     dependencies:
       builder-util-runtime: 9.2.10
+      fs-extra: 10.1.0
+      js-yaml: 4.1.0
+      lazy-val: 1.0.5
+      lodash.escaperegexp: 4.1.2
+      lodash.isequal: 4.5.0
+      semver: 7.7.1
+      tiny-typed-emitter: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
+  electron-updater@6.6.2:
+    dependencies:
+      builder-util-runtime: 9.3.1
       fs-extra: 10.1.0
       js-yaml: 4.1.0
       lazy-val: 1.0.5
@@ -22485,10 +22533,6 @@ snapshots:
       meow: 12.1.1
       split2: 4.2.0
 
-  github-url-to-object@4.0.6:
-    dependencies:
-      is-url: 1.2.4
-
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -22538,7 +22582,7 @@ snapshots:
       es6-error: 4.1.1
       matcher: 3.0.0
       roarr: 2.15.4
-      semver: 7.7.1
+      semver: 7.7.2
       serialize-error: 7.0.1
     optional: true
 
@@ -23102,8 +23146,6 @@ snapshots:
 
   is-unicode-supported@0.1.0: {}
 
-  is-url@1.2.4: {}
-
   is-weakmap@2.0.2: {}
 
   is-weakref@1.1.1:
@@ -23148,7 +23190,7 @@ snapshots:
       '@babel/parser': 7.26.8
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
-      semver: 7.7.1
+      semver: 7.7.2
     transitivePeerDependencies:
       - supports-color
 
@@ -23365,7 +23407,7 @@ snapshots:
       console-table-printer: 2.12.1
       p-queue: 6.6.2
       p-retry: 4.6.2
-      semver: 7.7.1
+      semver: 7.7.2
       uuid: 10.0.0
     optionalDependencies:
       openai: 4.87.3(encoding@0.1.13)(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@6.0.5))(zod@3.24.2)
@@ -23624,7 +23666,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.7.1
+      semver: 7.7.2
 
   make-error@1.3.6: {}
 
@@ -24371,7 +24413,7 @@ snapshots:
 
   node-abi@3.74.0:
     dependencies:
-      semver: 7.7.1
+      semver: 7.7.2
 
   node-abort-controller@3.1.1: {}
 
@@ -24382,7 +24424,7 @@ snapshots:
 
   node-api-version@0.2.0:
     dependencies:
-      semver: 7.7.1
+      semver: 7.7.2
 
   node-domexception@1.0.0: {}
 
@@ -24398,7 +24440,7 @@ snapshots:
     dependencies:
       growly: 1.3.0
       is-wsl: 2.2.0
-      semver: 7.7.1
+      semver: 7.7.2
       shellwords: 0.1.1
       uuid: 8.3.2
       which: 2.0.2
@@ -25782,6 +25824,8 @@ snapshots:
 
   semver@7.7.1: {}
 
+  semver@7.7.2: {}
+
   send@0.19.0:
     dependencies:
       debug: 2.6.9
@@ -26824,11 +26868,6 @@ snapshots:
       browserslist: 4.24.4
       escalade: 3.2.0
       picocolors: 1.1.1
-
-  update-electron-app@3.1.1:
-    dependencies:
-      github-url-to-object: 4.0.6
-      ms: 2.1.3
 
   uri-js@4.4.1:
     dependencies:

--- a/scripts/release-beta-pkgs.sh
+++ b/scripts/release-beta-pkgs.sh
@@ -12,16 +12,13 @@ pnpm changeset version
 echo "2. update dependencies..."
 pnpm install
 
-echo "3. create release tag..."
-pnpm changeset tag
-
-echo "4. publish to npm..."
+echo "3. publish to npm..."
 pnpm publish -r --no-git-checks --access public --tag beta
 
-echo "5. exit changeset..."
+echo "4. exit changeset..."
 pnpm changeset pre exit
 
-echo "6. prepare to push to remote git repository..."
+echo "5. prepare to push to remote git repository..."
 read -p "confirm push to remote git repository? (y/N) " confirm
 if [[ $confirm == [yY] ]]; then
     git add .

--- a/scripts/release-pkgs.sh
+++ b/scripts/release-pkgs.sh
@@ -14,13 +14,10 @@ echo "3. commit version update..."
 git add .
 git commit -m "release: publish packages"
 
-echo "4. create release tag..."
-pnpm changeset tag
-
-echo "5. publish to npm..."
+echo "4. publish to npm..."
 pnpm publish -r --no-git-checks --access public
 
-echo "6. prepare to push to remote git repository..."
+echo "5. prepare to push to remote git repository..."
 read -p "confirm push to remote git repository? (y/N) " confirm
 if [[ $confirm == [yY] ]]; then
     echo "pushing code and tag to remote git repository..."


### PR DESCRIPTION
Close https://github.com/bytedance/UI-TARS-desktop/issues/543

The original implementation relies on the GitHub releases feed at [https://github.com/bytedance/UI-TARS-desktop/releases.atom](https://github.com/bytedance/UI-TARS-desktop/releases.atom), which only returns the latest 10 tags.

<img width="1226" alt="image" src="https://github.com/user-attachments/assets/caf61918-611a-4773-a3fe-16298a912244" />


However, since our repository includes npm releases, UI-TARS, and Agent-TARS (two Electron apps), the feed often excludes the latest Agent-TARS tags. This prevents the latest label from being updated correctly for Agent-TARS, leading to update errors.

<img width="658" alt="image" src="https://github.com/user-attachments/assets/6723095e-b55e-42de-b39b-bc9cd135bef3" />


To resolve this, we now fetch the latest release version from our existing Homebrew tap using the Formulae API: `https://formulae.brew.sh/api/cask/ui-tars.json` and `https://formulae.brew.sh/api/cask/agent-tars.json`

https://github.com/Homebrew/homebrew-cask/blob/b2de6a21a317c30536896855f12eadd66e962848/Casks/a/agent-tars.rb#L11-L12

This reliably provides the correct latest version for both apps and ensures the update logic works as expected.(Fixed the issue with the releaseNote anomaly while at it)

![image](https://github.com/user-attachments/assets/0e339064-a657-41a5-a5d7-5999e7354dbe)

