### PR TITLE
feat(mcp-client): add tools and prompts filtering with comprehensive tests

### DIFF
--- a/packages/agent-infra/mcp-client/README.md
+++ b/packages/agent-infra/mcp-client/README.md
@@ -14,6 +14,7 @@
   - 🌐 **Streamable HTTP**: Efficient, stream-based HTTP communication for scalable remote tools.
 - 🛠️ **Unified API**: Interact with all transports using a single, consistent interface.
 - 🧩 **Highly Extensible**: Easily add custom transports or tools as needed.
+- 🔍 **Filtering Support**: Filter tools and prompts using glob patterns with allow/block lists.
 
 ### ⚡ Quick Start
 
@@ -64,6 +65,7 @@ const mcpClient = new MCPClient([
 
 
 await mcpClient.listTools();
+await mcpClient.listPrompts();
 const result = await mcpClient.callTool({
   client: 'FileSystem-sse',
   name: 'list_directory',
@@ -72,6 +74,49 @@ const result = await mcpClient.callTool({
   },
 });
 ```
+
+### 🔍 Filtering Tools and Prompts
+
+You can filter tools and prompts using glob patterns with allow and block lists:
+
+```ts
+const mcpClient = new MCPClient([
+  {
+    type: 'builtin',
+    name: 'FileSystem',
+    description: 'filesystem tool',
+    mcpServer: createFileSystemServer({
+      allowedDirectories: [omegaDir],
+    }),
+    // Filter configuration
+    filters: {
+      tools: {
+        allow: ['list_*', 'read_*'], // Only allow tools starting with 'list_' or 'read_'
+        block: ['delete_*']          // Block any tools starting with 'delete_'
+      },
+      prompts: {
+        allow: ['safe_*'],           // Only allow prompts starting with 'safe_'
+        block: ['admin_*']           // Block prompts starting with 'admin_'
+      }
+    }
+  }
+]);
+
+// List all tools (filtered)
+const tools = await mcpClient.listTools();
+
+// List all prompts (filtered)  
+const prompts = await mcpClient.listPrompts();
+
+// List tools from specific server
+const serverTools = await mcpClient.listTools('FileSystem');
+```
+
+**Filter Rules:**
+- **Allow patterns**: If specified, only items matching these patterns are included
+- **Block patterns**: Items matching these patterns are excluded
+- **Pattern syntax**: Uses [minimatch](https://github.com/isaacs/minimatch) glob patterns (`*`, `**`, `?`, `[...]`, etc.)
+- **Processing order**: Allow filter is applied first, then block filter
 
 ### 🙏 Credits
 

--- a/packages/agent-infra/mcp-client/package.json
+++ b/packages/agent-infra/mcp-client/package.json
@@ -33,20 +33,22 @@
     "test:integration": "vitest tests/integration"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "~1.15.1",
     "@agent-infra/mcp-shared": "workspace:*",
-    "zod": "^3.23.8",
-    "uuid": "^11.1.0"
+    "@modelcontextprotocol/sdk": "~1.15.1",
+    "glob": "^10.3.10",
+    "minimatch": "^9.0.0",
+    "uuid": "^11.1.0",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
-    "tsx": "^4.19.3",
-    "vitest": "^3.0.7",
-    "@types/uuid": "^10.0.0",
-    "@agent-infra/mcp-server-filesystem": "workspace:*",
-    "@agent-infra/mcp-server-commands": "workspace:*",
     "@agent-infra/mcp-server-browser": "workspace:*",
+    "@agent-infra/mcp-server-commands": "workspace:*",
+    "@agent-infra/mcp-server-filesystem": "workspace:*",
     "@types/node": "^20.11.24",
+    "@types/uuid": "^10.0.0",
+    "openai": "^4.86.2",
+    "tsx": "^4.19.3",
     "typescript": "^5.7.3",
-    "openai": "^4.86.2"
+    "vitest": "^3.0.7"
   }
 }

--- a/packages/agent-infra/mcp-client/test/index.test.ts
+++ b/packages/agent-infra/mcp-client/test/index.test.ts
@@ -1,7 +1,620 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { MCPClient, MCPTool } from '../src/index';
+import type {
+  MCPServer,
+  BuiltInMCPServer,
+  StdioMCPServer,
+  SSEMCPServer,
+  StreamableHTTPMCPServer,
+} from '../src/index';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { Tool } from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod';
 
-describe('MCP Client', () => {
-  it('should be a function', () => {
-    expect(1 + 1).toBe(2);
+// Mock implementation of an MCP server for testing
+class MockMCPServer extends McpServer {
+  private tools: Tool[] = [];
+  private prompts: any[] = [];
+
+  constructor() {
+    super(
+      {
+        name: 'mock-server',
+        version: '1.0.0',
+      },
+      {
+        capabilities: {
+          tools: {},
+          prompts: {},
+        },
+      },
+    );
+  }
+
+  setTools(tools: Tool[]) {
+    this.tools = tools;
+    this.server.setRequestHandler(
+      z.object({ method: z.literal('tools/list') }),
+      async () => ({ tools: this.tools }),
+    );
+  }
+
+  setPrompts(prompts: any[]) {
+    this.prompts = prompts;
+    this.server.setRequestHandler(
+      z.object({ method: z.literal('prompts/list') }),
+      async () => ({ prompts: this.prompts }),
+    );
+  }
+
+  setupToolCall(toolName: string, mockResult: any) {
+    this.server.setRequestHandler(
+      z.object({
+        method: z.literal('tools/call'),
+        params: z.object({ name: z.string() }).optional(),
+      }),
+      async (request: any) => {
+        if (request.params?.name === toolName) {
+          return mockResult;
+        }
+        throw new Error(`Tool ${request.params?.name} not found`);
+      },
+    );
+  }
+}
+
+describe('MCPClient', () => {
+  let client: MCPClient;
+  let mockServer: MockMCPServer;
+
+  beforeEach(() => {
+    mockServer = new MockMCPServer();
+  });
+
+  afterEach(async () => {
+    if (client) {
+      await client.cleanup();
+    }
+  });
+
+  describe('Constructor and Initialization', () => {
+    it('should create MCPClient with servers', () => {
+      const servers: MCPServer[] = [
+        {
+          name: 'test-server',
+          mcpServer: mockServer,
+          status: 'activate',
+        },
+      ];
+
+      client = new MCPClient(servers);
+      expect(client).toBeInstanceOf(MCPClient);
+    });
+
+    it('should initialize with debug mode', () => {
+      const servers: MCPServer[] = [
+        {
+          name: 'test-server',
+          mcpServer: mockServer,
+          status: 'activate',
+        },
+      ];
+
+      client = new MCPClient(servers, { isDebug: true });
+      expect(client).toBeInstanceOf(MCPClient);
+    });
+
+    it('should initialize servers on init', async () => {
+      const servers: MCPServer[] = [
+        {
+          name: 'test-server',
+          mcpServer: mockServer,
+          status: 'activate',
+        },
+      ];
+
+      client = new MCPClient(servers);
+      await client.init();
+
+      const availableServices = await client.listAvailableServices();
+      expect(availableServices).toHaveLength(1);
+      expect(availableServices[0].name).toBe('test-server');
+    });
+
+    it('should handle multiple init calls gracefully', async () => {
+      const servers: MCPServer[] = [
+        {
+          name: 'test-server',
+          mcpServer: mockServer,
+          status: 'activate',
+        },
+      ];
+
+      client = new MCPClient(servers);
+
+      // Call init multiple times
+      await Promise.all([client.init(), client.init(), client.init()]);
+
+      const services = await client.listAvailableServices();
+      expect(services).toHaveLength(1);
+    });
+  });
+
+  describe('Server Management', () => {
+    beforeEach(async () => {
+      client = new MCPClient([]);
+      await client.init();
+    });
+
+    it('should add a new server', async () => {
+      const server: BuiltInMCPServer = {
+        name: 'new-server',
+        mcpServer: mockServer,
+        status: 'activate',
+      };
+
+      await client.addServer(server);
+
+      const services = await client.listAvailableServices();
+      expect(services).toHaveLength(1);
+      expect(services[0].name).toBe('new-server');
+    });
+
+    it('should prevent adding duplicate servers', async () => {
+      const server: BuiltInMCPServer = {
+        name: 'duplicate-server',
+        mcpServer: mockServer,
+        status: 'activate',
+      };
+
+      await client.addServer(server);
+
+      await expect(client.addServer(server)).rejects.toThrow(
+        'Server with name duplicate-server already exists',
+      );
+    });
+
+    it('should get server by name', async () => {
+      const server: BuiltInMCPServer = {
+        name: 'get-server-test',
+        mcpServer: mockServer,
+        status: 'activate',
+      };
+
+      await client.addServer(server);
+      const retrievedServer = await client.getServer('get-server-test');
+
+      expect(retrievedServer).toBeDefined();
+      expect(retrievedServer?.name).toBe('get-server-test');
+    });
+
+    it('should update server configuration', async () => {
+      const server: BuiltInMCPServer = {
+        name: 'update-server',
+        mcpServer: mockServer,
+        status: 'activate',
+        description: 'Original description',
+      };
+
+      await client.addServer(server);
+
+      const updatedServer: BuiltInMCPServer = {
+        ...server,
+        description: 'Updated description',
+        status: 'error',
+      };
+
+      await client.updateServer(updatedServer);
+
+      const retrievedServer = await client.getServer('update-server');
+      expect(retrievedServer?.description).toBe('Updated description');
+      expect(retrievedServer?.status).toBe('error');
+    });
+
+    it('should delete server', async () => {
+      const server: BuiltInMCPServer = {
+        name: 'delete-server',
+        mcpServer: mockServer,
+        status: 'activate',
+      };
+
+      await client.addServer(server);
+      expect(await client.listAvailableServices()).toHaveLength(1);
+
+      await client.deleteServer('delete-server');
+      expect(await client.listAvailableServices()).toHaveLength(0);
+    });
+
+    it('should set server active status', async () => {
+      const server: BuiltInMCPServer = {
+        name: 'status-server',
+        mcpServer: mockServer,
+        status: 'activate',
+      };
+
+      await client.addServer(server);
+
+      await client.setServerActive({ name: 'status-server', isActive: false });
+      const retrievedServer = await client.getServer('status-server');
+      expect(retrievedServer?.status).toBe('error');
+
+      await client.setServerActive({ name: 'status-server', isActive: true });
+      const retrievedServerAgain = await client.getServer('status-server');
+      expect(retrievedServerAgain?.status).toBe('activate');
+    });
+  });
+
+  describe('Tools Management', () => {
+    beforeEach(async () => {
+      const mockTools: Tool[] = [
+        {
+          name: 'test-tool-1',
+          description: 'Test tool 1',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              param1: { type: 'string' },
+            },
+          },
+        },
+        {
+          name: 'test-tool-2',
+          description: 'Test tool 2',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              param2: { type: 'number' },
+            },
+          },
+        },
+      ];
+
+      mockServer.setTools(mockTools);
+
+      const server: BuiltInMCPServer = {
+        name: 'tools-server',
+        mcpServer: mockServer,
+        status: 'activate',
+      };
+
+      client = new MCPClient([server]);
+      await client.init();
+    });
+
+    it('should list all tools', async () => {
+      const tools = await client.listTools();
+
+      expect(tools).toHaveLength(2);
+      expect(tools[0].name).toBe('test-tool-1');
+      expect(tools[0].serverName).toBe('tools-server');
+      expect(tools[0].id).toMatch(/^f[a-f0-9]{32}$/);
+      expect(tools[1].name).toBe('test-tool-2');
+      expect(tools[1].serverName).toBe('tools-server');
+    });
+
+    it('should list tools for specific server', async () => {
+      const tools = await client.listTools('tools-server');
+
+      expect(tools).toHaveLength(2);
+      expect(tools[0].serverName).toBe('tools-server');
+    });
+
+    it('should handle tools listing error gracefully', async () => {
+      const tools = await client.listTools('non-existent-server');
+      expect(tools).toHaveLength(0);
+    });
+
+    it('should call tool successfully', async () => {
+      const mockResult = {
+        content: [{ type: 'text', text: 'Tool execution result' }],
+        isError: false,
+      };
+
+      mockServer.setupToolCall('test-tool-1', mockResult);
+
+      const result = await client.callTool({
+        client: 'tools-server',
+        name: 'test-tool-1',
+        args: { param1: 'test-value' },
+      });
+
+      expect(result).toEqual(mockResult);
+    });
+
+    it('should handle tool call error', async () => {
+      await expect(
+        client.callTool({
+          client: 'tools-server',
+          name: 'non-existent-tool',
+          args: {},
+        }),
+      ).rejects.toThrow();
+    });
+
+    it('should handle calling tool on non-existent server', async () => {
+      await expect(
+        client.callTool({
+          client: 'non-existent-server',
+          name: 'test-tool-1',
+          args: {},
+        }),
+      ).rejects.toThrow('MCP Client non-existent-server not found');
+    });
+  });
+
+  describe('Prompts Management', () => {
+    beforeEach(async () => {
+      const mockPrompts = [
+        {
+          name: 'test-prompt-1',
+          description: 'Test prompt 1',
+        },
+        {
+          name: 'test-prompt-2',
+          description: 'Test prompt 2',
+        },
+      ];
+
+      mockServer.setPrompts(mockPrompts);
+
+      const server: BuiltInMCPServer = {
+        name: 'prompts-server',
+        mcpServer: mockServer,
+        status: 'activate',
+      };
+
+      client = new MCPClient([server]);
+      await client.init();
+    });
+
+    it('should list all prompts', async () => {
+      const prompts = await client.listPrompts();
+
+      expect(prompts).toHaveLength(2);
+      expect(prompts[0].name).toBe('test-prompt-1');
+      expect(prompts[0].serverName).toBe('prompts-server');
+      expect(prompts[0].id).toMatch(/^p[a-f0-9]{32}$/);
+      expect(prompts[1].name).toBe('test-prompt-2');
+      expect(prompts[1].serverName).toBe('prompts-server');
+    });
+
+    it('should list prompts for specific server', async () => {
+      const prompts = await client.listPrompts('prompts-server');
+
+      expect(prompts).toHaveLength(2);
+      expect(prompts[0].serverName).toBe('prompts-server');
+    });
+
+    it('should handle prompts listing error gracefully', async () => {
+      const prompts = await client.listPrompts('non-existent-server');
+      expect(prompts).toHaveLength(0);
+    });
+  });
+
+  describe('Filtering', () => {
+    it('should apply allow and block filters to tools', async () => {
+      const mockTools: Tool[] = [
+        {
+          name: 'allowed-tool',
+          description: 'This tool should be allowed',
+          inputSchema: { type: 'object', properties: {} },
+        },
+        {
+          name: 'blocked-tool',
+          description: 'This tool should be blocked',
+          inputSchema: { type: 'object', properties: {} },
+        },
+        {
+          name: 'pattern-tool-test',
+          description: 'This tool matches pattern',
+          inputSchema: { type: 'object', properties: {} },
+        },
+      ];
+
+      mockServer.setTools(mockTools);
+
+      const server: BuiltInMCPServer = {
+        name: 'filter-server',
+        mcpServer: mockServer,
+        status: 'activate',
+        filters: {
+          tools: {
+            allow: ['allowed-tool', 'pattern-*'],
+            block: ['blocked-tool'],
+          },
+        },
+      };
+
+      client = new MCPClient([server]);
+      await client.init();
+
+      const tools = await client.listTools('filter-server');
+
+      expect(tools).toHaveLength(2);
+      expect(tools.map((t) => t.name)).toEqual([
+        'allowed-tool',
+        'pattern-tool-test',
+      ]);
+    });
+
+    it('should apply filters with prompts', async () => {
+      const mockPrompts = [
+        { name: 'allowed-prompt', description: 'Allowed prompt' },
+        { name: 'blocked-prompt', description: 'Blocked prompt' },
+        { name: 'pattern-prompt-test', description: 'Pattern prompt' },
+      ];
+
+      const promptMockServer = new MockMCPServer();
+      promptMockServer.setPrompts(mockPrompts);
+
+      const server: BuiltInMCPServer = {
+        name: 'filter-prompts-server',
+        mcpServer: promptMockServer,
+        status: 'activate',
+        filters: {
+          prompts: {
+            allow: ['allowed-prompt', 'pattern-*'],
+            block: ['blocked-prompt'],
+          },
+        },
+      };
+
+      client = new MCPClient([server]);
+      await client.init();
+
+      const prompts = await client.listPrompts('filter-prompts-server');
+      expect(prompts).toHaveLength(2);
+      expect(prompts.map((p) => p.name)).toEqual([
+        'allowed-prompt',
+        'pattern-prompt-test',
+      ]);
+    });
+  });
+
+  describe('Server Configuration Types', () => {
+    it('should handle stdio server configuration', () => {
+      const stdioServer: StdioMCPServer = {
+        name: 'stdio-server',
+        command: 'node',
+        args: ['server.js'],
+        status: 'activate',
+        env: { NODE_ENV: 'test' },
+        cwd: '/test/path',
+      };
+
+      client = new MCPClient([stdioServer]);
+      expect(client).toBeInstanceOf(MCPClient);
+    });
+
+    it('should handle SSE server configuration', () => {
+      const sseServer: SSEMCPServer = {
+        name: 'sse-server',
+        type: 'sse',
+        url: 'http://localhost:3000/sse',
+        status: 'activate',
+        headers: { Authorization: 'Bearer token' },
+      };
+
+      client = new MCPClient([sseServer]);
+      expect(client).toBeInstanceOf(MCPClient);
+    });
+
+    it('should handle StreamableHTTP server configuration', () => {
+      const httpServer: StreamableHTTPMCPServer = {
+        name: 'http-server',
+        type: 'streamable-http',
+        url: 'http://localhost:3000/mcp',
+        status: 'activate',
+        headers: { 'X-API-Key': 'test-key' },
+      };
+
+      client = new MCPClient([httpServer]);
+      expect(client).toBeInstanceOf(MCPClient);
+    });
+  });
+
+  describe('Error Handling', () => {
+    beforeEach(async () => {
+      client = new MCPClient([]);
+      await client.init();
+    });
+
+    it('should emit server-error event on activation failure', async () => {
+      const errorHandler = vi.fn();
+      client.on('server-error', errorHandler);
+
+      // Create a server that will fail to connect
+      const badServer: StdioMCPServer = {
+        name: 'bad-server',
+        command: 'non-existent-command',
+        args: [],
+        status: 'activate',
+      };
+
+      try {
+        await client.addServer(badServer);
+      } catch (error) {
+        // Expected to fail during addServer because activation fails
+      }
+
+      // Wait a bit for async error handling
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      expect(errorHandler).toHaveBeenCalledWith({
+        name: 'bad-server',
+        error: expect.any(Error),
+      });
+    });
+
+    it('should handle server status check', async () => {
+      const server: BuiltInMCPServer = {
+        name: 'status-check-server',
+        mcpServer: mockServer,
+        status: 'activate',
+      };
+
+      await expect(client.checkServerStatus(server)).resolves.not.toThrow();
+    });
+  });
+
+  describe('Event Emission', () => {
+    beforeEach(async () => {
+      client = new MCPClient([]);
+      await client.init();
+    });
+
+    it('should emit server-started event on successful activation', async () => {
+      const startedHandler = vi.fn();
+      client.on('server-started', startedHandler);
+
+      const server: BuiltInMCPServer = {
+        name: 'event-server',
+        mcpServer: mockServer,
+        status: 'activate',
+      };
+
+      await client.addServer(server);
+
+      expect(startedHandler).toHaveBeenCalledWith({ name: 'event-server' });
+    });
+
+    it('should emit server-stopped event on deactivation', async () => {
+      const stoppedHandler = vi.fn();
+      const server: BuiltInMCPServer = {
+        name: 'stop-server',
+        mcpServer: mockServer,
+        status: 'activate',
+      };
+
+      await client.addServer(server);
+
+      client.on('server-stopped', stoppedHandler);
+      await client.deactivate('stop-server');
+
+      expect(stoppedHandler).toHaveBeenCalledWith({ name: 'stop-server' });
+    });
+  });
+
+  describe('Cleanup', () => {
+    it('should cleanup all servers on cleanup call', async () => {
+      const server: BuiltInMCPServer = {
+        name: 'cleanup-server',
+        mcpServer: mockServer,
+        status: 'activate',
+      };
+
+      client = new MCPClient([server]);
+      await client.init();
+
+      // Verify server is active
+      const services = await client.listAvailableServices();
+      expect(services).toHaveLength(1);
+
+      await client.cleanup();
+
+      // After cleanup, tools should return empty array
+      const tools = await client.listTools();
+      expect(tools).toHaveLength(0);
+    });
   });
 });

--- a/packages/agent-infra/mcp-shared/src/client/types.ts
+++ b/packages/agent-infra/mcp-shared/src/client/types.ts
@@ -4,12 +4,24 @@ import { StdioServerParameters } from '@modelcontextprotocol/sdk/client/stdio.js
 // `type` field only save but not used
 export type MCP_SERVER_TYPE = 'stdio' | 'sse' | 'builtin' | 'streamable-http';
 
+export interface MCPFilterConfig {
+  allow?: string[];
+  block?: string[];
+}
+
+export interface MCPFilters {
+  tools?: MCPFilterConfig;
+  prompts?: MCPFilterConfig;
+}
+
 interface BaseMCPServer<ServerNames extends string = string> {
   name: ServerNames;
   status?: 'activate' | 'error' | 'disabled';
   description?: string;
   /** timeout (seconds), default 10s */
   timeout?: number;
+  /** filters for tools and prompts */
+  filters?: MCPFilters;
 }
 
 export type MCPServer<ServerNames extends string = string> =

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -645,6 +645,12 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ~1.15.1
         version: 1.15.1
+      glob:
+        specifier: ^10.3.10
+        version: 10.4.5
+      minimatch:
+        specifier: ^9.0.0
+        version: 9.0.5
       uuid:
         specifier: ^11.1.0
         version: 11.1.0


### PR DESCRIPTION
## Summary

This PR adds comprehensive filtering capabilities and testing to the MCP client:

```ts
const mcpClient = new MCPClient([
  {
    type: 'builtin',
    name: 'FileSystem',
    description: 'filesystem tool',
    mcpServer: createFileSystemServer({
      allowedDirectories: [omegaDir],
    }),
    // Filter configuration
    filters: {
      tools: {
        allow: ['list_*', 'read_*'], // Only allow tools starting with 'list_' or 'read_'
        block: ['delete_*']          // Block any tools starting with 'delete_'
      },
      prompts: {
        allow: ['safe_*'],           // Only allow prompts starting with 'safe_'
        block: ['admin_*']           // Block prompts starting with 'admin_'
      }
    }
  }
]);
```

## Test plan

- [x] All existing tests pass
- [x] New comprehensive test suite covers filtering functionality
- [x] Tests cover error scenarios and edge cases
- [x] Integration tests validate server management
- [x] Event emission tests ensure proper error handling

Close https://github.com/bytedance/UI-TARS-desktop/issues/1138
Close https://github.com/bytedance/UI-TARS-desktop/issues/1154