### PR TITLE
fix(agent-tars-docs): do not ssg 404

### DIFF
--- a/multimodal/websites/docs/src/components/NotFoundLayout.tsx
+++ b/multimodal/websites/docs/src/components/NotFoundLayout.tsx
@@ -1,15 +1,9 @@
-import { useI18n } from 'rspress/runtime';
 import { ActionCard } from './ActionCard';
-import { useLocation } from 'rspress/runtime';
-import { DYNAMIC_ROUTE } from '../shared/types';
+
+export const isInSSR = () => process.env.__SSR__;
 
 export function NotFoundLayout() {
-  const location = useLocation();
-  const t = useI18n<typeof import('i18n')>();
-  if (
-    location.pathname.startsWith(DYNAMIC_ROUTE.Showcase) ||
-    location.pathname.startsWith(DYNAMIC_ROUTE.Replay)
-  ) {
+  if (isInSSR()) {
     return null;
   }
 


### PR DESCRIPTION
<!--------------------------------------------------------------------------------
    Thank you for submitting a pull request!

    We appreciate the time and effort you have invested in making these changes. Please 
    ensure that you provide enough information to allow others to review your pull request 
    effectively, so please DO NOT delete this template.

    If you're new to contributing, learn more about contributing here:
    https://github.com/bytedance/UI-TARS-desktop/blob/main/CONTRIBUTING.md.  
---------------------------------------------------------------------------------->

## Summary

https://github.com/bytedance/UI-TARS-desktop/pull/917 tries to fixes `short 404 flicking` but does not actually fix it, the root reason is that the `404.html` has static HTML content.

https://agent-tars.com/replay/navigate-to-the-document-NUk7lAfylgrmBsFLl1cxc

### Before

![short-404](https://github.com/user-attachments/assets/b1e3c0d1-2151-4a8e-a6d8-c9bcf1baabcd)

### After

![fix-404](https://github.com/user-attachments/assets/cb1a799e-bca1-4f6c-b3f6-2a5876a5e03b)




<!--------------------------------------------------------------------------------
    Can you explain the reasoning behind implementing this change?  
    What problem or issue does this pull request resolve?  

    It would be helpful to include relevant context, such as GitHub issues 
    (e.g., Close: #xxx) or related discussions.

    If updating the UI, please include a **before/after screenshot** for visibility.
    Thank you for reading. Next, start describing your Summary on the next line
    after the comment ends. 👇🏻
---------------------------------------------------------------------------------->



## Checklist  

<!--  Before submitting the pull request, ensure the following items are checked: -->

- [ ] Added or updated necessary tests (Optional).  
- [ ] Updated documentation to align with changes (Optional).  
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).  
- [x] My change does not involve the above items. 
