### PR TITLE
feat: fix snapshot storage directory and add snapshot query API

### DIFF
--- a/multimodal/tarko/agent-server/src/api/controllers/index.ts
+++ b/multimodal/tarko/agent-server/src/api/controllers/index.ts
@@ -8,3 +8,4 @@ export * from './queries';
 export * from './system';
 export * from './share';
 export * from './oneshot';
+export * from './snapshots';

--- a/multimodal/tarko/agent-server/src/api/controllers/snapshots.ts
+++ b/multimodal/tarko/agent-server/src/api/controllers/snapshots.ts
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Request, Response } from 'express';
+import path from 'path';
+import os from 'os';
+import fs from 'fs/promises';
+import { AgentServer } from '../../server';
+
+/**
+ * Get all available snapshots
+ */
+export async function getAllSnapshots(req: Request, res: Response): Promise<void> {
+  try {
+    const server = req.app.get('server') as AgentServer;
+    const snapshotDirectory =
+      server.appConfig.snapshot?.storageDirectory ?? path.join(os.homedir(), '.tarko', 'snapshots');
+
+    // Check if snapshot directory exists
+    try {
+      await fs.access(snapshotDirectory);
+    } catch {
+      // Directory doesn't exist, return empty array
+      res.json({ snapshots: [] });
+      return;
+    }
+
+    // Read all session directories
+    const entries = await fs.readdir(snapshotDirectory, { withFileTypes: true });
+    const sessionIds = entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name);
+
+    // Get snapshot info for each session
+    const snapshots = await Promise.all(
+      sessionIds.map(async (sessionId) => {
+        const sessionPath = path.join(snapshotDirectory, sessionId);
+        try {
+          const stats = await fs.stat(sessionPath);
+          return {
+            sessionId,
+            createdAt: stats.birthtime,
+            modifiedAt: stats.mtime,
+            path: sessionPath,
+          };
+        } catch {
+          return null;
+        }
+      }),
+    );
+
+    // Filter out null results and sort by creation time
+    const validSnapshots = snapshots
+      .filter((snapshot) => snapshot !== null)
+      .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+
+    res.json({ snapshots: validSnapshots });
+  } catch (error) {
+    console.error('Error getting snapshots:', error);
+    res.status(500).json({
+      error: 'Failed to retrieve snapshots',
+      message: error instanceof Error ? error.message : 'Unknown error',
+    });
+  }
+}
+
+/**
+ * Get specific snapshot by sessionId
+ */
+export async function getSnapshot(req: Request, res: Response): Promise<void> {
+  try {
+    const { sessionId } = req.params;
+    const server = req.app.get('server') as AgentServer;
+    const snapshotDirectory =
+      server.appConfig.snapshot?.storageDirectory ?? path.join(os.homedir(), '.tarko', 'snapshots');
+
+    const sessionPath = path.join(snapshotDirectory, sessionId);
+
+    // Check if session snapshot exists
+    try {
+      const stats = await fs.stat(sessionPath);
+      if (!stats.isDirectory()) {
+        res.status(404).json({ error: 'Snapshot not found' });
+        return;
+      }
+
+      // Get snapshot metadata
+      const snapshot = {
+        sessionId,
+        createdAt: stats.birthtime,
+        modifiedAt: stats.mtime,
+        path: sessionPath,
+      };
+
+      res.json({ snapshot });
+    } catch {
+      res.status(404).json({ error: 'Snapshot not found' });
+    }
+  } catch (error) {
+    console.error('Error getting snapshot:', error);
+    res.status(500).json({
+      error: 'Failed to retrieve snapshot',
+      message: error instanceof Error ? error.message : 'Unknown error',
+    });
+  }
+}
+
+/**
+ * Get trace data for a specific session
+ */
+export async function getSnapshotTrace(req: Request, res: Response): Promise<void> {
+  try {
+    const { sessionId } = req.params;
+    const server = req.app.get('server') as AgentServer;
+    const snapshotDirectory =
+      server.appConfig.snapshot?.storageDirectory ?? path.join(os.homedir(), '.tarko', 'snapshots');
+
+    const sessionPath = path.join(snapshotDirectory, sessionId);
+    const tracePath = path.join(sessionPath, 'trace.json');
+
+    try {
+      const traceData = await fs.readFile(tracePath, 'utf-8');
+      const trace = JSON.parse(traceData);
+      res.json({ trace });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        res.status(404).json({ error: 'Trace data not found for this session' });
+      } else {
+        throw error;
+      }
+    }
+  } catch (error) {
+    console.error('Error getting snapshot trace:', error);
+    res.status(500).json({
+      error: 'Failed to retrieve trace data',
+      message: error instanceof Error ? error.message : 'Unknown error',
+    });
+  }
+}
+
+/**
+ * Get snapshot files for a specific session
+ */
+export async function getSnapshotFiles(req: Request, res: Response): Promise<void> {
+  try {
+    const { sessionId } = req.params;
+    const server = req.app.get('server') as AgentServer;
+    const snapshotDirectory =
+      server.appConfig.snapshot?.storageDirectory ?? path.join(os.homedir(), '.tarko', 'snapshots');
+
+    const sessionPath = path.join(snapshotDirectory, sessionId);
+
+    try {
+      // Check if session directory exists
+      await fs.access(sessionPath);
+
+      // Read all files in the session directory
+      const entries = await fs.readdir(sessionPath, { withFileTypes: true });
+      const files = await Promise.all(
+        entries.map(async (entry) => {
+          const filePath = path.join(sessionPath, entry.name);
+          const stats = await fs.stat(filePath);
+          return {
+            name: entry.name,
+            type: entry.isDirectory() ? 'directory' : 'file',
+            size: stats.size,
+            createdAt: stats.birthtime,
+            modifiedAt: stats.mtime,
+            path: filePath,
+          };
+        }),
+      );
+
+      res.json({ files });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        res.status(404).json({ error: 'Snapshot not found' });
+      } else {
+        throw error;
+      }
+    }
+  } catch (error) {
+    console.error('Error getting snapshot files:', error);
+    res.status(500).json({
+      error: 'Failed to retrieve snapshot files',
+      message: error instanceof Error ? error.message : 'Unknown error',
+    });
+  }
+}

--- a/multimodal/tarko/agent-server/src/api/routes/index.ts
+++ b/multimodal/tarko/agent-server/src/api/routes/index.ts
@@ -9,6 +9,7 @@ import { registerQueryRoutes } from './queries';
 import { registerSystemRoutes } from './system';
 import { registerShareRoutes } from './share';
 import { registerOneshotRoutes } from './oneshot';
+import { registerSnapshotRoutes } from './snapshots';
 
 /**
  * Register all API routes with the Express application
@@ -20,4 +21,5 @@ export function registerAllRoutes(app: express.Application): void {
   registerSystemRoutes(app);
   registerShareRoutes(app);
   registerOneshotRoutes(app);
+  registerSnapshotRoutes(app);
 }

--- a/multimodal/tarko/agent-server/src/api/routes/snapshots.ts
+++ b/multimodal/tarko/agent-server/src/api/routes/snapshots.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import express from 'express';
+import * as snapshotsController from '../controllers/snapshots';
+
+/**
+ * Register snapshot management routes
+ * @param app Express application
+ */
+export function registerSnapshotRoutes(app: express.Application): void {
+  app.group('/api/v1/snapshots', (router: express.Router) => {
+    // Get all available snapshots
+    router.get('/', snapshotsController.getAllSnapshots);
+
+    // Get specific snapshot by sessionId
+    router.get('/:sessionId', snapshotsController.getSnapshot);
+
+    // Get trace data for a specific session
+    router.get('/:sessionId/trace', snapshotsController.getSnapshotTrace);
+
+    // Get snapshot files for a specific session
+    router.get('/:sessionId/files', snapshotsController.getSnapshotFiles);
+  });
+}

--- a/multimodal/tarko/agent-server/src/core/AgentSession.ts
+++ b/multimodal/tarko/agent-server/src/core/AgentSession.ts
@@ -5,6 +5,7 @@
  */
 
 import path from 'path';
+import os from 'os';
 import {
   AgentEventStream,
   AgentStatus,
@@ -82,7 +83,7 @@ export class AgentSession {
     // Initialize agent snapshot if enabled
     if (agentOptions.snapshot?.enable) {
       const snapshotStoragesDirectory =
-        agentOptions.snapshot.storageDirectory ?? server.getCurrentWorkspace();
+        agentOptions.snapshot.storageDirectory ?? path.join(os.homedir(), '.tarko', 'snapshots');
 
       if (snapshotStoragesDirectory) {
         const snapshotPath = path.join(snapshotStoragesDirectory, sessionId);

--- a/multimodal/tarko/interface/src/server.ts
+++ b/multimodal/tarko/interface/src/server.ts
@@ -43,9 +43,10 @@ export interface AgentServerSnapshotOptions {
 
   /**
    * Directory to store agent snapshots
-   * If not specified, snapshots will be stored in the session's working directory
+   * @default "~/.tarko/snapshots"
+   * If not specified, snapshots will be stored in ~/.tarko/snapshots
    */
-  storageDirectory: string;
+  storageDirectory?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR addresses Issue #1051 by fixing the default snapshot storage directory and adding comprehensive snapshot query APIs.

## Changes

### 🔧 **Core Fix**
- **Fixed default storage path**: Changed `snapshot.storageDirectory` default from current workspace to `~/.tarko/snapshots`
- **Updated interface**: Made `storageDirectory` optional with proper documentation
- **Added OS module import**: Required for `os.homedir()` access

### 🚀 **New API Endpoints**
Implemented complete snapshot query API following existing `/api/v1` pattern:

- `GET /api/v1/snapshots` - List all available snapshots with metadata
- `GET /api/v1/snapshots/:sessionId` - Get specific snapshot details
- `GET /api/v1/snapshots/:sessionId/trace` - Get trace data for session replay
- `GET /api/v1/snapshots/:sessionId/files` - List all files in snapshot directory

### 📁 **File Changes**
- `multimodal/tarko/agent-server/src/core/AgentSession.ts` - Updated default path logic
- `multimodal/tarko/interface/src/server.ts` - Updated interface documentation
- `multimodal/tarko/agent-server/src/api/controllers/snapshots.ts` - New controller
- `multimodal/tarko/agent-server/src/api/routes/snapshots.ts` - New routes
- Updated route and controller index files

## Benefits

✅ **Centralized storage**: All snapshots now stored in `~/.tarko/snapshots`  
✅ **Clean project directories**: No more snapshot files cluttering workspace  
✅ **Frontend integration**: APIs enable trace viewing by sessionId  
✅ **Consistent design**: Follows existing `/api/v1` routing pattern  
✅ **Comprehensive querying**: Support for metadata, traces, and file listings  

## Testing

- ✅ Code compiles successfully
- ✅ Passes lint and formatting checks
- ✅ API endpoints follow established patterns
- ✅ Error handling implemented for missing snapshots

## Checklist

- [x] Fix default snapshot storage directory
- [x] Add snapshot query API endpoints
- [x] Update interface documentation
- [x] Follow existing API patterns
- [x] Implement proper error handling
- [x] Code passes build and lint checks

Closes #1051