### PR TITLE
fix(omni-tars): add missing super.onAgentLoopEnd() call

### DIFF
--- a/multimodal/omni-tars/core/src/ComposableAgent.ts
+++ b/multimodal/omni-tars/core/src/ComposableAgent.ts
@@ -68,8 +68,10 @@ export class ComposableAgent extends Agent {
     await this.composer.executeOnEachAgentLoopStart();
   }
 
-  async onAgentLoopEnd(): Promise<void> {
+  async onAgentLoopEnd(id: string): Promise<void> {
     // Execute hooks for all plugins
     await this.composer.executeOnAgentLoopEnd();
+    // Call parent implementation to ensure proper agent loop termination
+    await super.onAgentLoopEnd(id);
   }
 }


### PR DESCRIPTION
## Summary

Fixes agent execution hanging in Omni TARS by adding missing `super.onAgentLoopEnd()` call in ComposableAgent.

## Problem

Agent execution doesn't terminate properly - missing `agent_run_end` event causes Web UI to hang indefinitely.

## Solution

Added `await super.onAgentLoopEnd()` call to ensure execution controller cleanup runs properly.

## Changes

- Added missing parent method call in `ComposableAgent.onAgentLoopEnd()`
- Ensures proper agent loop termination and event stream completion

**Closes #1064**