### PR TITLE
fix(agent-tars-web-ui): browser vision control display wrong status

### DIFF
--- a/multimodal/agent-tars-web-ui/src/standalone/workspace/utils/contentStandardizer/handlers.ts
+++ b/multimodal/agent-tars-web-ui/src/standalone/workspace/utils/contentStandardizer/handlers.ts
@@ -1,5 +1,5 @@
 import { ToolResultContentPart } from '../../types';
-import { StandardPanelContent, SearchResult } from '../../types/panelContent';
+import { StandardPanelContent, SearchResult, PanelContentSource } from '../../types/panelContent';
 import {
   isMultimodalContent,
   isSearchResults,
@@ -245,8 +245,9 @@ export function handleFileContent(
 
 export function handleBrowserControlContent(
   panelContent: StandardPanelContent,
-  source: unknown,
+  source: PanelContentSource,
 ): ToolResultContentPart[] {
+  debugger;
   const { toolCallId, arguments: toolArguments, originalContent } = panelContent;
 
   const environmentImage = Array.isArray(originalContent) ? extractImageUrl(originalContent) : null;
@@ -259,7 +260,7 @@ export function handleBrowserControlContent(
       thought: (toolArguments?.thought as string) || '',
       step: (toolArguments?.step as string) || '',
       action: (toolArguments?.action as string) || '',
-      status: isCommandResult(source) ? source.command || 'unknown' : 'unknown',
+      status: source.status,
       environmentImage,
     },
   ];

--- a/multimodal/agent-tars-web-ui/src/standalone/workspace/utils/contentStandardizer/standardizer.ts
+++ b/multimodal/agent-tars-web-ui/src/standalone/workspace/utils/contentStandardizer/standardizer.ts
@@ -52,8 +52,6 @@ export function standardizeContent(panelContent: StandardPanelContent): ToolResu
     return handleImageContent(source, title);
   }
 
-  console.log('type', type);
-
   // Handle different content types
   switch (type) {
     case 'image':


### PR DESCRIPTION
<!--------------------------------------------------------------------------------
    Thank you for submitting a pull request!

    We appreciate the time and effort you have invested in making these changes. Please 
    ensure that you provide enough information to allow others to review your pull request 
    effectively, so please DO NOT delete this template.

    If you're new to contributing, learn more about contributing here:
    https://github.com/bytedance/UI-TARS-desktop/blob/main/CONTRIBUTING.md.  
---------------------------------------------------------------------------------->

## Summary

Workspace panel displays wrong status event if this tool call is successful:

<img width="1220" height="1098" alt="image" src="https://github.com/user-attachments/assets/bf24e12b-7f10-4231-91a7-bae03c614fa3" />


<!--------------------------------------------------------------------------------
    Can you explain the reasoning behind implementing this change?  
    What problem or issue does this pull request resolve?  

    It would be helpful to include relevant context, such as GitHub issues 
    (e.g., Close: #xxx) or related discussions.

    If updating the UI, please include a **before/after screenshot** for visibility.
    Thank you for reading. Next, start describing your Summary on the next line
    after the comment ends. 👇🏻
---------------------------------------------------------------------------------->



## Checklist  

<!--  Before submitting the pull request, ensure the following items are checked: -->

- [ ] Added or updated necessary tests (Optional).  
- [ ] Updated documentation to align with changes (Optional).  
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).  
- [x] My change does not involve the above items. 
