### PR TITLE
Fix link leading to local docs for local and remote operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ English | [简体中文](./README.zh-CN.md)
         <br>
         <br>
         It primarily ships a
-        <a href="https://github.com/bytedance/UI-TARS-desktop/blob/docs/new-readme/docs/quick-start.md#get-model-and-run" target="_blank">local</a> and 
-        <a href="https://github.com/bytedance/UI-TARS-desktop/blob/docs/new-readme/docs/quick-start.md#try-out-our-free-remote-operators" target="_blank">remote</a> computer as well as browser operators.
+        <a href="https://github.com/bytedance/UI-TARS-desktop/blob/main/docs/quick-start.md#get-model-and-run-local-operator" target="_blank">local</a> and 
+        <a href="https://github.com/bytedance/UI-TARS-desktop/blob/main/docs/quick-start.md#run-remote-operator" target="_blank">remote</a> computer as well as browser operators.
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
<!--------------------------------------------------------------------------------
    Thank you for submitting a pull request!

    We appreciate the time and effort you have invested in making these changes. Please 
    ensure that you provide enough information to allow others to review your pull request 
    effectively, so please DO NOT delete this template.

    If you're new to contributing, learn more about contributing here:
    https://github.com/bytedance/UI-TARS-desktop/blob/main/CONTRIBUTING.md.  
---------------------------------------------------------------------------------->

## Summary

<!--------------------------------------------------------------------------------
    Can you explain the reasoning behind implementing this change?  
    What problem or issue does this pull request resolve?  

    It would be helpful to include relevant context, such as GitHub issues 
    (e.g., Close: #xxx) or related discussions.

    If updating the UI, please include a **before/after screenshot** for visibility.
    Thank you for reading. Next, start describing your Summary on the next line
    after the comment ends. 👇🏻
---------------------------------------------------------------------------------->

Upon trying to setup my local environment I noticed the links are pointing to an old version of the repository that points to the wrong blob. This change brings the two broken links back up.

## Checklist  

<!--  Before submitting the pull request, ensure the following items are checked: -->

- [ ] Added or updated necessary tests (Optional).  
- [ ] Updated documentation to align with changes (Optional).  
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).  
- [x] My change does not involve the above items. 
