### PR TITLE
feat(agent-tars): always create new navigation screenshot for gui agent

### DIFF
--- a/multimodal/agent-tars/src/agent-tars.ts
+++ b/multimodal/agent-tars/src/agent-tars.ts
@@ -831,15 +831,8 @@ Current Working Directory: ${workingDirectory}
           }
         }
       } else if (this.browserGUIAgent) {
-        if (this.browserGUIAgent.currentScreenshot) {
-          this.browserState.currentScreenshot = this.browserGUIAgent.currentScreenshot;
-        } else {
-          await new Promise(function (resolve) {
-            setTimeout(resolve, 50);
-          });
-          const { compressedBase64 } = await this.browserGUIAgent.screenshot();
-          this.browserState.currentScreenshot = compressedBase64;
-        }
+        const { compressedBase64 } = await this.browserGUIAgent.screenshot();
+        this.browserState.currentScreenshot = compressedBase64;
       }
     }
 


### PR DESCRIPTION
<!--------------------------------------------------------------------------------
    Thank you for submitting a pull request!

    We appreciate the time and effort you have invested in making these changes. Please 
    ensure that you provide enough information to allow others to review your pull request 
    effectively, so please DO NOT delete this template.

    If you're new to contributing, learn more about contributing here:
    https://github.com/bytedance/UI-TARS-desktop/blob/main/CONTRIBUTING.md.  
---------------------------------------------------------------------------------->

## Summary

Always use manually generated screenshots, because browser gui agent screenshots are generated before `browser_navigate`, and they are a white background in all time.

<!--------------------------------------------------------------------------------
    Can you explain the reasoning behind implementing this change?  
    What problem or issue does this pull request resolve?  

    It would be helpful to include relevant context, such as GitHub issues 
    (e.g., Close: #xxx) or related discussions.

    If updating the UI, please include a **before/after screenshot** for visibility.
    Thank you for reading. Next, start describing your Summary on the next line
    after the comment ends. 👇🏻
---------------------------------------------------------------------------------->



## Checklist  

<!--  Before submitting the pull request, ensure the following items are checked: -->

- [ ] Added or updated necessary tests (Optional).  
- [ ] Updated documentation to align with changes (Optional).  
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).  
- [x] My change does not involve the above items. 
