### PR TITLE
fix(docs): correct workspace default path in English and Chinese guides

### DIFF
--- a/multimodal/websites/docs/docs/en/guide/basic/workspace.mdx
+++ b/multimodal/websites/docs/docs/en/guide/basic/workspace.mdx
@@ -6,7 +6,7 @@ In Agent TARS' local usage scenario, the directory that is currently allowed to 
 
 ## Default Settings
 
-To avoid affecting your local file system, the default value of Workspace is `$pwd/gent-tars-workspace`, which adds a layer of isolation. When you ask Agent TARS what files it can see:
+To avoid affecting your local file system, the default value of Workspace is `$pwd/agent-tars-workspace`, which adds a layer of isolation. When you ask Agent TARS what files it can see:
 
 ```text
 What files you can see?

--- a/multimodal/websites/docs/docs/zh/guide/basic/workspace.mdx
+++ b/multimodal/websites/docs/docs/zh/guide/basic/workspace.mdx
@@ -6,7 +6,7 @@ import { VideoPanel } from '@components/VideoPanel';
 
 ## 默认设定
 
-为了避免影响你本地的文件系统，Workspace 的默认值为 `$pwd/gent-tars-workspace`，相当于增加了一层隔离，当你问 Agent TARS 能看到哪些文件：
+为了避免影响你本地的文件系统，Workspace 的默认值为 `$pwd/agent-tars-workspace`，相当于增加了一层隔离，当你问 Agent TARS 能看到哪些文件：
 
 ```text
 What files you can see?


### PR DESCRIPTION
<!--------------------------------------------------------------------------------
    Thank you for submitting a pull request!

    We appreciate the time and effort you have invested in making these changes. Please 
    ensure that you provide enough information to allow others to review your pull request 
    effectively, so please DO NOT delete this template.

    If you're new to contributing, learn more about contributing here:
    https://github.com/bytedance/UI-TARS-desktop/blob/main/CONTRIBUTING.md.  
---------------------------------------------------------------------------------->

## Summary

Correct workspace default path in English and Chinese guides.

```diff
- $pwd/gent-tars-workspace
+ $pwd/agent-tars-workspace
```

## Checklist  

<!--  Before submitting the pull request, ensure the following items are checked: -->

- [ ] Added or updated necessary tests (Optional).  
- [ ] Updated documentation to align with changes (Optional).  
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).  
- [x] My change does not involve the above items. 
