### PR TITLE
feat(agent-tars-cli): support load config from global workspce

### DIFF
--- a/multimodal/agent-tars-cli/src/commands/options.ts
+++ b/multimodal/agent-tars-cli/src/commands/options.ts
@@ -137,7 +137,7 @@ export async function processCommonOptions(options: AgentTARSCLIArguments): Prom
       const configPath = path.join(globalWorkspacePath, file);
       if (fs.existsSync(configPath)) {
         logger.success(`Load global workspace config: ${configPath}`);
-        configPaths.unshift(configPath);
+        configPaths.push(configPath);
         break;
       }
     }

--- a/multimodal/agent-tars-cli/src/commands/workspace.ts
+++ b/multimodal/agent-tars-cli/src/commands/workspace.ts
@@ -512,3 +512,8 @@ export function isGlobalWorkspaceEnabled(): boolean {
 export function getGlobalWorkspacePath(): string {
   return path.join(os.homedir(), '.agent-tars-workspace');
 }
+
+/**
+ * Check if we should enable global workspace
+ */
+export const shouldUseGlobalWorkspace = isGlobalWorkspaceCreated() && isGlobalWorkspaceEnabled();

--- a/multimodal/agent-tars-cli/src/config/loader.ts
+++ b/multimodal/agent-tars-cli/src/config/loader.ts
@@ -15,10 +15,10 @@ import { logger } from '../utils';
  */
 export const CONFIG_FILES = [
   'agent-tars.config.ts',
-  'agent-tars.config.yml',
+  // 'agent-tars.config.yml',
   'agent-tars.config.yaml',
   'agent-tars.config.json',
-  'agent-tars.config.js',
+  // 'agent-tars.config.js',
 ];
 
 /**

--- a/multimodal/agent-tars-cli/src/config/loader.ts
+++ b/multimodal/agent-tars-cli/src/config/loader.ts
@@ -8,18 +8,7 @@ import { loadConfig } from '@multimodal/config-loader';
 import { AgentTARSAppConfig } from '@agent-tars/interface';
 import fetch from 'node-fetch';
 import { logger } from '../utils';
-
-/**
- * Default configuration files that will be automatically detected
- * The first file found in this list will be used if no explicit config is provided
- */
-export const CONFIG_FILES = [
-  'agent-tars.config.ts',
-  // 'agent-tars.config.yml',
-  'agent-tars.config.yaml',
-  'agent-tars.config.json',
-  // 'agent-tars.config.js',
-];
+import { CONFIG_FILES } from './paths';
 
 /**
  * Load remote configuration from URL

--- a/multimodal/agent-tars-cli/src/config/paths.ts
+++ b/multimodal/agent-tars-cli/src/config/paths.ts
@@ -1,0 +1,79 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { logger } from '../utils';
+import * as path from 'path';
+import * as fs from 'fs';
+
+/**
+ * Default configuration files that will be automatically detected
+ * The first file found in this list will be used if no explicit config is provided
+ */
+export const CONFIG_FILES = [
+  'agent-tars.config.ts',
+  // 'agent-tars.config.yml',
+  'agent-tars.config.yaml',
+  'agent-tars.config.json',
+  // 'agent-tars.config.js',
+];
+
+/**
+ * Build configuration paths array by combining CLI options, bootstrap config and workspace settings
+ *
+ * @param options Configuration options
+ * @param options.cliConfigPaths Array of config paths from CLI arguments
+ * @param options.bootstrapRemoteConfig Remote config from bootstrap options
+ * @param options.useGlobalWorkspace Whether global workspace should be used
+ * @param options.globalWorkspacePath Path to global workspace
+ * @param options.isDebug Debug mode flag
+ * @returns Array of configuration paths in priority order
+ */
+export function buildConfigPaths({
+  cliConfigPaths = [],
+  bootstrapRemoteConfig,
+  useGlobalWorkspace,
+  globalWorkspacePath,
+  isDebug = false,
+}: {
+  cliConfigPaths?: string[];
+  bootstrapRemoteConfig?: string;
+  useGlobalWorkspace?: boolean;
+  globalWorkspacePath?: string;
+  isDebug?: boolean;
+}): string[] {
+  const configPaths: string[] = [...cliConfigPaths];
+
+  // bootstrapCliOptions has lowest priority
+  if (bootstrapRemoteConfig) {
+    configPaths.unshift(bootstrapRemoteConfig);
+  }
+
+  // Add global workspace config if it exists and is enabled
+  if (useGlobalWorkspace && globalWorkspacePath) {
+    let foundWorkspaceConfig = false;
+
+    for (const file of CONFIG_FILES) {
+      const configPath = path.join(globalWorkspacePath, file);
+      if (fs.existsSync(configPath)) {
+        logger.success(`Load global workspace config: ${configPath}`);
+        // Config file in global workspace should have highest priority
+        configPaths.push(configPath);
+        foundWorkspaceConfig = true;
+        break;
+      }
+    }
+
+    if (!foundWorkspaceConfig && isDebug) {
+      logger.debug(`No config file found in global workspace: ${globalWorkspacePath}`);
+    }
+
+    if (isDebug) {
+      logger.debug(`Added global workspace configs: ${globalWorkspacePath}`);
+    }
+  }
+
+  return configPaths;
+}

--- a/multimodal/agent-tars-cli/src/core/interactive-ui.ts
+++ b/multimodal/agent-tars-cli/src/core/interactive-ui.ts
@@ -14,11 +14,7 @@ import chalk from 'chalk';
 import gradient from 'gradient-string';
 import { logger, toUserFriendlyPath } from '../utils';
 import { getBootstrapCliOptions } from './state';
-import {
-  isGlobalWorkspaceCreated,
-  getGlobalWorkspacePath,
-  isGlobalWorkspaceEnabled,
-} from '../commands/workspace';
+import { shouldUseGlobalWorkspace } from '../commands/workspace';
 
 interface UIServerOptions {
   appConfig: AgentTARSAppConfig;
@@ -90,10 +86,8 @@ export async function startInteractiveWebUI(options: UIServerOptions): Promise<h
 
     // Get and format workspace directory for display
     let workspaceLabel = 'Workspace:';
-    const isUsingGlobalWorkspace =
-      appConfig.workspace?.workingDirectory === getGlobalWorkspacePath();
 
-    if (isUsingGlobalWorkspace) {
+    if (shouldUseGlobalWorkspace) {
       workspaceLabel = 'Global Workspace:';
     }
 

--- a/multimodal/agent-tars-cli/tests/config-paths.test.ts
+++ b/multimodal/agent-tars-cli/tests/config-paths.test.ts
@@ -1,0 +1,124 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { buildConfigPaths } from '../src/config/paths';
+import * as fs from 'fs';
+
+// Mock fs and path
+vi.mock('fs', () => ({
+  existsSync: vi.fn(),
+}));
+
+describe('buildConfigPaths', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.clearAllMocks();
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should return CLI config paths when no other options provided', () => {
+    const cliConfigPaths = ['./config1.json', './config2.json'];
+
+    const result = buildConfigPaths({ cliConfigPaths });
+
+    expect(result).toEqual(cliConfigPaths);
+  });
+
+  it('should add bootstrap remote config with lowest priority', () => {
+    const cliConfigPaths = ['./config1.json', './config2.json'];
+    const bootstrapRemoteConfig = 'https://remote-config.com/config.json';
+
+    const result = buildConfigPaths({
+      cliConfigPaths,
+      bootstrapRemoteConfig,
+    });
+
+    expect(result).toEqual([bootstrapRemoteConfig, ...cliConfigPaths]);
+  });
+
+  it('should add global workspace config with highest priority', () => {
+    const cliConfigPaths = ['./config1.json'];
+    const globalWorkspacePath = '/home/user/.agent-tars-workspace';
+
+    // Mock fs.existsSync to return true for the first config file
+    vi.mocked(fs.existsSync).mockImplementation((path: string) => {
+      return path === `${globalWorkspacePath}/agent-tars.config.ts`;
+    });
+
+    const result = buildConfigPaths({
+      cliConfigPaths,
+      useGlobalWorkspace: true,
+      globalWorkspacePath,
+    });
+
+    expect(result).toEqual([...cliConfigPaths, `${globalWorkspacePath}/agent-tars.config.ts`]);
+  });
+
+  it('should handle all config sources together in correct priority order', () => {
+    const cliConfigPaths = ['./user-config.json'];
+    const bootstrapRemoteConfig = 'https://remote-config.com/config.json';
+    const globalWorkspacePath = '/home/user/.agent-tars-workspace';
+
+    // Mock fs.existsSync to return true for the workspace config
+    vi.mocked(fs.existsSync).mockImplementation((path: string) => {
+      return path === `${globalWorkspacePath}/agent-tars.config.json`;
+    });
+
+    const result = buildConfigPaths({
+      cliConfigPaths,
+      bootstrapRemoteConfig,
+      useGlobalWorkspace: true,
+      globalWorkspacePath,
+      isDebug: true,
+    });
+
+    // Expect: [remote config (lowest priority), cli configs, workspace config (highest priority)]
+    expect(result).toEqual([
+      bootstrapRemoteConfig,
+      ...cliConfigPaths,
+      `${globalWorkspacePath}/agent-tars.config.json`,
+    ]);
+  });
+
+  it('should not add workspace config if no config file exists', () => {
+    const cliConfigPaths = ['./config1.json'];
+    const globalWorkspacePath = '/home/user/.agent-tars-workspace';
+
+    // Mock fs.existsSync to always return false
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+
+    const result = buildConfigPaths({
+      cliConfigPaths,
+      useGlobalWorkspace: true,
+      globalWorkspacePath,
+      isDebug: true,
+    });
+
+    // Should only have CLI configs
+    expect(result).toEqual(cliConfigPaths);
+  });
+
+  it('should handle empty CLI config paths', () => {
+    const bootstrapRemoteConfig = 'https://remote-config.com/config.json';
+
+    const result = buildConfigPaths({
+      bootstrapRemoteConfig,
+    });
+
+    expect(result).toEqual([bootstrapRemoteConfig]);
+  });
+
+  it('should handle undefined CLI config paths', () => {
+    const result = buildConfigPaths({});
+
+    expect(result).toEqual([]);
+  });
+});


### PR DESCRIPTION
<!--------------------------------------------------------------------------------
    Thank you for submitting a pull request!

    We appreciate the time and effort you have invested in making these changes. Please 
    ensure that you provide enough information to allow others to review your pull request 
    effectively, so please DO NOT delete this template.

    If you're new to contributing, learn more about contributing here:
    https://github.com/bytedance/UI-TARS-desktop/blob/main/CONTRIBUTING.md.  
---------------------------------------------------------------------------------->

## Summary

Adjusting the configuration of Agent TARS through TypeScript is a very useful feature, but currently, Agent TARS CLI can only load the config passed through `--config` or the config file in the current directory. 

This Pull Request enables Agent TARS to read the configuration from the Global Workspace and give it the highest priority.

<!--------------------------------------------------------------------------------
    Can you explain the reasoning behind implementing this change?  
    What problem or issue does this pull request resolve?  

    It would be helpful to include relevant context, such as GitHub issues 
    (e.g., Close: #xxx) or related discussions.

    If updating the UI, please include a **before/after screenshot** for visibility.
    Thank you for reading. Next, start describing your Summary on the next line
    after the comment ends. 👇🏻
---------------------------------------------------------------------------------->



## Checklist  

<!--  Before submitting the pull request, ensure the following items are checked: -->

- [x] Added or updated necessary tests (Optional).  
- [ ] Updated documentation to align with changes (Optional).  
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).  
- [ ] My change does not involve the above items. 
