### PR TITLE
fix(agent-tars-web-ui): do not render system error

### DIFF
--- a/multimodal/agent-tars-web-ui/src/common/state/actions/eventProcessor.ts
+++ b/multimodal/agent-tars-web-ui/src/common/state/actions/eventProcessor.ts
@@ -461,13 +461,16 @@ function handleToolResult(set: Setter, sessionId: string, event: AgentEventStrea
 function handleSystemMessage(
   set: Setter,
   sessionId: string,
-  event: AgentEventStream.Event & { message: string; level?: string },
+  event: AgentEventStream.SystemEvent,
 ): void {
   const systemMessage: Message = {
-    id: uuidv4(),
+    id: event.id || uuidv4(),
     role: 'system',
     content: event.message,
     timestamp: event.timestamp || Date.now(),
+    // Add system-specific properties for enhanced error handling
+    level: event.level,
+    details: event.details,
   };
 
   set(messagesAtom, (prev: Record<string, Message[]>) => {

--- a/multimodal/agent-tars-web-ui/src/common/types/index.ts
+++ b/multimodal/agent-tars-web-ui/src/common/types/index.ts
@@ -54,6 +54,10 @@ export interface Message {
   description?: string; // Added for environment inputs
   isDeepResearch?: boolean; // Added for final answer events
   title?: string; // Added for research report title
+
+  // System message specific properties
+  level?: 'info' | 'warning' | 'error';
+  details?: Record<string, any>;
 }
 
 /**

--- a/multimodal/agent-tars-web-ui/src/standalone/chat/Message/Message.css
+++ b/multimodal/agent-tars-web-ui/src/standalone/chat/Message/Message.css
@@ -87,7 +87,7 @@
 }
 
 .message-system {
-  @apply text-gray-700 dark:text-gray-300 max-w-full mx-auto;
+  @apply px-2 text-gray-700 dark:text-gray-300 max-w-full mx-auto;
 }
 
 .message-gap {

--- a/multimodal/agent-tars-web-ui/src/standalone/chat/Message/Message.css
+++ b/multimodal/agent-tars-web-ui/src/standalone/chat/Message/Message.css
@@ -87,7 +87,7 @@
 }
 
 .message-system {
-  @apply bg-gray-50 dark:bg-gray-800/40 text-gray-700 dark:text-gray-300 max-w-full mx-auto;
+  @apply text-gray-700 dark:text-gray-300 max-w-full mx-auto;
 }
 
 .message-gap {

--- a/multimodal/agent-tars-web-ui/src/standalone/chat/Message/components/MessageGroup.tsx
+++ b/multimodal/agent-tars-web-ui/src/standalone/chat/Message/components/MessageGroup.tsx
@@ -32,7 +32,7 @@ export const MessageGroup: React.FC<MessageGroupProps> = ({ messages, isThinking
   // 获取用户消息和助手消息
   const userMessages = filteredMessages.filter((msg) => msg.role === 'user');
   const assistantMessages = filteredMessages.filter(
-    (msg) => msg.role === 'assistant' || msg.role === 'final_answer',
+    (msg) => msg.role === 'assistant' || msg.role === 'final_answer' || msg.role === 'system',
   );
 
   // 获取最后一条助手消息（用于时间戳和复制功能）

--- a/multimodal/agent-tars-web-ui/src/standalone/chat/Message/components/SystemMessage.tsx
+++ b/multimodal/agent-tars-web-ui/src/standalone/chat/Message/components/SystemMessage.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { motion } from 'framer-motion';
-import { FiInfo, FiAlertTriangle, FiAlertCircle, FiRefreshCw, FiExternalLink } from 'react-icons/fi';
+import { FiInfo, FiAlertTriangle, FiAlertCircle, FiChevronDown, FiChevronUp } from 'react-icons/fi';
 
 interface SystemMessageProps {
   content: string;
@@ -9,46 +8,50 @@ interface SystemMessageProps {
   timestamp?: number;
 }
 
-/**
- * Enhanced SystemMessage Component - displays system messages with appropriate styling based on severity
- * 
- * Design principles:
- * - Visual differentiation based on message level (info, warning, error)
- * - Clear iconography and color coding
- * - Expandable details for technical information
- * - Action buttons for common error scenarios
- */
-export const SystemMessage: React.FC<SystemMessageProps> = ({ 
-  content, 
+export const SystemMessage: React.FC<SystemMessageProps> = ({
+  content,
   level = 'info',
   details,
-  timestamp 
+  timestamp,
 }) => {
-  const [showDetails, setShowDetails] = React.useState(false);
-
-  // Get styling based on error level
+  const [showDetails, setShowDetails] = React.useState(level === 'error');
   const getMessageStyling = () => {
     switch (level) {
       case 'error':
         return {
-          container: 'bg-red-50/80 dark:bg-red-900/20 border-red-200/60 dark:border-red-800/40',
-          text: 'text-red-800 dark:text-red-200',
-          icon: 'text-red-600 dark:text-red-400',
-          IconComponent: FiAlertCircle
+          container: 'bg-red-50 dark:bg-red-950/50 border-red-200/60 dark:border-red-800/40',
+          icon: 'text-red-600 dark:text-red-400 bg-red-100 dark:bg-red-900/50',
+          title: 'text-red-900 dark:text-red-100',
+          content: 'text-red-800 dark:text-red-200',
+          button:
+            'text-red-700 dark:text-red-300 hover:text-red-900 dark:hover:text-red-100 hover:bg-red-100/50 dark:hover:bg-red-900/30',
+          detailsBg: 'bg-red-100/50 dark:bg-red-900/20 border-red-200/40 dark:border-red-800/30',
+          IconComponent: FiAlertCircle,
         };
       case 'warning':
         return {
-          container: 'bg-amber-50/80 dark:bg-amber-900/20 border-amber-200/60 dark:border-amber-800/40',
-          text: 'text-amber-800 dark:text-amber-200',
-          icon: 'text-amber-600 dark:text-amber-400',
-          IconComponent: FiAlertTriangle
+          container:
+            'bg-amber-50 dark:bg-amber-950/50 border-amber-200/60 dark:border-amber-800/40',
+          icon: 'text-amber-600 dark:text-amber-400 bg-amber-100 dark:bg-amber-900/50',
+          title: 'text-amber-900 dark:text-amber-100',
+          content: 'text-amber-800 dark:text-amber-200',
+          button:
+            'text-amber-700 dark:text-amber-300 hover:text-amber-900 dark:hover:text-amber-100 hover:bg-amber-100/50 dark:hover:bg-amber-900/30',
+          detailsBg:
+            'bg-amber-100/50 dark:bg-amber-900/20 border-amber-200/40 dark:border-amber-800/30',
+          IconComponent: FiAlertTriangle,
         };
       default:
         return {
-          container: 'bg-blue-50/80 dark:bg-blue-900/20 border-blue-200/60 dark:border-blue-800/40',
-          text: 'text-blue-800 dark:text-blue-200',
-          icon: 'text-blue-600 dark:text-blue-400',
-          IconComponent: FiInfo
+          container: 'bg-blue-50 dark:bg-blue-950/50 border-blue-200/60 dark:border-blue-800/40',
+          icon: 'text-blue-600 dark:text-blue-400 bg-blue-100 dark:bg-blue-900/50',
+          title: 'text-blue-900 dark:text-blue-100',
+          content: 'text-blue-800 dark:text-blue-200',
+          button:
+            'text-blue-700 dark:text-blue-300 hover:text-blue-900 dark:hover:text-blue-100 hover:bg-blue-100/50 dark:hover:bg-blue-900/30',
+          detailsBg:
+            'bg-blue-100/50 dark:bg-blue-900/20 border-blue-200/40 dark:border-blue-800/30',
+          IconComponent: FiInfo,
         };
     }
   };
@@ -56,109 +59,68 @@ export const SystemMessage: React.FC<SystemMessageProps> = ({
   const styling = getMessageStyling();
   const { IconComponent } = styling;
 
-  // Parse common error types for better UX
-  const getErrorActions = () => {
-    if (level !== 'error' || !details?.error) return null;
-
-    const errorMsg = details.error.toLowerCase();
-    
-    // API Rate limit errors
-    if (errorMsg.includes('rate limit') || errorMsg.includes('rpm') || errorMsg.includes('429')) {
-      return (
-        <div className="mt-3 pt-3 border-t border-current/10">
-          <div className="flex items-center gap-2 text-xs">
-            <span className="opacity-75">Suggestion:</span>
-            <span>Wait a moment before trying again</span>
-          </div>
-        </div>
-      );
-    }
-
-    // Network/Connection errors
-    if (errorMsg.includes('network') || errorMsg.includes('connection') || errorMsg.includes('timeout')) {
-      return (
-        <div className="mt-3 pt-3 border-t border-current/10">
-          <motion.button
-            whileHover={{ scale: 1.02 }}
-            whileTap={{ scale: 0.98 }}
-            className="flex items-center gap-1.5 text-xs px-2 py-1 rounded-lg bg-current/10 hover:bg-current/20 transition-colors"
-            onClick={() => window.location.reload()}
-          >
-            <FiRefreshCw size={12} />
-            Refresh Page
-          </motion.button>
-        </div>
-      );
-    }
-
-    return null;
-  };
-
-  // Format error message for better readability
-  const formatErrorMessage = (message: string) => {
-    // Extract readable parts from technical error messages
-    if (message.includes('429') && message.includes('RPM')) {
-      const match = message.match(/max RPM: (\d+)/);
-      const rpm = match ? match[1] : 'limit';
-      return `API rate limit exceeded (${rpm} requests/minute). Please wait before trying again.`;
-    }
-    
-    if (message.includes('Error:') && message.length > 100) {
-      // For long error messages, show a cleaner version
-      const cleanMsg = message.replace(/^Error:\s*/, '').split('\n')[0];
-      return cleanMsg.length > 80 ? cleanMsg.substring(0, 77) + '...' : cleanMsg;
-    }
-    
-    return message;
-  };
-
   return (
-    <motion.div
-      initial={{ opacity: 0, y: 10 }}
-      animate={{ opacity: 1, y: 0 }}
-      className={`rounded-xl border p-4 mx-auto max-w-2xl ${styling.container}`}
-    >
-      <div className="flex items-start gap-3">
-        <div className={`mt-0.5 ${styling.icon}`}>
-          <IconComponent size={18} />
-        </div>
-        
-        <div className="flex-1 min-w-0">
-          <div className={`text-sm font-medium leading-relaxed ${styling.text}`}>
-            {formatErrorMessage(content)}
+    <div className="w-full max-w-full">
+      <div className={`w-full border rounded-xl ${styling.container} overflow-hidden`}>
+        <div className="p-4">
+          <div className="flex items-start gap-4">
+            {/* Icon */}
+            <div
+              className={`w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 ${styling.icon}`}
+            >
+              <IconComponent size={18} />
+            </div>
+
+            {/* Content */}
+            <div className="flex-1 min-w-0">
+              <div className={`text-sm font-semibold leading-relaxed mb-1 ${styling.title}`}>
+                {level === 'error' ? 'Error' : level === 'warning' ? 'Warning' : 'Information'}
+              </div>
+              <div className={`text-sm leading-relaxed ${styling.content}`}>{content}</div>
+            </div>
           </div>
-          
-          {/* Error Actions */}
-          {getErrorActions()}
-          
+
           {/* Technical Details Toggle */}
           {details && Object.keys(details).length > 0 && (
-            <div className="mt-3">
-              <motion.button
-                whileHover={{ x: 2 }}
+            <div className="mt-4 pt-4 border-t border-gray-200/30 dark:border-gray-700/20">
+              <button
                 onClick={() => setShowDetails(!showDetails)}
-                className={`flex items-center gap-1.5 text-xs opacity-75 hover:opacity-100 transition-opacity ${styling.text}`}
+                className={`inline-flex items-center gap-2 px-3 py-2 text-sm font-medium rounded-lg transition-colors ${styling.button}`}
               >
-                <FiExternalLink size={12} />
-                {showDetails ? 'Hide' : 'Show'} technical details
-              </motion.button>
-              
-              {showDetails && (
-                <motion.div
-                  initial={{ height: 0, opacity: 0 }}
-                  animate={{ height: 'auto', opacity: 1 }}
-                  exit={{ height: 0, opacity: 0 }}
-                  className="mt-2 p-3 rounded-lg bg-current/5 border border-current/10 overflow-hidden"
-                >
-                  <pre className={`text-xs font-mono whitespace-pre-wrap break-all ${styling.text} opacity-80`}>
-                    {JSON.stringify(details, null, 2)}
-                  </pre>
-                </motion.div>
-              )}
+                {showDetails ? (
+                  <>
+                    <FiChevronUp size={16} />
+                    Hide technical details
+                  </>
+                ) : (
+                  <>
+                    <FiChevronDown size={16} />
+                    Show technical details
+                  </>
+                )}
+              </button>
             </div>
           )}
         </div>
+
+        {/* Technical Details - Full Width */}
+        {showDetails && details && Object.keys(details).length > 0 && (
+          <div className="w-full">
+            <div
+              className={`px-4 py-3 border-t border-gray-200/30 dark:border-gray-700/20 ${styling.detailsBg}`}
+            >
+              <div className="text-xs font-medium text-gray-700 dark:text-gray-300 mb-2">
+                Technical Details
+              </div>
+              <div className="bg-gray-900 dark:bg-gray-950 rounded-lg p-3 overflow-x-auto">
+                <pre className="text-xs font-mono text-green-400 dark:text-green-300 whitespace-pre-wrap break-words">
+                  {JSON.stringify(details, null, 2)}
+                </pre>
+              </div>
+            </div>
+          </div>
+        )}
       </div>
-    </motion.div>
+    </div>
   );
 };

--- a/multimodal/agent-tars-web-ui/src/standalone/chat/Message/components/SystemMessage.tsx
+++ b/multimodal/agent-tars-web-ui/src/standalone/chat/Message/components/SystemMessage.tsx
@@ -1,20 +1,164 @@
 import React from 'react';
-import { FiInfo } from 'react-icons/fi';
+import { motion } from 'framer-motion';
+import { FiInfo, FiAlertTriangle, FiAlertCircle, FiRefreshCw, FiExternalLink } from 'react-icons/fi';
 
 interface SystemMessageProps {
   content: string;
+  level?: 'info' | 'warning' | 'error';
+  details?: Record<string, any>;
+  timestamp?: number;
 }
 
 /**
- * Component for displaying system messages
+ * Enhanced SystemMessage Component - displays system messages with appropriate styling based on severity
  * 
  * Design principles:
- * - Simple, informational styling
- * - Clear visual indication of system-generated content
+ * - Visual differentiation based on message level (info, warning, error)
+ * - Clear iconography and color coding
+ * - Expandable details for technical information
+ * - Action buttons for common error scenarios
  */
-export const SystemMessage: React.FC<SystemMessageProps> = ({ content }) => (
-  <div className="flex items-center gap-2 text-sm">
-    <FiInfo className="shrink-0" />
-    <span>{content}</span>
-  </div>
-);
+export const SystemMessage: React.FC<SystemMessageProps> = ({ 
+  content, 
+  level = 'info',
+  details,
+  timestamp 
+}) => {
+  const [showDetails, setShowDetails] = React.useState(false);
+
+  // Get styling based on error level
+  const getMessageStyling = () => {
+    switch (level) {
+      case 'error':
+        return {
+          container: 'bg-red-50/80 dark:bg-red-900/20 border-red-200/60 dark:border-red-800/40',
+          text: 'text-red-800 dark:text-red-200',
+          icon: 'text-red-600 dark:text-red-400',
+          IconComponent: FiAlertCircle
+        };
+      case 'warning':
+        return {
+          container: 'bg-amber-50/80 dark:bg-amber-900/20 border-amber-200/60 dark:border-amber-800/40',
+          text: 'text-amber-800 dark:text-amber-200',
+          icon: 'text-amber-600 dark:text-amber-400',
+          IconComponent: FiAlertTriangle
+        };
+      default:
+        return {
+          container: 'bg-blue-50/80 dark:bg-blue-900/20 border-blue-200/60 dark:border-blue-800/40',
+          text: 'text-blue-800 dark:text-blue-200',
+          icon: 'text-blue-600 dark:text-blue-400',
+          IconComponent: FiInfo
+        };
+    }
+  };
+
+  const styling = getMessageStyling();
+  const { IconComponent } = styling;
+
+  // Parse common error types for better UX
+  const getErrorActions = () => {
+    if (level !== 'error' || !details?.error) return null;
+
+    const errorMsg = details.error.toLowerCase();
+    
+    // API Rate limit errors
+    if (errorMsg.includes('rate limit') || errorMsg.includes('rpm') || errorMsg.includes('429')) {
+      return (
+        <div className="mt-3 pt-3 border-t border-current/10">
+          <div className="flex items-center gap-2 text-xs">
+            <span className="opacity-75">Suggestion:</span>
+            <span>Wait a moment before trying again</span>
+          </div>
+        </div>
+      );
+    }
+
+    // Network/Connection errors
+    if (errorMsg.includes('network') || errorMsg.includes('connection') || errorMsg.includes('timeout')) {
+      return (
+        <div className="mt-3 pt-3 border-t border-current/10">
+          <motion.button
+            whileHover={{ scale: 1.02 }}
+            whileTap={{ scale: 0.98 }}
+            className="flex items-center gap-1.5 text-xs px-2 py-1 rounded-lg bg-current/10 hover:bg-current/20 transition-colors"
+            onClick={() => window.location.reload()}
+          >
+            <FiRefreshCw size={12} />
+            Refresh Page
+          </motion.button>
+        </div>
+      );
+    }
+
+    return null;
+  };
+
+  // Format error message for better readability
+  const formatErrorMessage = (message: string) => {
+    // Extract readable parts from technical error messages
+    if (message.includes('429') && message.includes('RPM')) {
+      const match = message.match(/max RPM: (\d+)/);
+      const rpm = match ? match[1] : 'limit';
+      return `API rate limit exceeded (${rpm} requests/minute). Please wait before trying again.`;
+    }
+    
+    if (message.includes('Error:') && message.length > 100) {
+      // For long error messages, show a cleaner version
+      const cleanMsg = message.replace(/^Error:\s*/, '').split('\n')[0];
+      return cleanMsg.length > 80 ? cleanMsg.substring(0, 77) + '...' : cleanMsg;
+    }
+    
+    return message;
+  };
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 10 }}
+      animate={{ opacity: 1, y: 0 }}
+      className={`rounded-xl border p-4 mx-auto max-w-2xl ${styling.container}`}
+    >
+      <div className="flex items-start gap-3">
+        <div className={`mt-0.5 ${styling.icon}`}>
+          <IconComponent size={18} />
+        </div>
+        
+        <div className="flex-1 min-w-0">
+          <div className={`text-sm font-medium leading-relaxed ${styling.text}`}>
+            {formatErrorMessage(content)}
+          </div>
+          
+          {/* Error Actions */}
+          {getErrorActions()}
+          
+          {/* Technical Details Toggle */}
+          {details && Object.keys(details).length > 0 && (
+            <div className="mt-3">
+              <motion.button
+                whileHover={{ x: 2 }}
+                onClick={() => setShowDetails(!showDetails)}
+                className={`flex items-center gap-1.5 text-xs opacity-75 hover:opacity-100 transition-opacity ${styling.text}`}
+              >
+                <FiExternalLink size={12} />
+                {showDetails ? 'Hide' : 'Show'} technical details
+              </motion.button>
+              
+              {showDetails && (
+                <motion.div
+                  initial={{ height: 0, opacity: 0 }}
+                  animate={{ height: 'auto', opacity: 1 }}
+                  exit={{ height: 0, opacity: 0 }}
+                  className="mt-2 p-3 rounded-lg bg-current/5 border border-current/10 overflow-hidden"
+                >
+                  <pre className={`text-xs font-mono whitespace-pre-wrap break-all ${styling.text} opacity-80`}>
+                    {JSON.stringify(details, null, 2)}
+                  </pre>
+                </motion.div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </motion.div>
+  );
+};

--- a/multimodal/agent-tars-web-ui/src/standalone/chat/Message/components/SystemMessage.tsx
+++ b/multimodal/agent-tars-web-ui/src/standalone/chat/Message/components/SystemMessage.tsx
@@ -14,7 +14,6 @@ export const SystemMessage: React.FC<SystemMessageProps> = ({
   details,
   timestamp,
 }) => {
-  const [showDetails, setShowDetails] = React.useState(level === 'error');
   const getMessageStyling = () => {
     switch (level) {
       case 'error':
@@ -79,47 +78,7 @@ export const SystemMessage: React.FC<SystemMessageProps> = ({
               <div className={`text-sm leading-relaxed ${styling.content}`}>{content}</div>
             </div>
           </div>
-
-          {/* Technical Details Toggle */}
-          {details && Object.keys(details).length > 0 && (
-            <div className="mt-4 pt-4 border-t border-gray-200/30 dark:border-gray-700/20">
-              <button
-                onClick={() => setShowDetails(!showDetails)}
-                className={`inline-flex items-center gap-2 px-3 py-2 text-sm font-medium rounded-lg transition-colors ${styling.button}`}
-              >
-                {showDetails ? (
-                  <>
-                    <FiChevronUp size={16} />
-                    Hide technical details
-                  </>
-                ) : (
-                  <>
-                    <FiChevronDown size={16} />
-                    Show technical details
-                  </>
-                )}
-              </button>
-            </div>
-          )}
         </div>
-
-        {/* Technical Details - Full Width */}
-        {showDetails && details && Object.keys(details).length > 0 && (
-          <div className="w-full">
-            <div
-              className={`px-4 py-3 border-t border-gray-200/30 dark:border-gray-700/20 ${styling.detailsBg}`}
-            >
-              <div className="text-xs font-medium text-gray-700 dark:text-gray-300 mb-2">
-                Technical Details
-              </div>
-              <div className="bg-gray-900 dark:bg-gray-950 rounded-lg p-3 overflow-x-auto">
-                <pre className="text-xs font-mono text-green-400 dark:text-green-300 whitespace-pre-wrap break-words">
-                  {JSON.stringify(details, null, 2)}
-                </pre>
-              </div>
-            </div>
-          </div>
-        )}
       </div>
     </div>
   );

--- a/multimodal/agent-tars-web-ui/src/standalone/chat/Message/index.tsx
+++ b/multimodal/agent-tars-web-ui/src/standalone/chat/Message/index.tsx
@@ -208,9 +208,13 @@ export const Message: React.FC<MessageProps> = ({
       className={`message-container ${message.role === 'user' ? 'message-container-user' : 'message-container-assistant'}`}
     >
       <div className={`message-bubble ${getMessageBubbleClasses()}`}>
-        {/* Role-based content */}
         {message.role === 'system' ? (
-          <SystemMessage content={message.content as string} />
+          <SystemMessage
+            content={message.content as string}
+            level={message.level}
+            details={message.details}
+            timestamp={message.timestamp}
+          />
         ) : (
           <>
             <div className={getProseClasses()}>{renderContent()}</div>


### PR DESCRIPTION
<!--------------------------------------------------------------------------------
    Thank you for submitting a pull request!

    We appreciate the time and effort you have invested in making these changes. Please 
    ensure that you provide enough information to allow others to review your pull request 
    effectively, so please DO NOT delete this template.

    If you're new to contributing, learn more about contributing here:
    https://github.com/bytedance/UI-TARS-desktop/blob/main/CONTRIBUTING.md.  
---------------------------------------------------------------------------------->

## Summary

In message group processing stage, we only filtered `user` and `assistant` message, this pull request fix this issue and refine the system error UI rendering:

<img width="1792" height="1282" alt="image" src="https://github.com/user-attachments/assets/52358bb5-133d-4a25-a57b-1b53a1ff5a53" />
<img width="1676" height="352" alt="image" src="https://github.com/user-attachments/assets/4fda3791-1b74-4505-86af-02bce2e336c1" />


<!--------------------------------------------------------------------------------
    Can you explain the reasoning behind implementing this change?  
    What problem or issue does this pull request resolve?  

    It would be helpful to include relevant context, such as GitHub issues 
    (e.g., Close: #xxx) or related discussions.

    If updating the UI, please include a **before/after screenshot** for visibility.
    Thank you for reading. Next, start describing your Summary on the next line
    after the comment ends. 👇🏻
---------------------------------------------------------------------------------->



## Checklist  

<!--  Before submitting the pull request, ensure the following items are checked: -->

- [ ] Added or updated necessary tests (Optional).  
- [ ] Updated documentation to align with changes (Optional).  
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).  
- [x] My change does not involve the above items. 
