### PR TITLE
feat(mcp): increase default timeout from 10s to 60s

### DIFF
--- a/packages/agent-infra/mcp-client/src/index.ts
+++ b/packages/agent-infra/mcp-client/src/index.ts
@@ -520,7 +520,7 @@ export class MCPClient<
         },
         undefined,
         {
-          timeout: server?.timeout ? server?.timeout * 1000 : 10000, // default: 10s
+          timeout: server?.timeout ? server?.timeout * 1000 : 60000, // default: 60s
         },
       );
       this.log('info', '[MCP] Call Tool Result:', result);


### PR DESCRIPTION
## Summary

Increase MCP client default timeout from 10 seconds to 60 seconds to prevent timeouts on slower operations.

Closes #1140

## Checklist

- [ ] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [x] My change does not involve the above items.