### PR TITLE
feat(tarko): display workspace path in workspace header

### DIFF
--- a/multimodal/tarko/agent-web-ui/src/standalone/workspace/WorkspaceContent.tsx
+++ b/multimodal/tarko/agent-web-ui/src/standalone/workspace/WorkspaceContent.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
 import { useSession } from '@/common/hooks/useSession';
 import { usePlan } from '@/common/hooks/usePlan';
@@ -11,6 +11,8 @@ import {
   FiActivity,
   FiFileText,
 } from 'react-icons/fi';
+import { apiService } from '@/common/services/apiService';
+import { normalizeFilePath } from '@/common/utils/pathNormalizer';
 import './Workspace.css';
 
 /**
@@ -24,6 +26,21 @@ import './Workspace.css';
 export const WorkspaceContent: React.FC = () => {
   const { activeSessionId, setActivePanelContent } = useSession();
   const { currentPlan } = usePlan(activeSessionId);
+  const [workspacePath, setWorkspacePath] = useState<string>('');
+
+  useEffect(() => {
+    const fetchWorkspaceInfo = async () => {
+      try {
+        const workspaceInfo = await apiService.getWorkspaceInfo();
+        setWorkspacePath(normalizeFilePath(workspaceInfo.path));
+      } catch (error) {
+        console.error('Failed to fetch workspace info:', error);
+        setWorkspacePath('');
+      }
+    };
+
+    fetchWorkspaceInfo();
+  }, []);
 
   // Animation variants
   const containerVariants = {
@@ -206,7 +223,7 @@ export const WorkspaceContent: React.FC = () => {
         <div>
           <h2 className="font-medium text-gray-900 dark:text-gray-100 text-lg">Workspace</h2>
           <div className="text-xs text-gray-500 dark:text-gray-400">
-            View tool outputs and plan details
+            {workspacePath || 'Loading workspace...'}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Replace hardcoded "View tool outputs and plan details" text with actual workspace directory path in WorkspaceContent header. Uses getWorkspaceInfo API and normalizeFilePath utility for proper home directory handling.

### Before

<img width="2156" height="270" alt="image" src="https://github.com/user-attachments/assets/8dde4702-0307-45f1-9e9d-532e257ec943" />

### After
<img width="2150" height="258" alt="image" src="https://github.com/user-attachments/assets/ff65c738-7157-4dc1-adcd-ed583e86919d" />



## Checklist

- [ ] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [x] My change does not involve the above items.