### PR TITLE
docs: clarify instructions field behavior

### DIFF
--- a/multimodal/tarko/agent-interface/src/agent-options.ts
+++ b/multimodal/tarko/agent-interface/src/agent-options.ts
@@ -50,8 +50,9 @@ export interface AgentBaseOptions {
 
   /**
    * Used to define the Agent's system prompt.
+   * This completely replaces the default system prompt when provided.
    *
-   * @defaultValue `undefined`
+   * @defaultValue `undefined` (uses default prompt: "You are an intelligent assistant...")
    */
   instructions?: string;
 }


### PR DESCRIPTION
## Summary
Improve documentation clarity for the `instructions` field in `AgentOptions` to explicitly state that it completely replaces the default system prompt rather than appending to it.

## Changes
- Add explicit note that `instructions` completely replaces default system prompt
- Update `@defaultValue` description to include example of default prompt behavior
- Enhance developer understanding of how the field works

## Context
The previous comment was technically accurate but could be misinterpreted as incremental addition. This change makes the full replacement behavior explicit.

## Impact
- **Documentation**: Improved clarity for developers
- **Breaking Changes**: None - this is purely documentation
- **Behavior**: No functional changes