### PR TITLE
feat(agent-tars-cli): support `agent-tars run --cache` by default

### DIFF
--- a/multimodal/agent-tars-cli/src/core/index.ts
+++ b/multimodal/agent-tars-cli/src/core/index.ts
@@ -7,5 +7,6 @@ export * from './interactive-ui';
 export * from './headless-server';
 export * from './request';
 export * from './run';
+export * from './server-run';
 export * from './state';
 export * from './types';

--- a/multimodal/agent-tars-cli/src/core/server-run.ts
+++ b/multimodal/agent-tars-cli/src/core/server-run.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { AgentTARSAppConfig, LogLevel } from '@agent-tars/interface';
+import { AgentTARSServer } from '@agent-tars/server';
+import { ConsoleInterceptor } from '../utils/console-interceptor';
+import { getBootstrapCliOptions } from './state';
+
+interface ServerRunOptions {
+  appConfig: AgentTARSAppConfig;
+  input: string;
+  format?: 'json' | 'text';
+  includeLogs?: boolean;
+  isDebug?: boolean;
+}
+
+/**
+ * Process a query in server mode with result caching
+ * This allows results to be stored and retrieved later from the UI
+ */
+export async function processServerRun(options: ServerRunOptions): Promise<void> {
+  const { appConfig, input, format = 'text', includeLogs = false, isDebug = false } = options;
+
+  if (!appConfig.workspace) {
+    appConfig.workspace = {};
+  }
+
+  // Configure server storage if not explicitly set
+  if (!appConfig.server) {
+    appConfig.server = {
+      port: 0, // Use random available port
+      storage: { type: 'sqlite' }, // Default to SQLite storage for caching
+    };
+  } else if (!appConfig.server.storage) {
+    appConfig.server.storage = { type: 'sqlite' };
+  }
+
+  // Start with console interception for clean output
+  const { result, logs } = await ConsoleInterceptor.run(
+    async () => {
+      let server: AgentTARSServer | undefined;
+      try {
+        // Create and start server
+        server = new AgentTARSServer(appConfig as Required<AgentTARSAppConfig>, {
+          agioProvider: getBootstrapCliOptions().agioProvider,
+        });
+        await server.start();
+
+        // Send request to server
+        const response = await fetch(`http://localhost:${server.port}/api/v1/oneshot/query`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            query: input,
+            sessionName: 'CLI Run',
+            sessionTags: ['cli', 'run'],
+          }),
+        });
+
+        if (!response.ok) {
+          throw new Error(`Server request failed: ${response.statusText}`);
+        }
+
+        return await response.json();
+      } finally {
+        // Ensure server is stopped within the interceptor context
+        if (server) {
+          try {
+            await server.stop();
+          } catch (stopError) {
+            if (isDebug) {
+              console.error(`Error stopping server: ${stopError}`);
+            }
+          }
+        }
+      }
+    },
+    {
+      silent: !isDebug, // Only show logs in debug mode
+      capture: includeLogs || isDebug, // Capture logs if requested or in debug mode
+      debug: isDebug,
+    },
+  );
+
+  // Output based on format
+  if (format === 'json') {
+    // Output as JSON with optional logs
+    const output = {
+      ...result,
+      ...(includeLogs ? { logs } : {}),
+    };
+    process.stdout.write(JSON.stringify(output, null, 2));
+  } else {
+    // Output as plain text (just the content)
+    if (result.result?.content) {
+      process.stdout.write(result.result.content);
+    } else {
+      process.stdout.write(JSON.stringify(result, null, 2));
+    }
+
+    // If includeLogs is true, append logs after content
+    if (includeLogs && logs.length > 0) {
+      process.stdout.write('\n\n--- Logs ---\n');
+      process.stdout.write(logs.join('\n'));
+    }
+  }
+}

--- a/multimodal/agent-tars-server/src/server.ts
+++ b/multimodal/agent-tars-server/src/server.ts
@@ -209,7 +209,6 @@ export class AgentTARSServer {
           }
 
           this.isRunning = false;
-          console.log('Server stopped');
           resolve();
         });
       });


### PR DESCRIPTION
<!--------------------------------------------------------------------------------
    Thank you for submitting a pull request!

    We appreciate the time and effort you have invested in making these changes. Please 
    ensure that you provide enough information to allow others to review your pull request 
    effectively, so please DO NOT delete this template.

    If you're new to contributing, learn more about contributing here:
    https://github.com/bytedance/UI-TARS-desktop/blob/main/CONTRIBUTING.md.  
---------------------------------------------------------------------------------->

## Summary

`agent-tars run` is currently fully run in memory, this pull request has introduced a new feature (`--cache`) to launch `agent-tars run` by launching the Agent TARS Server, then `agent-tars run` has the ability to automatically save Session data.

This new cli flag `--cache` is enabled by default, and user can use `no-cache` to downgrade to the old behavior.

<!--------------------------------------------------------------------------------
    Can you explain the reasoning behind implementing this change?  
    What problem or issue does this pull request resolve?  

    It would be helpful to include relevant context, such as GitHub issues 
    (e.g., Close: #xxx) or related discussions.

    If updating the UI, please include a **before/after screenshot** for visibility.
    Thank you for reading. Next, start describing your Summary on the next line
    after the comment ends. 👇🏻
---------------------------------------------------------------------------------->



## Checklist  

<!--  Before submitting the pull request, ensure the following items are checked: -->

- [ ] Added or updated necessary tests (Optional).  
- [ ] Updated documentation to align with changes (Optional).  
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).  
- [x] My change does not involve the above items. 
