### PR TITLE
fix(tarko): inline code dark mode text color

### DIFF
--- a/multimodal/tarko/agent-web-ui/src/sdk/markdown-renderer/components/CodeBlock.tsx
+++ b/multimodal/tarko/agent-web-ui/src/sdk/markdown-renderer/components/CodeBlock.tsx
@@ -15,7 +15,7 @@ export const CodeBlock: React.FC<CodeBlockProps> = ({ inline, className, childre
 
   if (inline || !match) {
     return (
-      <code className="font-mono text-[#525252] bg-[#1b1f230d] dark:bg-[#333e4ecc] dark:text-gray-800 px-1 py-0.5 mx-0.5 whitespace-nowrap rounded-md">
+      <code className="font-mono text-[#525252] bg-[#1b1f230d] dark:bg-[#333e4ecc] dark:text-gray-200 px-1 py-0.5 mx-0.5 whitespace-nowrap rounded-md">
         {children}
       </code>
     );


### PR DESCRIPTION
## Summary

Fixed inline code text color in dark mode from `dark:text-gray-800` to `dark:text-gray-200` for better visibility.

```tsx
// Before
<code className="... dark:text-gray-800 ...">

// After  
<code className="... dark:text-gray-200 ...">
```

### Before

<img width="1646" height="282" alt="image" src="https://github.com/user-attachments/assets/93c17f9e-cb6c-4423-816a-7d2d8fa2cc62" />


### After

<img width="1644" height="250" alt="image" src="https://github.com/user-attachments/assets/49a14d80-1019-4315-9ba0-bbacf72636be" />


## Checklist

- [ ] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [x] My change does not involve the above items.