### PR TITLE
fix(agent): tool schema miss `properties` in native tool call (close: #769)

### DIFF
--- a/multimodal/agent-tars/tests/__snapshots__/browser_tools_browser-use-only.snap
+++ b/multimodal/agent-tars/tests/__snapshots__/browser_tools_browser-use-only.snap
@@ -125,6 +125,7 @@
       "description": "[browser] Get the clickable or hoverable or selectable elements on the current page, don't call this tool multiple times",
       "name": "browser_get_clickable_elements",
       "parameters": {
+        "properties": {},
         "type": "object",
       },
     },
@@ -132,6 +133,7 @@
       "description": "[browser] Get the markdown content of the current page",
       "name": "browser_get_markdown",
       "parameters": {
+        "properties": {},
         "type": "object",
       },
     },
@@ -139,6 +141,7 @@
       "description": "[browser] Get all links on the current page",
       "name": "browser_read_links",
       "parameters": {
+        "properties": {},
         "type": "object",
       },
     },
@@ -161,6 +164,7 @@
       "description": "[browser] Go back to the previous page",
       "name": "browser_go_back",
       "parameters": {
+        "properties": {},
         "type": "object",
       },
     },
@@ -168,6 +172,7 @@
       "description": "[browser] Go forward to the next page",
       "name": "browser_go_forward",
       "parameters": {
+        "properties": {},
         "type": "object",
       },
     },
@@ -175,6 +180,7 @@
       "description": "[browser] Get the list of tabs",
       "name": "browser_tab_list",
       "parameters": {
+        "properties": {},
         "type": "object",
       },
     },
@@ -200,6 +206,7 @@
       "description": "[browser] Close the current tab",
       "name": "browser_close_tab",
       "parameters": {
+        "properties": {},
         "type": "object",
       },
     },

--- a/multimodal/agent-tars/tests/__snapshots__/browser_tools_mixed.snap
+++ b/multimodal/agent-tars/tests/__snapshots__/browser_tools_mixed.snap
@@ -224,6 +224,7 @@ wait()                                         - Wait 5 seconds and take a scree
       "description": "[browser] Get the clickable or hoverable or selectable elements on the current page, don't call this tool multiple times",
       "name": "browser_get_clickable_elements",
       "parameters": {
+        "properties": {},
         "type": "object",
       },
     },
@@ -231,6 +232,7 @@ wait()                                         - Wait 5 seconds and take a scree
       "description": "[browser] Get all links on the current page",
       "name": "browser_read_links",
       "parameters": {
+        "properties": {},
         "type": "object",
       },
     },
@@ -253,6 +255,7 @@ wait()                                         - Wait 5 seconds and take a scree
       "description": "[browser] Get the list of tabs",
       "name": "browser_tab_list",
       "parameters": {
+        "properties": {},
         "type": "object",
       },
     },
@@ -278,6 +281,7 @@ wait()                                         - Wait 5 seconds and take a scree
       "description": "[browser] Close the current tab",
       "name": "browser_close_tab",
       "parameters": {
+        "properties": {},
         "type": "object",
       },
     },

--- a/multimodal/agent/src/agent/tool-manager.ts
+++ b/multimodal/agent/src/agent/tool-manager.ts
@@ -19,6 +19,9 @@ export class ToolManager {
    */
   registerTool(tool: Tool): void {
     this.logger.info(`[Tool] Registered: ${tool.name} | Description: "${tool.description}"`);
+    if (tool.schema.type === 'object' && !tool.schema.properties) {
+      tool.schema.properties = {};
+    }
     this.tools.set(tool.name, tool);
   }
 


### PR DESCRIPTION
<!--------------------------------------------------------------------------------
    Thank you for submitting a pull request!

    We appreciate the time and effort you have invested in making these changes. Please 
    ensure that you provide enough information to allow others to review your pull request 
    effectively, so please DO NOT delete this template.

    If you're new to contributing, learn more about contributing here:
    https://github.com/bytedance/UI-TARS-desktop/blob/main/CONTRIBUTING.md.  
---------------------------------------------------------------------------------->

## Summary

- Close: #769 

`0.1.12-beta.5` does not work in `aws_sdk_claude37_sonnet` model with `azure-openai` provider 

> Error in agent execution: Error: 400 operation error Bedrock Runtime: ConverseStream, https response error StatusCode: 400, RequestID: 9075e9e9-bf98-43e6-a615-e5e0018c5f02, ValidationException: The json schema definition at toolConfig.tools.13.toolSpec.inputSchema is invalid. Fix the following errors and try again: $.properties: null found, object expected

<!--------------------------------------------------------------------------------
    Can you explain the reasoning behind implementing this change?  
    What problem or issue does this pull request resolve?  

    It would be helpful to include relevant context, such as GitHub issues 
    (e.g., Close: #xxx) or related discussions.

    If updating the UI, please include a **before/after screenshot** for visibility.
    Thank you for reading. Next, start describing your Summary on the next line
    after the comment ends. 👇🏻
---------------------------------------------------------------------------------->



## Checklist  

<!--  Before submitting the pull request, ensure the following items are checked: -->

- [x] Added or updated necessary tests (Optional).  
- [ ] Updated documentation to align with changes (Optional).  
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).  
- [ ] My change does not involve the above items. 
