### PR TITLE
feat(agent-server): handle old workspace schema migration

### DIFF
--- a/multimodal/tarko/agent-server/src/storage/SQLiteStorageProvider.ts
+++ b/multimodal/tarko/agent-server/src/storage/SQLiteStorageProvider.ts
@@ -63,7 +63,10 @@ export class SQLiteStorageProvider implements StorageProvider {
         // Enable WAL mode for better concurrent performance
         this.db.exec('PRAGMA journal_mode = WAL');
 
-        // Create sessions table
+        // Check if we need to migrate from old schema
+        await this.migrateIfNeeded();
+
+        // Create sessions table with current schema
         this.db.exec(`
           CREATE TABLE IF NOT EXISTS sessions (
             id TEXT PRIMARY KEY,
@@ -99,6 +102,71 @@ export class SQLiteStorageProvider implements StorageProvider {
         console.error('Failed to initialize SQLite database:', error);
         throw error;
       }
+    }
+  }
+
+  /**
+   * Check and migrate from old database schema if needed
+   */
+  private async migrateIfNeeded(): Promise<void> {
+    try {
+      // Check if sessions table exists and get its schema
+      const tableInfoStmt = this.db.prepare(`
+        PRAGMA table_info(sessions)
+      `);
+
+      const columns = tableInfoStmt.all() as Array<{
+        cid: number;
+        name: string;
+        type: string;
+        notnull: number;
+        dflt_value: any;
+        pk: number;
+      }>;
+
+      if (columns.length === 0) {
+        // Table doesn't exist yet, no migration needed
+        return;
+      }
+
+      // Check if we have the old 'workingDirectory' column instead of 'workspace'
+      const hasWorkingDirectory = columns.some((col) => col.name === 'workingDirectory');
+      const hasWorkspace = columns.some((col) => col.name === 'workspace');
+
+      if (hasWorkingDirectory && !hasWorkspace) {
+        console.log('Migrating database schema: renaming workingDirectory to workspace');
+
+        // SQLite doesn't support column renaming directly in older versions
+        // We need to create a new table and copy data
+        this.db.exec(`
+          CREATE TABLE sessions_new (
+            id TEXT PRIMARY KEY,
+            createdAt INTEGER NOT NULL,
+            updatedAt INTEGER NOT NULL,
+            name TEXT,
+            workspace TEXT NOT NULL,
+            tags TEXT
+          )
+        `);
+
+        // Copy data from old table to new table
+        this.db.exec(`
+          INSERT INTO sessions_new (id, createdAt, updatedAt, name, workspace, tags)
+          SELECT id, createdAt, updatedAt, name, workingDirectory, tags
+          FROM sessions
+        `);
+
+        // Drop old table and rename new table
+        this.db.exec('DROP TABLE sessions');
+        this.db.exec('ALTER TABLE sessions_new RENAME TO sessions');
+
+        console.log('Database schema migration completed successfully');
+      }
+    } catch (error) {
+      console.error('Failed to migrate database schema:', error);
+      throw new Error(
+        `Database migration failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
     }
   }
 


### PR DESCRIPTION
## Summary

This PR implements database schema migration functionality to handle the transition from the old `workingDirectory` column to the new `workspace` column in the SQLite sessions table.

**Problem Solved:**

Users upgrading from older versions encounter database errors when the application tries to access the new `workspace` column that doesn't exist in their existing database schema:

```
SessionRestoreMiddleware Session restore middleware error: Failed to get session: no such column: workspace
Failed to get session jr5gOEY_W4K3CPTS5Q5vh: Error: no such column: workspace
    at SQLiteStorageProvider.getSessionMetadata (/multimodal/tarko/agent-server/dist/index.js:18813:42)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async sessionRestoreMiddleware (/Users/chenhaoli/workspace/code/UI-TARS-desktop-5/multimodal/tarko/agent-server/dist/index.js:17491:38) {
  code: 'ERR_SQLITE_ERROR',
  errcode: 1,
  errstr: 'SQL logic error'
}
```

This PR provides:
- Backward compatibility for existing databases that still use the old `workingDirectory` column name
- Prevents database errors when upgrading from older versions of the application
- Provides seamless migration path for users with existing session data

**Key Changes:**
- Added `migrateIfNeeded()` method to check and perform schema migration
- Implemented table recreation strategy to rename `workingDirectory` to `workspace`
- Added proper error handling and logging for migration process
- Ensures migration only runs when necessary (old schema detected)

**Technical Details:**
- Uses SQLite's table recreation approach since direct column renaming isn't supported in older SQLite versions
- Preserves all existing session data during migration
- Includes comprehensive error handling and user feedback

## Checklist

- [ ] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [x] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [ ] My change does not involve the above items.