### PR TITLE
feat(tarko): add raw events state

### DIFF
--- a/multimodal/tarko/agent-web-ui/src/common/state/atoms/rawEvents.ts
+++ b/multimodal/tarko/agent-web-ui/src/common/state/atoms/rawEvents.ts
@@ -1,0 +1,17 @@
+import { atom } from 'jotai';
+import { AgentEventStream } from '@/common/types';
+
+/**
+ * Raw event stream storage - grouped by session
+ */
+export const rawEventsAtom = atom<Record<string, AgentEventStream.Event[]>>({});
+
+/**
+ * Original tool call/result mapping
+ */
+export interface RawToolMapping {
+  toolCall: AgentEventStream.ToolCallEvent;
+  toolResult: AgentEventStream.ToolResultEvent | null;
+}
+
+export const rawToolMappingAtom = atom<Record<string, Record<string, RawToolMapping>>>({});


### PR DESCRIPTION
## Summary

Add raw events and tool mapping storage atoms to preserve original event data for debugging purposes.

## Usage

### All events

```ts
import { useAtomValue } from 'jotai';
import { rawEventsAtom } from '@/common/state/atoms/rawEvents';

function EventsComponent({ sessionId }: { sessionId: string }) {
  const rawEvents = useAtomValue(rawEventsAtom);
  const events = rawEvents[sessionId] || [];

  return (
    <div>
      <h3>Raw Events ({events.length})</h3>
      {events.map((event, index) => (
        <div key={index}>
          <strong>{event.type}</strong> - {event.timestamp}
        </div>
      ))}
    </div>
  );
}
```

### Tool events

```tsx
import { useAtomValue } from 'jotai';
import { rawToolMappingAtom } from '@/common/state/atoms/rawEvents';

function ToolsComponent({ sessionId }: { sessionId: string }) {
  const rawToolMapping = useAtomValue(rawToolMappingAtom);
  const toolMappings = rawToolMapping[sessionId] || {};

  return (
    <div>
      <h3>Tool Calls ({Object.keys(toolMappings).length})</h3>
      {Object.entries(toolMappings).map(([id, mapping]) => (
        <div key={id}>
          <strong>{mapping.toolCall?.name}</strong>
          {mapping.toolResult && <span> ✓</span>}
        </div>
      ))}
    </div>
  );
}
```

## Checklist  

- [ ] Added or updated necessary tests (Optional).  
- [ ] Updated documentation to align with changes (Optional).  
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).  
- [x] My change does not involve the above items.