### PR TITLE
fix(browser): remove disable http2

### DIFF
--- a/packages/agent-infra/browser/src/local-browser.ts
+++ b/packages/agent-infra/browser/src/local-browser.ts
@@ -47,7 +47,6 @@ export class LocalBrowser extends BaseBrowser {
         '--no-sandbox',
         '--mute-audio',
         '--disable-gpu',
-        '--disable-http2',
         '--disable-blink-features=AutomationControlled',
         '--disable-infobars',
         '--disable-background-timer-throttling',


### PR DESCRIPTION
`--disable-http2` will cause GraphQL to fail to connect!

| args | screenshot |
| ------ | ------ |
| `--disable-http2` | <img width="929" height="443" alt="image" src="https://github.com/user-attachments/assets/b9fecb99-6908-4feb-b911-f37934289815" /> |
| normal | <img width="986" height="261" alt="image" src="https://github.com/user-attachments/assets/e7586875-b511-477d-8ca7-080144fa097d" /> | 