### PR TITLE
fix: replace node-fetch with native fetch for Node.js 22

### DIFF
--- a/packages/agent-infra/search/search/src/searxng.ts
+++ b/packages/agent-infra/search/search/src/searxng.ts
@@ -2,7 +2,6 @@
  * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
  * SPDX-License-Identifier: Apache-2.0
  */
-import fetch from 'node-fetch';
 
 export interface SearXNGSearchConfig {
   baseUrl?: string;


### PR DESCRIPTION
Fixes `npx @agent-infra/mcp-server-search` failing with "Cannot find module 'node-fetch'" error by using native fetch API available in Node.js 18+.