### PR TITLE
feat(agent-tars): support flexible system prompt override

### DIFF
--- a/multimodal/agent-tars/core/src/agent-tars.ts
+++ b/multimodal/agent-tars/core/src/agent-tars.ts
@@ -123,10 +123,10 @@ Current Working Directory: ${workspace}
 
     `;
 
-    // Prepare system instructions by combining default prompt with custom instructions
-    const instructions = options.instructions
-      ? `${systemPrompt}\n\n${options.instructions}`
-      : systemPrompt;
+    // Prepare system instructions with flexible override support
+    // If instructions are provided, use them as the complete system prompt
+    // Otherwise, use the default system prompt with browser rules and environment
+    const instructions = options.instructions || systemPrompt;
 
     super({
       ...tarsOptions,

--- a/multimodal/agent-tars/core/src/agent-tars.ts
+++ b/multimodal/agent-tars/core/src/agent-tars.ts
@@ -123,10 +123,17 @@ Current Working Directory: ${workspace}
 
     `;
 
-    // Prepare system instructions with flexible override support
-    // If instructions are provided, use them as the complete system prompt
-    // Otherwise, use the default system prompt with browser rules and environment
-    const instructions = options.instructions || systemPrompt;
+    // Prepare system instructions with flexible layering support
+    // Custom instructions take precedence and are placed first, followed by core system capabilities
+    const instructions = options.instructions
+      ? `${options.instructions}
+
+---
+
+**Note: The following system capabilities and rules have higher priority and should be followed:**
+
+${systemPrompt}`
+      : systemPrompt;
 
     super({
       ...tarsOptions,

--- a/multimodal/agent-tars/core/src/agent-tars.ts
+++ b/multimodal/agent-tars/core/src/agent-tars.ts
@@ -123,16 +123,16 @@ Current Working Directory: ${workspace}
 
     `;
 
-    // Prepare system instructions with flexible layering support
-    // Custom instructions take precedence and are placed first, followed by core system capabilities
+    // Prepare system instructions with user instructions taking priority
+    // Core system capabilities provide the foundation, but user instructions override behavior
     const instructions = options.instructions
-      ? `${options.instructions}
+      ? `${systemPrompt}
 
 ---
 
-**Note: The following system capabilities and rules have higher priority and should be followed:**
+**User Instructions (Higher Priority):**
 
-${systemPrompt}`
+${options.instructions}`
       : systemPrompt;
 
     super({


### PR DESCRIPTION
## Summary

Improves AgentTARS system prompt handling with a layered approach that preserves core functionality while giving user instructions higher priority.

**Problem**: Original concatenation approach (`${systemPrompt}\n\n${options.instructions}`) put user instructions at the end, making them less effective. Direct override would break agent-tars core capabilities.

**Solution**: Layered prompt strategy where:
- Core system capabilities provide the foundation (browser rules, file handling, etc.)
- User instructions are placed **after** with explicit higher priority
- Preserves all agent-tars functionality while allowing effective customization

**Before**: `${systemPrompt}\n\n${options.instructions}` - user instructions simply appended
**After**: System prompt first, then user instructions with explicit priority marker

This ensures user instructions can effectively override default behavior while maintaining agent-tars reliability.

## Checklist

- [ ] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [x] My change does not involve the above items.