### PR TITLE
fix(tarko): use plain text rendering for user messages (closes #1103)

### DIFF
--- a/multimodal/tarko/agent-web-ui/src/standalone/chat/Message/components/MultimodalContent.tsx
+++ b/multimodal/tarko/agent-web-ui/src/standalone/chat/Message/components/MultimodalContent.tsx
@@ -69,7 +69,7 @@ export const MultimodalContent: React.FC<MultimodalContentProps> = ({
       {/* Render text content - ensure text is visible in user messages */}
       {textContents.map((part, index) => (
         <div key={`text-${index}`} className="text-current">
-          <MarkdownRenderer key={`text-${index}`} content={part.text} />
+          <MarkdownRenderer key={`text-${index}`} content={part.text} forceDarkTheme={true} />
         </div>
       ))}
     </>

--- a/multimodal/tarko/agent-web-ui/src/standalone/chat/Message/components/MultimodalContent.tsx
+++ b/multimodal/tarko/agent-web-ui/src/standalone/chat/Message/components/MultimodalContent.tsx
@@ -68,8 +68,8 @@ export const MultimodalContent: React.FC<MultimodalContentProps> = ({
 
       {/* Render text content - ensure text is visible in user messages */}
       {textContents.map((part, index) => (
-        <div key={`text-${index}`} className="text-current">
-          <MarkdownRenderer key={`text-${index}`} content={part.text} forceDarkTheme={true} />
+        <div key={`text-${index}`} className="text-current" style={{ whiteSpace: 'break-spaces' }}>
+          {part.text}
         </div>
       ))}
     </>

--- a/multimodal/tarko/agent-web-ui/src/standalone/chat/Message/index.tsx
+++ b/multimodal/tarko/agent-web-ui/src/standalone/chat/Message/index.tsx
@@ -126,13 +126,7 @@ export const Message: React.FC<MessageProps> = ({
 
     if (isUserMessage) {
       return (
-        <div
-          style={{
-            whiteSpace: 'break-spaces',
-          }}
-        >
-          {message.content as string}
-        </div>
+        <MarkdownRenderer content={message.content as string} forceDarkTheme={true} />
       );
     }
 

--- a/multimodal/tarko/agent-web-ui/src/standalone/chat/Message/index.tsx
+++ b/multimodal/tarko/agent-web-ui/src/standalone/chat/Message/index.tsx
@@ -126,7 +126,13 @@ export const Message: React.FC<MessageProps> = ({
 
     if (isUserMessage) {
       return (
-        <MarkdownRenderer content={message.content as string} forceDarkTheme={true} />
+        <div
+          style={{
+            whiteSpace: 'break-spaces',
+          }}
+        >
+          {message.content as string}
+        </div>
       );
     }
 


### PR DESCRIPTION
## Summary

Fixes text visibility issue in user messages by using consistent plain text rendering, avoiding markdown styling conflicts.

### Before

<img width="2102" height="1822" alt="image" src="https://github.com/user-attachments/assets/80821e32-786b-4a97-a0c2-d085014d1446" />

### After

<img width="2388" height="1498" alt="image" src="https://github.com/user-attachments/assets/bf00542d-9b80-4366-a17d-5416dc4b57a4" />



---


### Another Example Reporudction Prompts

Text + Image

<img width="954" height="354" alt="image" src="https://github.com/user-attachments/assets/4196a54d-ae6b-41ea-9e14-8ec85d045b22" />

````md
Explain this code in image and following block:

```ts
export type TConstructor<T, U extends unknown[] = unknown[]> = new (...args: U) => T;
```
````



### Before


<img width="3784" height="1908" alt="image" src="https://github.com/user-attachments/assets/1f26ac74-beaf-40a2-b563-cd40fc6c5918" />


### After

<img width="3776" height="1896" alt="image" src="https://github.com/user-attachments/assets/208e1d0a-ad2e-42ec-836e-00a8e7619d4d" />




## What's Next?


https://github.com/bytedance/UI-TARS-desktop/issues/1105

## Testing
- ✅ Build passes
- ✅ Text now visible in all user message types
- ✅ No unwanted toolbars or styling conflicts
- ✅ Clean, simple rendering approach

Closes #1103