### PR TITLE
fix(agent-tars): all file and command tools should respect workspace

### DIFF
--- a/multimodal/agent-tars/src/agent-tars.ts
+++ b/multimodal/agent-tars/src/agent-tars.ts
@@ -39,6 +39,11 @@ import * as browserModule from '@agent-infra/mcp-server-browser/dist/server.cjs'
 import * as filesystemModule from '@agent-infra/mcp-server-filesystem';
 import * as commandsModule from '@agent-infra/mcp-server-commands';
 
+import {
+  WorkspacePathResolver,
+  DEFAULT_PATH_PARAMETER_MAPPING,
+} from './shared/workspace-path-resolver';
+
 /**
  * A Agent TARS that uses in-memory MCP tool call
  * for built-in MCP Servers.
@@ -57,6 +62,9 @@ export class AgentTARS<T extends AgentTARSOptions = AgentTARSOptions> extends MC
 
   // Message history dumper for experimental dump feature
   private messageHistoryDumper?: MessageHistoryDumper;
+
+  // Add workspace path resolver
+  private workspacePathResolver: WorkspacePathResolver;
 
   constructor(options: T) {
     // Apply default config using the new utility function
@@ -160,6 +168,11 @@ Current Working Directory: ${workingDirectory}
       if (event.type === 'tool_result' && event.name === 'browser_navigate') {
         event._extra = this.browserState;
       }
+    });
+
+    // Initialize workspace path resolver
+    this.workspacePathResolver = new WorkspacePathResolver({
+      workingDirectory: this.workingDirectory,
     });
   }
 
@@ -468,7 +481,8 @@ Current Working Directory: ${workingDirectory}
    * Lazy browser initialization using on-demand pattern
    *
    * This hook intercepts tool calls and lazily initializes the browser only when
-   * it's first needed by a browser-related tool.
+   * it's first needed by a browser-related tool. It also resolves workspace paths
+   * for tools that work with file system operations.
    */
   override async onBeforeToolCall(
     id: string,
@@ -503,26 +517,9 @@ Current Working Directory: ${workingDirectory}
       }
     }
 
-    /**
-     * #815 `write_file` should respect workspace
-     */
-    if (toolCall.name === 'write_file') {
-      if (
-        typeof args === 'object' &&
-        typeof args.path === 'string' &&
-        !path.isAbsolute(args.path)
-      ) {
-        args.path = path.resolve(this.workingDirectory, args.path);
-      }
-    }
-
-    /**
-     * #817 `run_command` do not respect workspace
-     */
-    if (toolCall.name === 'run_command' || toolCall.name === 'run_script') {
-      if (typeof args === 'object') {
-        args.cwd = this.workingDirectory;
-      }
+    // Resolve workspace paths for all tools that have path parameters
+    if (this.workspacePathResolver.hasPathParameters(toolCall.name)) {
+      return this.workspacePathResolver.resolveToolPaths(toolCall.name, args);
     }
 
     return args;

--- a/multimodal/agent-tars/src/agent-tars.ts
+++ b/multimodal/agent-tars/src/agent-tars.ts
@@ -39,10 +39,7 @@ import * as browserModule from '@agent-infra/mcp-server-browser/dist/server.cjs'
 import * as filesystemModule from '@agent-infra/mcp-server-filesystem';
 import * as commandsModule from '@agent-infra/mcp-server-commands';
 
-import {
-  WorkspacePathResolver,
-  DEFAULT_PATH_PARAMETER_MAPPING,
-} from './shared/workspace-path-resolver';
+import { WorkspacePathResolver } from './shared/workspace-path-resolver';
 
 /**
  * A Agent TARS that uses in-memory MCP tool call
@@ -481,6 +478,7 @@ Current Working Directory: ${workingDirectory}
    * Lazy browser initialization using on-demand pattern
    *
    * This hook intercepts tool calls and lazily initializes the browser only when
+
    * it's first needed by a browser-related tool. It also resolves workspace paths
    * for tools that work with file system operations.
    */

--- a/multimodal/agent-tars/src/shared/workspace-path-resolver.ts
+++ b/multimodal/agent-tars/src/shared/workspace-path-resolver.ts
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import path from 'path';
+
+/**
+ * Configuration for workspace path resolution
+ */
+export interface WorkspacePathResolverConfig {
+  /** The working directory to resolve relative paths against */
+  workingDirectory: string;
+}
+
+/**
+ * Tool call arguments that may contain path parameters
+ */
+export interface ToolCallArgs {
+  [key: string]: unknown;
+  path?: string;
+  directory?: string;
+  cwd?: string;
+}
+
+/**
+ * Mapping of tool names to their path parameter names
+ */
+export interface PathParameterMapping {
+  [toolName: string]: string[];
+}
+
+/**
+ * Default mapping of tool names to their path parameter names
+ */
+export const DEFAULT_PATH_PARAMETER_MAPPING: PathParameterMapping = {
+  // Filesystem tools
+  write_file: ['path'],
+  read_file: ['path'],
+  edit_file: ['path'],
+  create_directory: ['path'],
+  list_directory: ['path'],
+  delete_file: ['path'],
+  delete_directory: ['path'],
+  move_file: ['source', 'destination'],
+  copy_file: ['source', 'destination'],
+  get_file_info: ['path'],
+
+  // Command tools
+  run_command: ['cwd'],
+  run_script: ['cwd'],
+};
+
+/**
+ * WorkspacePathResolver - Resolves relative paths to absolute paths within workspace context
+ *
+ * This utility class provides a centralized way to handle path resolution for tools
+ * that operate on files and directories, ensuring they respect the configured workspace.
+ *
+ * Key features:
+ * - Converts relative paths to absolute paths within workspace
+ * - Supports configurable path parameter mappings for different tools
+ * - Preserves absolute paths that are already correctly specified
+ * - Provides type-safe path resolution with proper error handling
+ */
+export class WorkspacePathResolver {
+  private readonly config: WorkspacePathResolverConfig;
+  private readonly pathMapping: PathParameterMapping;
+
+  /**
+   * Create a new workspace path resolver
+   *
+   * @param config - Configuration for path resolution
+   * @param pathMapping - Custom mapping of tool names to path parameters (optional)
+   */
+  constructor(
+    config: WorkspacePathResolverConfig,
+    pathMapping: PathParameterMapping = DEFAULT_PATH_PARAMETER_MAPPING,
+  ) {
+    this.config = config;
+    this.pathMapping = pathMapping;
+  }
+
+  /**
+   * Resolve path parameters in tool call arguments based on workspace context
+   *
+   * @param toolName - Name of the tool being called
+   * @param args - Tool call arguments that may contain path parameters
+   * @returns Modified arguments with resolved paths
+   */
+  resolveToolPaths(toolName: string, args: ToolCallArgs): ToolCallArgs {
+    // Get path parameter names for this tool
+    const pathParams = this.pathMapping[toolName];
+
+    if (!pathParams || pathParams.length === 0) {
+      // No path parameters defined for this tool, return args as-is
+      return args;
+    }
+
+    // Create a shallow copy to avoid mutating the original args
+    const resolvedArgs = { ...args };
+
+    // Process each path parameter
+    for (const paramName of pathParams) {
+      const pathValue = resolvedArgs[paramName];
+
+      if (typeof pathValue === 'string' && pathValue.trim() !== '') {
+        resolvedArgs[paramName] = this.resolvePath(pathValue);
+      }
+    }
+
+    return resolvedArgs;
+  }
+
+  /**
+   * Resolve a single path relative to the workspace directory
+   *
+   * @param inputPath - The path to resolve
+   * @returns Absolute path resolved within workspace context
+   */
+  private resolvePath(inputPath: string): string {
+    // If already absolute, return as-is
+    if (path.isAbsolute(inputPath)) {
+      return inputPath;
+    }
+
+    // Resolve relative path against workspace directory
+    return path.resolve(this.config.workingDirectory, inputPath);
+  }
+
+  /**
+   * Check if a tool has path parameters that can be resolved
+   *
+   * @param toolName - Name of the tool to check
+   * @returns True if the tool has resolvable path parameters
+   */
+  hasPathParameters(toolName: string): boolean {
+    const pathParams = this.pathMapping[toolName];
+    return pathParams !== undefined && pathParams.length > 0;
+  }
+
+  /**
+   * Get the list of path parameter names for a specific tool
+   *
+   * @param toolName - Name of the tool
+   * @returns Array of path parameter names, or empty array if none
+   */
+  getPathParameters(toolName: string): string[] {
+    return this.pathMapping[toolName] || [];
+  }
+
+  /**
+   * Get the current working directory
+   *
+   * @returns The configured working directory
+   */
+  getWorkingDirectory(): string {
+    return this.config.workingDirectory;
+  }
+
+  /**
+   * Update the path parameter mapping for additional tools
+   *
+   * @param additionalMapping - Additional tool-to-path-parameters mapping
+   */
+  addPathMapping(additionalMapping: PathParameterMapping): void {
+    Object.assign(this.pathMapping, additionalMapping);
+  }
+}

--- a/multimodal/agent-tars/src/shared/workspace-path-resolver.ts
+++ b/multimodal/agent-tars/src/shared/workspace-path-resolver.ts
@@ -34,25 +34,33 @@ export interface PathParameterMapping {
 }
 
 /**
+ * Create a copy of the default path parameter mapping
+ * Avoid state pollution between multiple instances
+ */
+function createDefaultPathMapping(): PathParameterMapping {
+  return {
+    // Filesystem tools
+    write_file: ['path'],
+    read_file: ['path'],
+    read_multiple_files: ['paths'],
+    edit_file: ['path'],
+    create_directory: ['path'],
+    list_directory: ['path'],
+    directory_tree: ['path'],
+    move_file: ['source', 'destination'],
+    search_files: ['path'],
+    get_file_info: ['path'],
+
+    // Command tools
+    run_command: ['cwd'],
+    run_script: ['cwd'],
+  };
+}
+
+/**
  * Default mapping of tool names to their path parameter names
  */
-export const DEFAULT_PATH_PARAMETER_MAPPING: PathParameterMapping = {
-  // Filesystem tools
-  write_file: ['path'],
-  read_file: ['path'],
-  read_multiple_files: ['paths'],
-  edit_file: ['path'],
-  create_directory: ['path'],
-  list_directory: ['path'],
-  directory_tree: ['path'],
-  move_file: ['source', 'destination'],
-  search_files: ['path'],
-  get_file_info: ['path'],
-
-  // Command tools
-  run_command: ['cwd'],
-  run_script: ['cwd'],
-};
+export const DEFAULT_PATH_PARAMETER_MAPPING: PathParameterMapping = createDefaultPathMapping();
 
 /**
  * WorkspacePathResolver - Resolves relative paths to absolute paths within workspace context
@@ -78,10 +86,11 @@ export class WorkspacePathResolver {
    */
   constructor(
     config: WorkspacePathResolverConfig,
-    pathMapping: PathParameterMapping = DEFAULT_PATH_PARAMETER_MAPPING,
+
+    pathMapping?: PathParameterMapping,
   ) {
     this.config = config;
-    this.pathMapping = pathMapping;
+    this.pathMapping = pathMapping ? { ...pathMapping } : createDefaultPathMapping();
   }
 
   /**

--- a/multimodal/agent-tars/tests/shared/workspace-path-resolver.test.ts
+++ b/multimodal/agent-tars/tests/shared/workspace-path-resolver.test.ts
@@ -98,7 +98,7 @@ describe('WorkspacePathResolver', () => {
           source: 'relative/source.ts',
           destination: absolutePath,
         };
-        const result = resolver.resolveToolPaths('copy_file', args);
+        const result = resolver.resolveToolPaths('move_file', args);
 
         expect(result.source).toBe(path.join(testWorkingDir, 'relative/source.ts'));
         expect(result.destination).toBe(absolutePath);
@@ -154,8 +154,8 @@ describe('WorkspacePathResolver', () => {
         'edit_file',
         'create_directory',
         'list_directory',
-        'delete_file',
-        'delete_directory',
+        'directory_tree',
+        'search_files',
         'get_file_info',
       ];
 
@@ -167,12 +167,15 @@ describe('WorkspacePathResolver', () => {
 
     it('should include file operation tools with multiple paths', () => {
       expect(DEFAULT_PATH_PARAMETER_MAPPING['move_file']).toEqual(['source', 'destination']);
-      expect(DEFAULT_PATH_PARAMETER_MAPPING['copy_file']).toEqual(['source', 'destination']);
     });
 
     it('should include command tools with cwd parameter', () => {
       expect(DEFAULT_PATH_PARAMETER_MAPPING['run_command']).toEqual(['cwd']);
       expect(DEFAULT_PATH_PARAMETER_MAPPING['run_script']).toEqual(['cwd']);
+    });
+
+    it('should include read_multiple_files with paths parameter', () => {
+      expect(DEFAULT_PATH_PARAMETER_MAPPING['read_multiple_files']).toEqual(['paths']);
     });
   });
 
@@ -274,6 +277,36 @@ describe('WorkspacePathResolver', () => {
 
       expect(result).not.toBe(args);
       expect(result.path).not.toBe(args.path);
+      expect(result.path).toBe(path.join(testWorkingDir, 'relative/path.ts'));
+    });
+  });
+
+  describe('Array Path Parameters', () => {
+    it('should resolve array of paths for read_multiple_files', () => {
+      const args: ToolCallArgs = {
+        paths: ['src/file1.ts', 'src/file2.ts', '/absolute/file3.ts'],
+      };
+      const result = resolver.resolveToolPaths('read_multiple_files', args);
+
+      expect(result.paths).toEqual([
+        path.join(testWorkingDir, 'src/file1.ts'),
+        path.join(testWorkingDir, 'src/file2.ts'),
+        '/absolute/file3.ts',
+      ]);
+    });
+
+    it('should handle empty or invalid paths in arrays', () => {
+      const args: ToolCallArgs = {
+        paths: ['src/file1.ts', '', '   ', 'src/file2.ts'],
+      };
+      const result = resolver.resolveToolPaths('read_multiple_files', args);
+
+      expect(result.paths).toEqual([
+        path.join(testWorkingDir, 'src/file1.ts'),
+        '',
+        '   ',
+        path.join(testWorkingDir, 'src/file2.ts'),
+      ]);
     });
   });
 });

--- a/multimodal/agent-tars/tests/shared/workspace-path-resolver.test.ts
+++ b/multimodal/agent-tars/tests/shared/workspace-path-resolver.test.ts
@@ -1,0 +1,279 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import path from 'path';
+import {
+  WorkspacePathResolver,
+  DEFAULT_PATH_PARAMETER_MAPPING,
+  type WorkspacePathResolverConfig,
+  type PathParameterMapping,
+  type ToolCallArgs,
+} from '../../src/shared/workspace-path-resolver';
+
+describe('WorkspacePathResolver', () => {
+  let resolver: WorkspacePathResolver;
+  let config: WorkspacePathResolverConfig;
+  const testWorkingDir = '/workspace/test-project';
+
+  beforeEach(() => {
+    config = { workingDirectory: testWorkingDir };
+    resolver = new WorkspacePathResolver(config);
+  });
+
+  describe('Constructor and Configuration', () => {
+    it('should initialize with default configuration', () => {
+      expect(resolver.getWorkingDirectory()).toBe(testWorkingDir);
+    });
+
+    it('should initialize with custom path mapping', () => {
+      const customMapping: PathParameterMapping = {
+        custom_tool: ['custom_path'],
+      };
+      const customResolver = new WorkspacePathResolver(config, customMapping);
+
+      expect(customResolver.hasPathParameters('custom_tool')).toBe(true);
+      expect(customResolver.getPathParameters('custom_tool')).toEqual(['custom_path']);
+    });
+
+    it('should use default path mapping when not provided', () => {
+      expect(resolver.hasPathParameters('write_file')).toBe(true);
+      expect(resolver.getPathParameters('write_file')).toEqual(['path']);
+    });
+  });
+
+  describe('Path Resolution', () => {
+    describe('Single Path Parameters', () => {
+      it('should resolve relative path to absolute path', () => {
+        const args: ToolCallArgs = { path: 'src/index.ts' };
+        const result = resolver.resolveToolPaths('write_file', args);
+
+        expect(result.path).toBe(path.join(testWorkingDir, 'src/index.ts'));
+      });
+
+      it('should preserve absolute paths unchanged', () => {
+        const absolutePath = '/absolute/path/to/file.ts';
+        const args: ToolCallArgs = { path: absolutePath };
+        const result = resolver.resolveToolPaths('write_file', args);
+
+        expect(result.path).toBe(absolutePath);
+      });
+
+      it('should handle empty or whitespace-only paths', () => {
+        const emptyArgs: ToolCallArgs = { path: '' };
+        const whitespaceArgs: ToolCallArgs = { path: '   ' };
+
+        const emptyResult = resolver.resolveToolPaths('write_file', emptyArgs);
+        const whitespaceResult = resolver.resolveToolPaths('write_file', whitespaceArgs);
+
+        expect(emptyResult.path).toBe('');
+        expect(whitespaceResult.path).toBe('   ');
+      });
+
+      it('should handle non-string path values', () => {
+        const args: ToolCallArgs = {
+          path: 123,
+          otherParam: 'value',
+        };
+        const result = resolver.resolveToolPaths('write_file', args);
+
+        // Non-string values should remain unchanged
+        expect(result.path).toBe(123);
+        expect(result.otherParam).toBe('value');
+      });
+    });
+
+    describe('Multiple Path Parameters', () => {
+      it('should resolve multiple path parameters for move_file tool', () => {
+        const args: ToolCallArgs = {
+          source: 'src/old.ts',
+          destination: 'src/new.ts',
+        };
+        const result = resolver.resolveToolPaths('move_file', args);
+
+        expect(result.source).toBe(path.join(testWorkingDir, 'src/old.ts'));
+        expect(result.destination).toBe(path.join(testWorkingDir, 'src/new.ts'));
+      });
+
+      it('should handle mixed absolute and relative paths', () => {
+        const absolutePath = '/absolute/destination.ts';
+        const args: ToolCallArgs = {
+          source: 'relative/source.ts',
+          destination: absolutePath,
+        };
+        const result = resolver.resolveToolPaths('copy_file', args);
+
+        expect(result.source).toBe(path.join(testWorkingDir, 'relative/source.ts'));
+        expect(result.destination).toBe(absolutePath);
+      });
+    });
+
+    describe('Command Tools with CWD', () => {
+      it('should resolve cwd parameter for run_command tool', () => {
+        const args: ToolCallArgs = {
+          command: 'npm test',
+          cwd: 'packages/frontend',
+        };
+        const result = resolver.resolveToolPaths('run_command', args);
+
+        expect(result.cwd).toBe(path.join(testWorkingDir, 'packages/frontend'));
+        expect(result.command).toBe('npm test');
+      });
+    });
+  });
+
+  describe('Tool Path Parameter Management', () => {
+    it('should correctly identify tools with path parameters', () => {
+      expect(resolver.hasPathParameters('write_file')).toBe(true);
+      expect(resolver.hasPathParameters('read_file')).toBe(true);
+      expect(resolver.hasPathParameters('unknown_tool')).toBe(false);
+    });
+
+    it('should return correct path parameters for known tools', () => {
+      expect(resolver.getPathParameters('write_file')).toEqual(['path']);
+      expect(resolver.getPathParameters('move_file')).toEqual(['source', 'destination']);
+      expect(resolver.getPathParameters('run_command')).toEqual(['cwd']);
+      expect(resolver.getPathParameters('unknown_tool')).toEqual([]);
+    });
+
+    it('should handle tools without path parameters', () => {
+      const args: ToolCallArgs = {
+        someParam: 'value',
+        anotherParam: 42,
+      };
+      const result = resolver.resolveToolPaths('unknown_tool', args);
+
+      // Args should remain unchanged for tools without path parameters
+      expect(result).toEqual(args);
+      expect(result).not.toBe(args); // Should return a copy
+    });
+  });
+
+  describe('Default Path Parameter Mapping', () => {
+    it('should include all expected filesystem tools', () => {
+      const filesystemTools = [
+        'write_file',
+        'read_file',
+        'edit_file',
+        'create_directory',
+        'list_directory',
+        'delete_file',
+        'delete_directory',
+        'get_file_info',
+      ];
+
+      filesystemTools.forEach((tool) => {
+        expect(DEFAULT_PATH_PARAMETER_MAPPING[tool]).toBeDefined();
+        expect(DEFAULT_PATH_PARAMETER_MAPPING[tool]).toContain('path');
+      });
+    });
+
+    it('should include file operation tools with multiple paths', () => {
+      expect(DEFAULT_PATH_PARAMETER_MAPPING['move_file']).toEqual(['source', 'destination']);
+      expect(DEFAULT_PATH_PARAMETER_MAPPING['copy_file']).toEqual(['source', 'destination']);
+    });
+
+    it('should include command tools with cwd parameter', () => {
+      expect(DEFAULT_PATH_PARAMETER_MAPPING['run_command']).toEqual(['cwd']);
+      expect(DEFAULT_PATH_PARAMETER_MAPPING['run_script']).toEqual(['cwd']);
+    });
+  });
+
+  describe('Custom Path Mapping', () => {
+    it('should add new path mappings without affecting existing ones', () => {
+      const additionalMapping: PathParameterMapping = {
+        custom_tool: ['custom_path'],
+        another_tool: ['dir1', 'dir2'],
+      };
+
+      resolver.addPathMapping(additionalMapping);
+
+      // New mappings should be available
+      expect(resolver.hasPathParameters('custom_tool')).toBe(true);
+      expect(resolver.getPathParameters('custom_tool')).toEqual(['custom_path']);
+      expect(resolver.getPathParameters('another_tool')).toEqual(['dir1', 'dir2']);
+
+      // Existing mappings should remain intact
+      expect(resolver.hasPathParameters('write_file')).toBe(true);
+      expect(resolver.getPathParameters('write_file')).toEqual(['path']);
+    });
+
+    it('should override existing mappings when adding duplicates', () => {
+      const overrideMapping: PathParameterMapping = {
+        write_file: ['new_path_param'],
+      };
+
+      resolver.addPathMapping(overrideMapping);
+
+      expect(resolver.getPathParameters('write_file')).toEqual(['new_path_param']);
+    });
+  });
+
+  describe('Edge Cases and Error Handling', () => {
+    it('should handle undefined or null arguments gracefully', () => {
+      const result1 = resolver.resolveToolPaths('write_file', undefined);
+      const result2 = resolver.resolveToolPaths('write_file', null);
+
+      expect(result1).toEqual({});
+      expect(result2).toEqual({});
+    });
+
+    it('should preserve non-path parameters unchanged', () => {
+      const args: ToolCallArgs = {
+        path: 'relative/path.ts',
+        content: 'file content',
+        encoding: 'utf-8',
+        overwrite: true,
+        metadata: { created: new Date() },
+      };
+
+      const result = resolver.resolveToolPaths('write_file', args);
+
+      expect(result.path).toBe(path.join(testWorkingDir, 'relative/path.ts'));
+      expect(result.content).toBe('file content');
+      expect(result.encoding).toBe('utf-8');
+      expect(result.overwrite).toBe(true);
+      expect(result.metadata).toBe(args.metadata);
+    });
+
+    it('should work with different working directory formats', () => {
+      // Test with Windows-style path
+      const windowsConfig = { workingDirectory: 'C:\\workspace\\project' };
+      const windowsResolver = new WorkspacePathResolver(windowsConfig);
+
+      const args: ToolCallArgs = { path: 'src/file.ts' };
+      const result = windowsResolver.resolveToolPaths('write_file', args);
+
+      expect(result.path).toBe(path.join('C:\\workspace\\project', 'src/file.ts'));
+    });
+
+    it('should handle complex relative paths with .. and .', () => {
+      const args: ToolCallArgs = {
+        path: '../sibling/./file.ts',
+      };
+      const result = resolver.resolveToolPaths('write_file', args);
+
+      expect(result.path).toBe(path.resolve(testWorkingDir, '../sibling/./file.ts'));
+    });
+  });
+
+  describe('Immutability', () => {
+    it('should not mutate original arguments object', () => {
+      const originalArgs: ToolCallArgs = {
+        path: 'relative/path.ts',
+        content: 'original content',
+      };
+      const argsCopy = { ...originalArgs };
+
+      resolver.resolveToolPaths('write_file', originalArgs);
+
+      // Original args should remain unchanged
+      expect(originalArgs).toEqual(argsCopy);
+    });
+
+    it('should return a new object with resolved paths', () => {
+      const args: ToolCallArgs = { path: 'relative/path.ts' };
+      const result = resolver.resolveToolPaths('write_file', args);
+
+      expect(result).not.toBe(args);
+      expect(result.path).not.toBe(args.path);
+    });
+  });
+});

--- a/multimodal/agent-tars/tests/shared/workspace-path-resolver.test.ts
+++ b/multimodal/agent-tars/tests/shared/workspace-path-resolver.test.ts
@@ -222,29 +222,23 @@ describe('WorkspacePathResolver', () => {
       const args: ToolCallArgs = {
         path: 'relative/path.ts',
         content: 'file content',
-        encoding: 'utf-8',
-        overwrite: true,
-        metadata: { created: new Date() },
       };
 
       const result = resolver.resolveToolPaths('write_file', args);
 
       expect(result.path).toBe(path.join(testWorkingDir, 'relative/path.ts'));
       expect(result.content).toBe('file content');
-      expect(result.encoding).toBe('utf-8');
-      expect(result.overwrite).toBe(true);
-      expect(result.metadata).toBe(args.metadata);
     });
 
     it('should work with different working directory formats', () => {
-      // Test with Windows-style path
-      const windowsConfig = { workingDirectory: 'C:\\workspace\\project' };
-      const windowsResolver = new WorkspacePathResolver(windowsConfig);
+      const absoluteWorkingDir = path.resolve('/workspace/project');
+      const config = { workingDirectory: absoluteWorkingDir };
+      const testResolver = new WorkspacePathResolver(config);
 
       const args: ToolCallArgs = { path: 'src/file.ts' };
-      const result = windowsResolver.resolveToolPaths('write_file', args);
+      const result = testResolver.resolveToolPaths('write_file', args);
 
-      expect(result.path).toBe(path.join('C:\\workspace\\project', 'src/file.ts'));
+      expect(result.path).toBe(path.join(absoluteWorkingDir, 'src/file.ts'));
     });
 
     it('should handle complex relative paths with .. and .', () => {
@@ -276,8 +270,9 @@ describe('WorkspacePathResolver', () => {
       const result = resolver.resolveToolPaths('write_file', args);
 
       expect(result).not.toBe(args);
-      expect(result.path).not.toBe(args.path);
+      // 路径应该被解析，所以值会不同
       expect(result.path).toBe(path.join(testWorkingDir, 'relative/path.ts'));
+      expect(result.path).not.toBe(args.path);
     });
   });
 


### PR DESCRIPTION
<!--------------------------------------------------------------------------------
    Thank you for submitting a pull request!

    We appreciate the time and effort you have invested in making these changes. Please 
    ensure that you provide enough information to allow others to review your pull request 
    effectively, so please DO NOT delete this template.

    If you're new to contributing, learn more about contributing here:
    https://github.com/bytedance/UI-TARS-desktop/blob/main/CONTRIBUTING.md.  
---------------------------------------------------------------------------------->

## Summary

In https://github.com/bytedance/UI-TARS-desktop/pull/860 and https://github.com/bytedance/UI-TARS-desktop/pull/862 , we fixed the path resolve issue of some workspace path for some tools, in this pull request, we add full support for file and command tools. 

### Before

<img width="1747" height="786" alt="image" src="https://github.com/user-attachments/assets/de134525-3ea1-4fb0-a047-0a02348ca38e" />

### After

<img width="1747" height="619" alt="image" src="https://github.com/user-attachments/assets/6a4fc99d-59ed-4d53-bb12-06714fb07982" />



<!--------------------------------------------------------------------------------
    Can you explain the reasoning behind implementing this change?  
    What problem or issue does this pull request resolve?  

    It would be helpful to include relevant context, such as GitHub issues 
    (e.g., Close: #xxx) or related discussions.

    If updating the UI, please include a **before/after screenshot** for visibility.
    Thank you for reading. Next, start describing your Summary on the next line
    after the comment ends. 👇🏻
---------------------------------------------------------------------------------->



## Checklist  

<!--  Before submitting the pull request, ensure the following items are checked: -->

- [x] Added or updated necessary tests (Optional).  
- [ ] Updated documentation to align with changes (Optional).  
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).  
- [ ] My change does not involve the above items. 
