### PR TITLE
feat(tarko): add workspace config support for instructions.md

### DIFF
--- a/multimodal/tarko/agent-cli/src/config/builder.ts
+++ b/multimodal/tarko/agent-cli/src/config/builder.ts
@@ -25,12 +25,11 @@ export type CLIOptionsEnhancer<
 > = (cliArguments: T, appConfig: Partial<U>) => void;
 
 /**
-
  * Build complete application configuration from CLI arguments, user config, and app defaults
- * 
+ *
  * Follows the configuration priority order:
  * L0: CLI Arguments (highest priority)
- * L1: Workspace Config File  
+ * L1: Workspace Config File
  * L2: Global Workspace Config File
  * L3: CLI Config Files
  * L4: CLI Remote Config
@@ -46,21 +45,18 @@ export function buildAppConfig<
   cliOptionsEnhancer?: CLIOptionsEnhancer<T, U>,
   workspacePath?: string,
 ): U {
-  // Start with app defaults (L5 - lowest priority)
   let config: Partial<U> = appDefaults ? { ...appDefaults } : {};
 
-  // Merge with user config (L4-L1 based on file loading order)
   // @ts-expect-error
   config = deepMerge(config, userConfig);
 
-  // Load and merge workspace config (L1 - high priority)
   if (workspacePath) {
     const workspaceConfig = loadWorkspaceConfig(workspacePath);
     // @ts-expect-error
     config = deepMerge(config, workspaceConfig);
   }
 
-  // Extract CLI-specific properties that need special handling
+  // Extract CLI-specific properties
   const {
     agent,
     workspace,
@@ -81,7 +77,7 @@ export function buildAppConfig<
     ...cliConfigProps
   } = cliArguments;
 
-  // Handle core deprecated options
+  // Handle deprecated options
   const deprecatedOptions = { provider, apiKey: apiKey || undefined, baseURL, shareProvider }; // secretlint-disable-line @secretlint/secretlint-rule-pattern
   const deprecatedKeys = Object.entries(deprecatedOptions)
     .filter(([, value]) => value !== undefined)
@@ -90,32 +86,31 @@ export function buildAppConfig<
   logDeprecatedWarning(deprecatedKeys);
   handleCoreDeprecatedOptions(cliConfigProps, deprecatedOptions);
 
-  // Handle tool filter options
+  // Handle tool filters
   handleToolFilterOptions(cliConfigProps, { tool });
 
-  // Handle MCP server filter options
+  // Handle MCP server filters
   handleMCPServerFilterOptions(cliConfigProps, { mcpServer });
 
-  // Allow external handler to process additional options
+  // Process additional options
   if (cliOptionsEnhancer) {
     cliOptionsEnhancer(cliArguments, config);
   }
 
-  // Extract environment variables in CLI model configuration
+  // Resolve model secrets
   resolveModelSecrets(cliConfigProps);
 
-  // Merge CLI configuration properties (L0 - highest priority)
-  // @ts-expect-error TypeScript cannot infer the complex generic relationship
+  // @ts-expect-error
   config = deepMerge(config, cliConfigProps);
 
-  // Apply CLI shortcuts and special handling
+  // Apply CLI shortcuts
   applyLoggingShortcuts(config, { debug, quiet });
   applyServerConfiguration(config, { port });
 
-  // Apply WebUI defaults after all merging is complete
+  // Apply WebUI defaults
   applyWebUIDefaults(config as AgentAppConfig);
 
-  // Log final configuration summary (debug only)
+  // Log configuration
   const isDebug = cliArguments.debug || false;
   logConfigComplete(config as AgentAppConfig, isDebug);
 

--- a/multimodal/tarko/agent-cli/src/config/builder.ts
+++ b/multimodal/tarko/agent-cli/src/config/builder.ts
@@ -13,7 +13,7 @@ import {
   LogLevel,
   isAgentWebUIImplementationType,
 } from '@tarko/interface';
-import { resolveValue } from '../utils';
+import { resolveValue, loadWorkspaceConfig } from '../utils';
 import { logDeprecatedWarning, logConfigComplete } from './display';
 
 /**
@@ -44,6 +44,7 @@ export function buildAppConfig<
   userConfig: Partial<U>,
   appDefaults?: Partial<U>,
   cliOptionsEnhancer?: CLIOptionsEnhancer<T, U>,
+  workspacePath?: string,
 ): U {
   // Start with app defaults (L5 - lowest priority)
   let config: Partial<U> = appDefaults ? { ...appDefaults } : {};
@@ -51,6 +52,13 @@ export function buildAppConfig<
   // Merge with user config (L4-L1 based on file loading order)
   // @ts-expect-error
   config = deepMerge(config, userConfig);
+
+  // Load and merge workspace config (L1 - high priority)
+  if (workspacePath) {
+    const workspaceConfig = loadWorkspaceConfig(workspacePath);
+    // @ts-expect-error
+    config = deepMerge(config, workspaceConfig);
+  }
 
   // Extract CLI-specific properties that need special handling
   const {

--- a/multimodal/tarko/agent-cli/src/core/cli.ts
+++ b/multimodal/tarko/agent-cli/src/core/cli.ts
@@ -338,6 +338,7 @@ export class AgentCLI {
       userConfig,
       this.options.appConfig,
       cliOptionsEnhancer,
+      workspace,
     );
 
     // Update logger level with final config if it differs from CLI arguments

--- a/multimodal/tarko/agent-cli/src/utils/index.ts
+++ b/multimodal/tarko/agent-cli/src/utils/index.ts
@@ -8,5 +8,6 @@ export * from './logo';
 export * from './misc';
 export * from './console-interceptor';
 export * from './workspace-path';
+export * from './workspace-config';
 export * from './port';
 export * from './server-setup';

--- a/multimodal/tarko/agent-cli/src/utils/workspace-config.ts
+++ b/multimodal/tarko/agent-cli/src/utils/workspace-config.ts
@@ -17,9 +17,6 @@ export const WORKSPACE_CONFIG_PATHS = {
 
 /**
  * Load workspace configuration from .tarko directory
- *
- * @param workspacePath The workspace directory path
- * @returns Partial configuration to merge with existing config
  */
 export function loadWorkspaceConfig(workspacePath: string): Partial<AgentAppConfig> {
   const config: Partial<AgentAppConfig> = {};
@@ -33,7 +30,6 @@ export function loadWorkspaceConfig(workspacePath: string): Partial<AgentAppConf
         config.instructions = instructions;
       }
     } catch (error) {
-      // Silently ignore read errors to avoid breaking the CLI
       console.warn(
         `Warning: Failed to read ${instructionsPath}: ${error instanceof Error ? error.message : String(error)}`,
       );
@@ -45,9 +41,6 @@ export function loadWorkspaceConfig(workspacePath: string): Partial<AgentAppConf
 
 /**
  * Check if workspace has any .tarko configuration files
- *
- * @param workspacePath The workspace directory path
- * @returns True if any .tarko config files exist
  */
 export function hasWorkspaceConfig(workspacePath: string): boolean {
   const tarkoDir = path.join(workspacePath, '.tarko');
@@ -55,7 +48,6 @@ export function hasWorkspaceConfig(workspacePath: string): boolean {
     return false;
   }
 
-  // Check for instructions.md
   const instructionsPath = path.join(workspacePath, WORKSPACE_CONFIG_PATHS.INSTRUCTIONS);
   return fs.existsSync(instructionsPath);
 }

--- a/multimodal/tarko/agent-cli/src/utils/workspace-config.ts
+++ b/multimodal/tarko/agent-cli/src/utils/workspace-config.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { AgentAppConfig } from '@tarko/interface';
+
+/**
+ * Workspace configuration file paths
+ */
+export const WORKSPACE_CONFIG_PATHS = {
+  INSTRUCTIONS: '.tarko/instructions.md',
+  // Future: RULES: '.tarko/rules/*.md',
+} as const;
+
+/**
+ * Load workspace configuration from .tarko directory
+ *
+ * @param workspacePath The workspace directory path
+ * @returns Partial configuration to merge with existing config
+ */
+export function loadWorkspaceConfig(workspacePath: string): Partial<AgentAppConfig> {
+  const config: Partial<AgentAppConfig> = {};
+
+  // Load instructions.md if exists
+  const instructionsPath = path.join(workspacePath, WORKSPACE_CONFIG_PATHS.INSTRUCTIONS);
+  if (fs.existsSync(instructionsPath)) {
+    try {
+      const instructions = fs.readFileSync(instructionsPath, 'utf-8').trim();
+      if (instructions) {
+        config.instructions = instructions;
+      }
+    } catch (error) {
+      // Silently ignore read errors to avoid breaking the CLI
+      console.warn(
+        `Warning: Failed to read ${instructionsPath}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  return config;
+}
+
+/**
+ * Check if workspace has any .tarko configuration files
+ *
+ * @param workspacePath The workspace directory path
+ * @returns True if any .tarko config files exist
+ */
+export function hasWorkspaceConfig(workspacePath: string): boolean {
+  const tarkoDir = path.join(workspacePath, '.tarko');
+  if (!fs.existsSync(tarkoDir)) {
+    return false;
+  }
+
+  // Check for instructions.md
+  const instructionsPath = path.join(workspacePath, WORKSPACE_CONFIG_PATHS.INSTRUCTIONS);
+  return fs.existsSync(instructionsPath);
+}

--- a/multimodal/tarko/agent-cli/tests/config-builder.test.ts
+++ b/multimodal/tarko/agent-cli/tests/config-builder.test.ts
@@ -24,15 +24,6 @@ vi.mock('../src/utils', () => ({
 
 /**
  * Test suite for the buildAppConfig function
- *
- * These tests verify:
- * 1. CLI arguments are properly merged with user configuration
- * 2. Nested configuration structures are handled correctly
- * 3. Environment variable resolution works
- * 4. Configuration merging prioritizes CLI over user config
- * 5. CLI shortcuts (debug, quiet, port) work correctly
- * 6. Deprecated options are handled correctly
- * 7. Server storage defaults are applied correctly
  */
 describe('buildAppConfig', () => {
   beforeEach(() => {
@@ -254,10 +245,8 @@ describe('buildAppConfig', () => {
     });
 
     it('should resolve environment variables in model configuration', async () => {
-      // Get the mocked resolveValue function
       const { resolveValue } = await import('../src/utils');
 
-      // Configure the mock to return specific values
       vi.mocked(resolveValue)
         .mockReturnValueOnce('resolved-api-key')
         .mockReturnValueOnce('resolved-base-url');
@@ -699,10 +688,8 @@ describe('buildAppConfig', () => {
 
   describe('workspace configuration integration', () => {
     it('should merge workspace config when workspacePath is provided', async () => {
-      // Get the mocked loadWorkspaceConfig function
       const { loadWorkspaceConfig } = await import('../src/utils');
 
-      // Configure the mock to return workspace config
       vi.mocked(loadWorkspaceConfig).mockReturnValue({
         instructions: 'You are a workspace-specific assistant.',
       });
@@ -747,7 +734,6 @@ describe('buildAppConfig', () => {
     it('should prioritize workspace config over user config', async () => {
       const { loadWorkspaceConfig } = await import('../src/utils');
 
-      // Workspace config should override user config
       vi.mocked(loadWorkspaceConfig).mockReturnValue({
         instructions: 'Workspace instructions',
         model: {
@@ -799,7 +785,6 @@ describe('buildAppConfig', () => {
     it('should handle workspace config with empty return', async () => {
       const { loadWorkspaceConfig } = await import('../src/utils');
 
-      // Empty workspace config should not affect the result
       vi.mocked(loadWorkspaceConfig).mockReturnValue({});
 
       const cliArgs: AgentCLIArguments = {

--- a/multimodal/tarko/agent-cli/tests/workspace-config-e2e.test.ts
+++ b/multimodal/tarko/agent-cli/tests/workspace-config-e2e.test.ts
@@ -197,8 +197,19 @@ For this specific project:
       const result = buildAppConfig({}, {}, undefined, undefined, workspacePath);
 
       expect(result.instructions).toBe(multilineInstructions);
-      expect(result.instructions).toContain('You are a helpful coding assistant.');
-      expect(result.instructions).toContain('React and Node.js development');
+      expect(result.instructions).toMatchInlineSnapshot(`
+        "You are a helpful coding assistant.
+
+        Please follow these guidelines:
+        - Write clean, readable code
+        - Add comprehensive comments
+        - Use TypeScript best practices
+        - Follow the project's coding standards
+
+        For this specific project:
+        - Focus on React and Node.js development
+        - Prioritize performance and maintainability"
+      `);
     });
   });
 
@@ -234,8 +245,9 @@ For this specific project:
 
       const result = buildAppConfig(cliArgs, {}, undefined, undefined, workspacePath);
 
-      expect(result.instructions).toContain('test-project');
-      expect(result.instructions).toContain('TypeScript/Node.js');
+      expect(result.instructions).toMatchInlineSnapshot(`
+        "You are working on the test-project. This is a TypeScript/Node.js project. Please help with code reviews, bug fixes, and feature development."
+      `);
       expect(result.model?.provider).toBe('openai');
       expect(result.model?.id).toBe('gpt-4');
       expect(result.server?.port).toBe(8080);

--- a/multimodal/tarko/agent-cli/tests/workspace-config-e2e.test.ts
+++ b/multimodal/tarko/agent-cli/tests/workspace-config-e2e.test.ts
@@ -12,13 +12,6 @@ import { AgentCLIArguments, AgentAppConfig } from '@tarko/interface';
 
 /**
  * End-to-end tests for workspace configuration feature
- *
- * These tests verify the complete integration of workspace config
- * through the actual configuration building process, testing:
- * 1. Real file system operations for .tarko/instructions.md
- * 2. Workspace config is properly merged with other configs
- * 3. Priority order is correctly maintained
- * 4. Error handling in real scenarios
  */
 describe('workspace-config E2E', () => {
   let tempDir: string;
@@ -28,24 +21,19 @@ describe('workspace-config E2E', () => {
   let originalCwd: string;
 
   beforeEach(() => {
-    // Save original working directory
     originalCwd = process.cwd();
 
-    // Create temporary workspace
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tarko-e2e-'));
     workspacePath = tempDir;
     tarkoDir = path.join(workspacePath, '.tarko');
     instructionsPath = path.join(tarkoDir, 'instructions.md');
 
-    // Change to temp directory to simulate real workspace
     process.chdir(workspacePath);
   });
 
   afterEach(() => {
-    // Restore original working directory
     process.chdir(originalCwd);
 
-    // Clean up temporary directory
     if (fs.existsSync(tempDir)) {
       fs.rmSync(tempDir, { recursive: true, force: true });
     }

--- a/multimodal/tarko/agent-cli/tests/workspace-config-e2e.test.ts
+++ b/multimodal/tarko/agent-cli/tests/workspace-config-e2e.test.ts
@@ -1,0 +1,262 @@
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { buildAppConfig } from '../src/config/builder';
+import { AgentCLIArguments, AgentAppConfig } from '@tarko/interface';
+
+/**
+ * End-to-end tests for workspace configuration feature
+ *
+ * These tests verify the complete integration of workspace config
+ * through the actual configuration building process, testing:
+ * 1. Real file system operations for .tarko/instructions.md
+ * 2. Workspace config is properly merged with other configs
+ * 3. Priority order is correctly maintained
+ * 4. Error handling in real scenarios
+ */
+describe('workspace-config E2E', () => {
+  let tempDir: string;
+  let workspacePath: string;
+  let tarkoDir: string;
+  let instructionsPath: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    // Save original working directory
+    originalCwd = process.cwd();
+
+    // Create temporary workspace
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tarko-e2e-'));
+    workspacePath = tempDir;
+    tarkoDir = path.join(workspacePath, '.tarko');
+    instructionsPath = path.join(tarkoDir, 'instructions.md');
+
+    // Change to temp directory to simulate real workspace
+    process.chdir(workspacePath);
+  });
+
+  afterEach(() => {
+    // Restore original working directory
+    process.chdir(originalCwd);
+
+    // Clean up temporary directory
+    if (fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  describe('Real file system integration', () => {
+    it('should load workspace instructions when .tarko/instructions.md exists', () => {
+      // Setup workspace config
+      const workspaceInstructions = 'You are a TypeScript expert assistant for this project.';
+      fs.mkdirSync(tarkoDir, { recursive: true });
+      fs.writeFileSync(instructionsPath, workspaceInstructions);
+
+      // Build config with real file system operations
+      const cliArgs: AgentCLIArguments = {
+        model: {
+          provider: 'openai',
+          id: 'gpt-4',
+        },
+      };
+
+      const userConfig: AgentAppConfig = {};
+
+      const result = buildAppConfig(cliArgs, userConfig, undefined, undefined, workspacePath);
+
+      // Verify workspace instructions were loaded
+      expect(result.instructions).toBe(workspaceInstructions);
+      expect(result.model?.provider).toBe('openai');
+      expect(result.model?.id).toBe('gpt-4');
+    });
+
+    it('should prioritize CLI args > workspace config > user config', () => {
+      // Setup workspace config
+      const workspaceInstructions = 'Workspace instructions';
+      fs.mkdirSync(tarkoDir, { recursive: true });
+      fs.writeFileSync(instructionsPath, workspaceInstructions);
+
+      // User config (lowest priority)
+      const userConfig: AgentAppConfig = {
+        instructions: 'User instructions',
+        model: {
+          provider: 'anthropic',
+          id: 'claude-3',
+        },
+      };
+
+      // CLI args (highest priority)
+      const cliArgs: AgentCLIArguments = {
+        model: {
+          provider: 'openai', // Should override workspace and user
+        },
+        debug: true, // Should override user logLevel
+      };
+
+      const result = buildAppConfig(cliArgs, userConfig, undefined, undefined, workspacePath);
+
+      // Verify priority order
+      expect(result.instructions).toBe('Workspace instructions'); // Workspace overrides user
+      expect(result.model?.provider).toBe('openai'); // CLI overrides workspace
+      expect(result.model?.id).toBe('claude-3'); // User config preserved where not overridden
+      // Note: logLevel is set by applyLoggingShortcuts which runs after config merging
+      // The debug flag sets logLevel to DEBUG (3) during the shortcuts application
+    });
+
+    it('should work when no workspace config exists', () => {
+      // No .tarko directory created
+
+      const userConfig: AgentAppConfig = {
+        instructions: 'User instructions',
+        model: {
+          provider: 'openai',
+        },
+      };
+
+      const cliArgs: AgentCLIArguments = {
+        port: 3000,
+      };
+
+      const result = buildAppConfig(cliArgs, userConfig, undefined, undefined, workspacePath);
+
+      // Should use user config since no workspace config
+      expect(result.instructions).toBe('User instructions');
+      expect(result.model?.provider).toBe('openai');
+      expect(result.server?.port).toBe(3000);
+    });
+
+    it('should handle empty workspace instructions file', () => {
+      // Create empty instructions file
+      fs.mkdirSync(tarkoDir, { recursive: true });
+      fs.writeFileSync(instructionsPath, '   \n\n   '); // Only whitespace
+
+      const userConfig: AgentAppConfig = {
+        instructions: 'User instructions',
+      };
+
+      const result = buildAppConfig({}, userConfig, undefined, undefined, workspacePath);
+
+      // Should use user config since workspace file is empty
+      expect(result.instructions).toBe('User instructions');
+    });
+
+    it('should handle file read errors gracefully', () => {
+      // Create instructions file with restricted permissions
+      fs.mkdirSync(tarkoDir, { recursive: true });
+      fs.writeFileSync(instructionsPath, 'Test instructions');
+
+      // Mock console.warn to capture warning messages
+      const mockWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      // Mock fs.readFileSync to simulate permission error
+      const originalReadFileSync = fs.readFileSync;
+      vi.spyOn(fs, 'readFileSync').mockImplementation((filePath, options) => {
+        if (typeof filePath === 'string' && filePath.includes('instructions.md')) {
+          throw new Error('Permission denied');
+        }
+        return originalReadFileSync(filePath, options);
+      });
+
+      const userConfig: AgentAppConfig = {
+        instructions: 'User instructions',
+      };
+
+      const result = buildAppConfig({}, userConfig, undefined, undefined, workspacePath);
+
+      // Should fall back to user config and log warning
+      expect(result.instructions).toBe('User instructions');
+      expect(mockWarn).toHaveBeenCalledWith(expect.stringContaining('Warning: Failed to read'));
+
+      // Restore mocks
+      mockWarn.mockRestore();
+      vi.restoreAllMocks();
+    });
+
+    it('should handle multiline workspace instructions correctly', () => {
+      const multilineInstructions = `You are a helpful coding assistant.
+
+Please follow these guidelines:
+- Write clean, readable code
+- Add comprehensive comments
+- Use TypeScript best practices
+- Follow the project's coding standards
+
+For this specific project:
+- Focus on React and Node.js development
+- Prioritize performance and maintainability`;
+
+      fs.mkdirSync(tarkoDir, { recursive: true });
+      fs.writeFileSync(instructionsPath, multilineInstructions);
+
+      const result = buildAppConfig({}, {}, undefined, undefined, workspacePath);
+
+      expect(result.instructions).toBe(multilineInstructions);
+      expect(result.instructions).toContain('You are a helpful coding assistant.');
+      expect(result.instructions).toContain('React and Node.js development');
+    });
+  });
+
+  describe('Real workspace scenarios', () => {
+    it('should work with typical project structure', () => {
+      // Simulate a real project structure
+      fs.mkdirSync(path.join(workspacePath, 'src'), { recursive: true });
+      fs.mkdirSync(path.join(workspacePath, 'tests'));
+      fs.writeFileSync(
+        path.join(workspacePath, 'package.json'),
+        JSON.stringify({
+          name: 'test-project',
+          version: '1.0.0',
+        }),
+      );
+      fs.writeFileSync(path.join(workspacePath, 'README.md'), '# Test Project');
+
+      // Add workspace config
+      fs.mkdirSync(tarkoDir, { recursive: true });
+      fs.writeFileSync(
+        instructionsPath,
+        'You are working on the test-project. This is a TypeScript/Node.js project. ' +
+          'Please help with code reviews, bug fixes, and feature development.',
+      );
+
+      const cliArgs: AgentCLIArguments = {
+        model: {
+          provider: 'openai',
+          id: 'gpt-4',
+        },
+        port: 8080,
+      };
+
+      const result = buildAppConfig(cliArgs, {}, undefined, undefined, workspacePath);
+
+      expect(result.instructions).toContain('test-project');
+      expect(result.instructions).toContain('TypeScript/Node.js');
+      expect(result.model?.provider).toBe('openai');
+      expect(result.model?.id).toBe('gpt-4');
+      expect(result.server?.port).toBe(8080);
+    });
+
+    it('should handle different workspace paths correctly', () => {
+      // Create workspace config in the temp directory
+      fs.mkdirSync(tarkoDir, { recursive: true });
+      fs.writeFileSync(instructionsPath, 'Root workspace instructions');
+
+      // Test with different workspace path (subdirectory that doesn't have .tarko)
+      const subDir = path.join(workspacePath, 'packages', 'frontend');
+      fs.mkdirSync(subDir, { recursive: true });
+
+      // Use subdirectory as workspace path (should not find config)
+      const result1 = buildAppConfig({}, {}, undefined, undefined, subDir);
+      expect(result1.instructions).toBeUndefined();
+
+      // Use root directory as workspace path (should find config)
+      const result2 = buildAppConfig({}, {}, undefined, undefined, workspacePath);
+      expect(result2.instructions).toBe('Root workspace instructions');
+    });
+  });
+});

--- a/multimodal/tarko/agent-cli/tests/workspace-config.test.ts
+++ b/multimodal/tarko/agent-cli/tests/workspace-config.test.ts
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import {
+  loadWorkspaceConfig,
+  hasWorkspaceConfig,
+  WORKSPACE_CONFIG_PATHS,
+} from '../src/utils/workspace-config';
+
+/**
+ * Test suite for workspace configuration utilities
+ *
+ * These tests verify:
+ * 1. loadWorkspaceConfig correctly loads instructions.md
+ * 2. hasWorkspaceConfig detects workspace configuration
+ * 3. Error handling for file system operations
+ * 4. Edge cases with empty files and missing directories
+ */
+describe('workspace-config', () => {
+  let tempDir: string;
+  let workspacePath: string;
+
+  beforeEach(() => {
+    // Create a temporary directory for each test
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tarko-test-'));
+    workspacePath = tempDir;
+  });
+
+  afterEach(() => {
+    // Clean up temporary directory
+    if (fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  describe('loadWorkspaceConfig', () => {
+    it('should return empty config when .tarko directory does not exist', () => {
+      const result = loadWorkspaceConfig(workspacePath);
+      expect(result).toEqual({});
+    });
+
+    it('should return empty config when instructions.md does not exist', () => {
+      // Create .tarko directory but no instructions.md
+      const tarkoDir = path.join(workspacePath, '.tarko');
+      fs.mkdirSync(tarkoDir);
+
+      const result = loadWorkspaceConfig(workspacePath);
+      expect(result).toEqual({});
+    });
+
+    it('should load instructions from instructions.md', () => {
+      const tarkoDir = path.join(workspacePath, '.tarko');
+      const instructionsPath = path.join(workspacePath, WORKSPACE_CONFIG_PATHS.INSTRUCTIONS);
+      const instructionsContent = 'You are a helpful coding assistant specialized in TypeScript.';
+
+      fs.mkdirSync(tarkoDir, { recursive: true });
+      fs.writeFileSync(instructionsPath, instructionsContent);
+
+      const result = loadWorkspaceConfig(workspacePath);
+      expect(result).toEqual({
+        instructions: instructionsContent,
+      });
+    });
+
+    it('should trim whitespace from instructions', () => {
+      const tarkoDir = path.join(workspacePath, '.tarko');
+      const instructionsPath = path.join(workspacePath, WORKSPACE_CONFIG_PATHS.INSTRUCTIONS);
+      const instructionsContent = '\n\n  You are a helpful assistant.  \n\n';
+      const expectedContent = 'You are a helpful assistant.';
+
+      fs.mkdirSync(tarkoDir, { recursive: true });
+      fs.writeFileSync(instructionsPath, instructionsContent);
+
+      const result = loadWorkspaceConfig(workspacePath);
+      expect(result).toEqual({
+        instructions: expectedContent,
+      });
+    });
+
+    it('should return empty config when instructions.md is empty after trimming', () => {
+      const tarkoDir = path.join(workspacePath, '.tarko');
+      const instructionsPath = path.join(workspacePath, WORKSPACE_CONFIG_PATHS.INSTRUCTIONS);
+
+      fs.mkdirSync(tarkoDir, { recursive: true });
+      fs.writeFileSync(instructionsPath, '   \n\n   ');
+
+      const result = loadWorkspaceConfig(workspacePath);
+      expect(result).toEqual({});
+    });
+
+    it('should handle file read errors gracefully', () => {
+      const tarkoDir = path.join(workspacePath, '.tarko');
+      const instructionsPath = path.join(workspacePath, WORKSPACE_CONFIG_PATHS.INSTRUCTIONS);
+
+      fs.mkdirSync(tarkoDir, { recursive: true });
+      fs.writeFileSync(instructionsPath, 'test content');
+
+      // Mock fs.readFileSync to throw an error
+      const originalReadFileSync = fs.readFileSync;
+      const mockConsoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      vi.spyOn(fs, 'readFileSync').mockImplementation((filePath, options) => {
+        if (filePath === instructionsPath) {
+          throw new Error('Permission denied');
+        }
+        return originalReadFileSync(filePath, options);
+      });
+
+      const result = loadWorkspaceConfig(workspacePath);
+
+      expect(result).toEqual({});
+      expect(mockConsoleWarn).toHaveBeenCalledWith(
+        expect.stringContaining('Warning: Failed to read'),
+      );
+      expect(mockConsoleWarn).toHaveBeenCalledWith(expect.stringContaining('Permission denied'));
+
+      // Restore mocks
+      vi.restoreAllMocks();
+      mockConsoleWarn.mockRestore();
+    });
+
+    it('should handle non-Error exceptions gracefully', () => {
+      const tarkoDir = path.join(workspacePath, '.tarko');
+      const instructionsPath = path.join(workspacePath, WORKSPACE_CONFIG_PATHS.INSTRUCTIONS);
+
+      fs.mkdirSync(tarkoDir, { recursive: true });
+      fs.writeFileSync(instructionsPath, 'test content');
+
+      // Mock fs.readFileSync to throw a non-Error object
+      const originalReadFileSync = fs.readFileSync;
+      const mockConsoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      vi.spyOn(fs, 'readFileSync').mockImplementation((filePath, options) => {
+        if (filePath === instructionsPath) {
+          throw 'String error';
+        }
+        return originalReadFileSync(filePath, options);
+      });
+
+      const result = loadWorkspaceConfig(workspacePath);
+
+      expect(result).toEqual({});
+      expect(mockConsoleWarn).toHaveBeenCalledWith(expect.stringContaining('String error'));
+
+      // Restore mocks
+      vi.restoreAllMocks();
+      mockConsoleWarn.mockRestore();
+    });
+
+    it('should load multiline instructions correctly', () => {
+      const tarkoDir = path.join(workspacePath, '.tarko');
+      const instructionsPath = path.join(workspacePath, WORKSPACE_CONFIG_PATHS.INSTRUCTIONS);
+      const instructionsContent = `You are a helpful coding assistant.
+
+Please follow these guidelines:
+- Write clean code
+- Add proper comments
+- Use TypeScript`;
+
+      fs.mkdirSync(tarkoDir, { recursive: true });
+      fs.writeFileSync(instructionsPath, instructionsContent);
+
+      const result = loadWorkspaceConfig(workspacePath);
+      expect(result).toEqual({
+        instructions: instructionsContent,
+      });
+    });
+  });
+
+  describe('hasWorkspaceConfig', () => {
+    it('should return false when .tarko directory does not exist', () => {
+      const result = hasWorkspaceConfig(workspacePath);
+      expect(result).toBe(false);
+    });
+
+    it('should return false when .tarko directory exists but no instructions.md', () => {
+      const tarkoDir = path.join(workspacePath, '.tarko');
+      fs.mkdirSync(tarkoDir);
+
+      const result = hasWorkspaceConfig(workspacePath);
+      expect(result).toBe(false);
+    });
+
+    it('should return true when instructions.md exists', () => {
+      const tarkoDir = path.join(workspacePath, '.tarko');
+      const instructionsPath = path.join(workspacePath, WORKSPACE_CONFIG_PATHS.INSTRUCTIONS);
+
+      fs.mkdirSync(tarkoDir, { recursive: true });
+      fs.writeFileSync(instructionsPath, 'test instructions');
+
+      const result = hasWorkspaceConfig(workspacePath);
+      expect(result).toBe(true);
+    });
+
+    it('should return true even when instructions.md is empty', () => {
+      const tarkoDir = path.join(workspacePath, '.tarko');
+      const instructionsPath = path.join(workspacePath, WORKSPACE_CONFIG_PATHS.INSTRUCTIONS);
+
+      fs.mkdirSync(tarkoDir, { recursive: true });
+      fs.writeFileSync(instructionsPath, '');
+
+      const result = hasWorkspaceConfig(workspacePath);
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('WORKSPACE_CONFIG_PATHS', () => {
+    it('should have correct path for instructions', () => {
+      expect(WORKSPACE_CONFIG_PATHS.INSTRUCTIONS).toBe('.tarko/instructions.md');
+    });
+  });
+});

--- a/multimodal/tarko/agent-cli/tests/workspace-config.test.ts
+++ b/multimodal/tarko/agent-cli/tests/workspace-config.test.ts
@@ -15,25 +15,17 @@ import {
 
 /**
  * Test suite for workspace configuration utilities
- *
- * These tests verify:
- * 1. loadWorkspaceConfig correctly loads instructions.md
- * 2. hasWorkspaceConfig detects workspace configuration
- * 3. Error handling for file system operations
- * 4. Edge cases with empty files and missing directories
  */
 describe('workspace-config', () => {
   let tempDir: string;
   let workspacePath: string;
 
   beforeEach(() => {
-    // Create a temporary directory for each test
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tarko-test-'));
     workspacePath = tempDir;
   });
 
   afterEach(() => {
-    // Clean up temporary directory
     if (fs.existsSync(tempDir)) {
       fs.rmSync(tempDir, { recursive: true, force: true });
     }
@@ -46,7 +38,6 @@ describe('workspace-config', () => {
     });
 
     it('should return empty config when instructions.md does not exist', () => {
-      // Create .tarko directory but no instructions.md
       const tarkoDir = path.join(workspacePath, '.tarko');
       fs.mkdirSync(tarkoDir);
 
@@ -101,7 +92,6 @@ describe('workspace-config', () => {
       fs.mkdirSync(tarkoDir, { recursive: true });
       fs.writeFileSync(instructionsPath, 'test content');
 
-      // Mock fs.readFileSync to throw an error
       const originalReadFileSync = fs.readFileSync;
       const mockConsoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
@@ -120,7 +110,6 @@ describe('workspace-config', () => {
       );
       expect(mockConsoleWarn).toHaveBeenCalledWith(expect.stringContaining('Permission denied'));
 
-      // Restore mocks
       vi.restoreAllMocks();
       mockConsoleWarn.mockRestore();
     });
@@ -132,7 +121,6 @@ describe('workspace-config', () => {
       fs.mkdirSync(tarkoDir, { recursive: true });
       fs.writeFileSync(instructionsPath, 'test content');
 
-      // Mock fs.readFileSync to throw a non-Error object
       const originalReadFileSync = fs.readFileSync;
       const mockConsoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
@@ -148,7 +136,6 @@ describe('workspace-config', () => {
       expect(result).toEqual({});
       expect(mockConsoleWarn).toHaveBeenCalledWith(expect.stringContaining('String error'));
 
-      // Restore mocks
       vi.restoreAllMocks();
       mockConsoleWarn.mockRestore();
     });

--- a/multimodal/tarko/agent-cli/vitest.config.mts
+++ b/multimodal/tarko/agent-cli/vitest.config.mts
@@ -9,4 +9,8 @@ export default defineConfig({
     environment: 'node',
     include: ['**/*.test.ts'],
   },
+  define: {
+    __BUILD_TIME__: JSON.stringify(new Date().toISOString()),
+    __GIT_HASH__: JSON.stringify('test-hash'),
+  },
 });


### PR DESCRIPTION
## Summary

Adds support for workspace-specific configuration files in Agent CLI. The CLI now automatically loads `.tarko/instructions.md` from the workspace directory and injects it as the agent's system prompt.

### Configuration Priority Order

- L0: CLI Arguments (highest priority)
- **L1: Workspace Config File (.tarko/instructions.md)** ← New addition
- L2: Global Workspace Config File
- L3: CLI Config Files
- L4: CLI Remote Config
- L5: CLI Node API Config (lowest priority)

### Usage

```bash
# Create workspace instructions
mkdir -p .tarko
echo "You are a helpful coding assistant specialized in TypeScript." > .tarko/instructions.md

# Run agent with workspace-specific instructions
tarko start
```

## Checklist

- [x] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [ ] My change does not involve the above items.