### PR TITLE
chore(gui-agent): handle `browser_vision_control` tool result

### DIFF
--- a/multimodal/gui-agent/agent-sdk/src/SeedGUIAgent.ts
+++ b/multimodal/gui-agent/agent-sdk/src/SeedGUIAgent.ts
@@ -105,7 +105,7 @@ export class SeedGUIAgent extends Agent {
         parameters: {},
         function: async (input) => {
           this.logger.log('browser_vision_control input:', input);
-          await this.operator!.execute({
+          const result = await this.operator!.execute({
             parsedPrediction: input.operator_action,
             screenWidth: getScreenInfo().screenWidth ?? 1000,
             screenHeight: getScreenInfo().screenHeight ?? 1000,
@@ -113,6 +113,7 @@ export class SeedGUIAgent extends Agent {
             scaleFactor: 1000,
             factors: [1, 1],
           });
+          return { action: input.action, status: 'success', result };
         },
       }),
     );


### PR DESCRIPTION
<!--------------------------------------------------------------------------------
    Thank you for submitting a pull request!

    We appreciate the time and effort you have invested in making these changes. Please 
    ensure that you provide enough information to allow others to review your pull request 
    effectively, so please DO NOT delete this template.

    If you're new to contributing, learn more about contributing here:
    https://github.com/bytedance/UI-TARS-desktop/blob/main/CONTRIBUTING.md.  
---------------------------------------------------------------------------------->

## Summary

This pull request updates the `SeedGUIAgent` class to improve the handling of the `browser_vision_control` function. The main change is to ensure that the function returns a result object after executing the operator action, rather than just performing the action without returning feedback.

Improvements to function return value:

* Modified the `browser_vision_control` function in `SeedGUIAgent` to return an object containing the action, status, and execution result after calling `operator.execute`, providing clearer feedback to callers.

<!--------------------------------------------------------------------------------
    Can you explain the reasoning behind implementing this change?  
    What problem or issue does this pull request resolve?  

    It would be helpful to include relevant context, such as GitHub issues 
    (e.g., Close: #xxx) or related discussions.

    If updating the UI, please include a **before/after screenshot** for visibility.
    Thank you for reading. Next, start describing your Summary on the next line
    after the comment ends. 👇🏻
---------------------------------------------------------------------------------->



## Checklist  

<!--  Before submitting the pull request, ensure the following items are checked: -->

- [ ] Added or updated necessary tests (Optional).  
- [ ] Updated documentation to align with changes (Optional).  
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).  
- [x] My change does not involve the above items. 
