### PR TITLE
fix(agent-tars-cli): set apiKey with env does not work

### DIFF
--- a/multimodal/agent-tars-cli/src/config/builder.ts
+++ b/multimodal/agent-tars-cli/src/config/builder.ts
@@ -62,6 +62,9 @@ export class ConfigBuilder {
       shareProvider,
     });
 
+    // Resolve environment variables in CLI model configuration before merging
+    this.resolveModelSecrets(cliConfigProps);
+
     // Merge CLI configuration properties directly (CLI overrides user config)
     this.deepMerge(config, cliConfigProps);
 
@@ -69,9 +72,6 @@ export class ConfigBuilder {
     this.handleWorkspaceOptions(config, workspace);
     this.applyLoggingShortcuts(config, { debug, quiet });
     this.applyServerConfiguration(config, { port });
-
-    // Resolve environment variables in CLI model configuration before merging
-    this.resolveModelSecrets(cliConfigProps);
 
     return config;
   }
@@ -86,10 +86,13 @@ export class ConfigBuilder {
     const workspaceConfig: AgentTARSAppConfig['workspace'] = {};
     if (typeof workspace === 'string') {
       workspaceConfig.workingDirectory = workspace;
-    } else if (typeof config.workspace === 'object') {
+    } else if (typeof workspace === 'object') {
       Object.assign(workspaceConfig, workspace);
     }
-    config.workspace = workspaceConfig;
+    if (!config.workspace) {
+      config.workspace = {};
+    }
+    Object.assign(config.workspace, workspaceConfig);
   }
 
   /**

--- a/multimodal/agent-tars-cli/tests/config-builder.test.ts
+++ b/multimodal/agent-tars-cli/tests/config-builder.test.ts
@@ -68,6 +68,7 @@ describe('ConfigBuilder', () => {
             type: 'sqlite',
           },
         },
+        workspace: {},
       });
     });
 
@@ -306,7 +307,9 @@ describe('ConfigBuilder', () => {
         },
       };
 
-      const result = ConfigBuilder.buildAppConfig(cliArgs, {});
+      const result = ConfigBuilder.buildAppConfig(cliArgs, {
+        model: {},
+      });
 
       expect(resolveValue).toHaveBeenCalledWith('OPENAI_API_KEY', 'API key');
       expect(resolveValue).toHaveBeenCalledWith('OPENAI_BASE_URL', 'base URL');
@@ -478,6 +481,7 @@ describe('ConfigBuilder', () => {
         share: {
           provider: 'https://share.test.com',
         },
+        workspace: {},
         server: {
           port: 8888,
           storage: {


### PR DESCRIPTION
<!--------------------------------------------------------------------------------
    Thank you for submitting a pull request!

    We appreciate the time and effort you have invested in making these changes. Please 
    ensure that you provide enough information to allow others to review your pull request 
    effectively, so please DO NOT delete this template.

    If you're new to contributing, learn more about contributing here:
    https://github.com/bytedance/UI-TARS-desktop/blob/main/CONTRIBUTING.md.  
---------------------------------------------------------------------------------->

## Summary

The following command do not work because of a historical regression issue:

```
agent-tars
--provider deepseek \
--model deepseek-chat \
--apiKey DEEPSEEK_API_KEY
```

<!--------------------------------------------------------------------------------
    Can you explain the reasoning behind implementing this change?  
    What problem or issue does this pull request resolve?  

    It would be helpful to include relevant context, such as GitHub issues 
    (e.g., Close: #xxx) or related discussions.

    If updating the UI, please include a **before/after screenshot** for visibility.
    Thank you for reading. Next, start describing your Summary on the next line
    after the comment ends. 👇🏻
---------------------------------------------------------------------------------->



## Checklist  

<!--  Before submitting the pull request, ensure the following items are checked: -->

- [ ] Added or updated necessary tests (Optional).  
- [ ] Updated documentation to align with changes (Optional).  
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).  
- [x] My change does not involve the above items. 
