### PR TITLE
feat(agent-tars-server): add `/api/v1/version`

### DIFF
--- a/multimodal/agent-tars-cli/rslib.config.ts
+++ b/multimodal/agent-tars-cli/rslib.config.ts
@@ -14,6 +14,9 @@ export default defineConfig({
     entry: {
       index: ['src/index.ts'],
     },
+    define: {
+      __BUILD_TIME__: JSON.stringify(Date.now()),
+    },
   },
   lib: [
     {

--- a/multimodal/agent-tars-cli/src/core/headless-server.ts
+++ b/multimodal/agent-tars-cli/src/core/headless-server.ts
@@ -36,6 +36,8 @@ export async function startHeadlessServer(options: HeadlessServerOptions): Promi
   // Create and start the server with config
   const tarsServer = new AgentTARSServer(appConfig as Required<AgentTARSAppConfig>, {
     agioProvider: getBootstrapCliOptions().agioProvider,
+    version: getBootstrapCliOptions().version,
+    buildTime: __BUILD_TIME__,
   });
   const server = await tarsServer.start();
 

--- a/multimodal/agent-tars-cli/src/core/interactive-ui.ts
+++ b/multimodal/agent-tars-cli/src/core/interactive-ui.ts
@@ -14,7 +14,6 @@ import chalk from 'chalk';
 import gradient from 'gradient-string';
 import { logger, toUserFriendlyPath } from '../utils';
 import { getBootstrapCliOptions } from './state';
-import { shouldUseGlobalWorkspace } from '../commands/workspace';
 
 interface UIServerOptions {
   appConfig: AgentTARSAppConfig;
@@ -64,6 +63,8 @@ export async function startInteractiveWebUI(options: UIServerOptions): Promise<h
   // Create and start the server with config
   const tarsServer = new AgentTARSServer(appConfig as Required<AgentTARSAppConfig>, {
     agioProvider: getBootstrapCliOptions().agioProvider,
+    version: getBootstrapCliOptions().version,
+    buildTime: __BUILD_TIME__,
   });
   const server = await tarsServer.start();
 

--- a/multimodal/agent-tars-cli/src/env.d.ts
+++ b/multimodal/agent-tars-cli/src/env.d.ts
@@ -1,0 +1,1 @@
+declare const __BUILD_TIME__: string;

--- a/multimodal/agent-tars-server/src/api/controllers/system.ts
+++ b/multimodal/agent-tars-server/src/api/controllers/system.ts
@@ -12,3 +12,14 @@ import { AgentTARSServer } from '../../server';
 export function healthCheck(req: Request, res: Response) {
   res.status(200).json({ status: 'ok' });
 }
+
+/**
+ * Get version information
+ */
+export function getVersion(req: Request, res: Response) {
+  const server = req.app.locals.server;
+  res.status(200).json({
+    version: server.extraOptions?.version,
+    buildTime: server.extraOptions?.buildTime,
+  });
+}

--- a/multimodal/agent-tars-server/src/api/routes/system.ts
+++ b/multimodal/agent-tars-server/src/api/routes/system.ts
@@ -13,4 +13,7 @@ import * as systemController from '../controllers/system';
 export function registerSystemRoutes(app: express.Application): void {
   // Health check endpoint
   app.get('/api/v1/health', systemController.healthCheck);
+  
+  // Version information endpoint
+  app.get('/api/v1/version', systemController.getVersion);
 }

--- a/multimodal/agent-tars-server/src/server.ts
+++ b/multimodal/agent-tars-server/src/server.ts
@@ -16,11 +16,15 @@ import type { AgentSession } from './core';
 export { express };
 
 /**
- * Server injection options for dependency injection
+ * Server extra options for dependency injection
  */
-export interface ServerInjectionOptions {
+export interface ServerExtraOptions {
   /** Custom AGIO provider implementation */
   agioProvider?: AgioProviderImpl;
+  /** Server version */
+  version?: string;
+  /** Build timestamp */
+  buildTime?: string;
 }
 
 /**
@@ -57,7 +61,10 @@ export class AgentTARSServer {
   public readonly storageProvider: StorageProvider | null = null;
   public readonly appConfig: Required<AgentTARSAppConfig>;
 
-  constructor(appConfig: Required<AgentTARSAppConfig>, injectionOptions?: ServerInjectionOptions) {
+  constructor(
+    appConfig: Required<AgentTARSAppConfig>,
+    public readonly extraOptions?: ServerExtraOptions,
+  ) {
     // Initialize options
     this.appConfig = appConfig;
     this.port = appConfig.server.port ?? 3000;
@@ -65,7 +72,7 @@ export class AgentTARSServer {
     this.isDebug = appConfig.logLevel === LogLevel.DEBUG;
 
     // Store injection options
-    this.customAgioProvider = injectionOptions?.agioProvider;
+    this.customAgioProvider = extraOptions?.agioProvider;
 
     // Initialize Express app and HTTP server
     this.app = express();


### PR DESCRIPTION
## Summary

This pull request enhances the Agent TARS Server by integrating version and build timestamp metadata.  creating a new API endpoint (`/api/v1/version`) for version details

```bash
curl --location 'http://localhost:8888/api/v1/version' \
--header 'Content-Type: application/json'
```

```json
{"version":"0.2.10","buildTime":1752213411190}
```

## Other Changes

Renamed `ServerInjectionOptions` to `ServerExtraOptions` and expanded it to include version-related properties. Adjusted relevant server constructors and configurations to reflect the updated options structure.


## Checklist  

<!--  Before submitting the pull request, ensure the following items are checked: -->

- [ ] Added or updated necessary tests (Optional).  
- [ ] Updated documentation to align with changes (Optional).  
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).  
- [x] My change does not involve the above items. 
