### PR TITLE
feat(agent-tars-web-ui): support share generate files

### DIFF
--- a/multimodal/agent-tars-web-ui/src/standalone/workspace/components/ShareButton.tsx
+++ b/multimodal/agent-tars-web-ui/src/standalone/workspace/components/ShareButton.tsx
@@ -1,0 +1,72 @@
+import React, { useState } from 'react';
+import { motion } from 'framer-motion';
+import { FiShare2, FiCheck, FiCopy } from 'react-icons/fi';
+import { useReplayMode } from '@/common/hooks/useReplayMode';
+
+interface ShareButtonProps {
+  fileName: string;
+  title?: string;
+  className?: string;
+}
+
+/**
+ * ShareButton - A reusable share button component for HTML and Markdown files
+ *
+ * Only shows in replay mode and generates share URLs with focus parameter
+ */
+export const ShareButton: React.FC<ShareButtonProps> = ({
+  fileName,
+  title = 'Share this file',
+  className = '',
+}) => {
+  const [copied, setCopied] = useState(false);
+  const isReplayMode = useReplayMode();
+
+  // Only show in replay mode
+  if (!isReplayMode) {
+    return null;
+  }
+
+  // Check if file is HTML or Markdown
+  const isShareableFile = fileName.toLowerCase().match(/\.(html?|md|markdown)$/);
+  if (!isShareableFile) {
+    return null;
+  }
+
+  const handleShare = async () => {
+    try {
+      // Create URL with focus parameter
+      const currentUrl = new URL(window.location.href);
+      currentUrl.searchParams.set('focus', fileName);
+      const shareUrl = currentUrl.toString();
+
+      await navigator.clipboard.writeText(shareUrl);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (error) {
+      console.error('Failed to share:', error);
+      // Fallback to manual URL construction and clipboard
+      try {
+        const currentUrl = new URL(window.location.href);
+        currentUrl.searchParams.set('focus', fileName);
+        await navigator.clipboard.writeText(currentUrl.toString());
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      } catch (clipboardError) {
+        console.error('Failed to copy to clipboard:', clipboardError);
+      }
+    }
+  };
+
+  return (
+    <motion.button
+      whileHover={{ scale: 1.05 }}
+      whileTap={{ scale: 0.95 }}
+      onClick={handleShare}
+      className={`p-2 rounded-lg bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors ${className}`}
+      title={title}
+    >
+      {copied ? <FiCheck size={16} className="text-green-500" /> : <FiShare2 size={16} />}
+    </motion.button>
+  );
+};

--- a/multimodal/agent-tars-web-ui/src/standalone/workspace/components/WorkspaceHeader.tsx
+++ b/multimodal/agent-tars-web-ui/src/standalone/workspace/components/WorkspaceHeader.tsx
@@ -5,6 +5,7 @@ import { formatTimestamp } from '@/common/utils/formatters';
 import { useTool } from '@/common/hooks/useTool';
 import { StandardPanelContent } from '../types/panelContent';
 import { ToggleSwitch, ToggleSwitchProps } from '../renderers/generic/components/ToggleSwitch';
+import { ShareButton } from './ShareButton';
 import { FileDisplayMode } from '../types';
 
 interface WorkspaceHeaderProps {
@@ -27,6 +28,14 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
   const { getToolIcon } = useTool();
 
   const isResearchReport = panelContent.toolCallId?.startsWith('final-answer');
+
+  // Extract file name for share functionality
+  const getFileName = (): string => {
+    if (panelContent.arguments?.path) {
+      return panelContent.arguments.path.split('/').pop() || panelContent.arguments.path;
+    }
+    return panelContent.title;
+  };
 
   return (
     <div className="flex items-center justify-between px-4 py-3 workspace-control-panel">
@@ -75,6 +84,9 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
       <div className="ml-4 flex-shrink-0 flex items-center gap-3">
         {/* Toggle switch */}
         {showToggle && toggleConfig && <ToggleSwitch<FileDisplayMode> {...toggleConfig} />}
+
+        {/* Share button */}
+        <ShareButton fileName={getFileName()} title="Share this file" />
 
         {/* Fullscreen button */}
         {showFullscreen && onFullscreen && (


### PR DESCRIPTION
<!--------------------------------------------------------------------------------
    Thank you for submitting a pull request!

    We appreciate the time and effort you have invested in making these changes. Please 
    ensure that you provide enough information to allow others to review your pull request 
    effectively, so please DO NOT delete this template.

    If you're new to contributing, learn more about contributing here:
    https://github.com/bytedance/UI-TARS-desktop/blob/main/CONTRIBUTING.md.  
---------------------------------------------------------------------------------->

## Summary

Currently, if the Web UI supports if the query has `?focus={file}` and the file exists in Generated Files, the state switches to full screen rendering html or markdown.

This pull request add a button on the far right in the Workspace Header  to support the share button for HTML and Markdown. When the user clicks it, it essentially adds `?focus={file}` based on the current location href. Next, if others get this URL, they can directly focus on this file for display.

<img width="1736" height="186" alt="image" src="https://github.com/user-attachments/assets/aafccb2e-d731-42fe-a6ba-a9e03ade5320" />


<!--------------------------------------------------------------------------------
    Can you explain the reasoning behind implementing this change?  
    What problem or issue does this pull request resolve?  

    It would be helpful to include relevant context, such as GitHub issues 
    (e.g., Close: #xxx) or related discussions.

    If updating the UI, please include a **before/after screenshot** for visibility.
    Thank you for reading. Next, start describing your Summary on the next line
    after the comment ends. 👇🏻
---------------------------------------------------------------------------------->



## Checklist  

<!--  Before submitting the pull request, ensure the following items are checked: -->

- [ ] Added or updated necessary tests (Optional).  
- [ ] Updated documentation to align with changes (Optional).  
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).  
- [x] My change does not involve the above items. 
