### PR TITLE
feat(tarko): update run command semantics

### DIFF
--- a/multimodal/tarko/agent-cli/README.md
+++ b/multimodal/tarko/agent-cli/README.md
@@ -17,15 +17,24 @@ npm install @tarko/agent-cli
 ```bash
 # 启动交互式 Web UI（默认命令）
 tarko
+# 或
+tarko run
+
+# 使用自定义 Agent 启动交互式 Web UI
+tarko run ./my-agent.js
 
 # 启动无头 API 服务器
 tarko serve
 
 # 静默模式运行（输出到 stdout）
-tarko run "帮我分析当前目录的文件结构"
+tarko run --headless --input "帮我分析当前目录的文件结构"
+# 或简写
+tarko --headless --input "帮我分析当前目录的文件结构"
 
-# 管道输入
-echo "总结这段代码" | tarko run
+# 管道输入（静默模式）
+echo "总结这段代码" | tarko run --headless
+# 或简写
+echo "总结这段代码" | tarko --headless
 ```
 
 ### 配置文件
@@ -66,18 +75,29 @@ tarko --workspace ./my-workspace
 # 调试模式
 tarko --debug
 
-# 使用自定义 Agent
+# 使用自定义 Agent（交互式 UI）
+tarko run ./my-agent.js
+# 或
 tarko --agent ./my-agent.js
+
+# 使用自定义 Agent（静默模式）
+tarko run ./my-agent.js --headless --input "查询内容"
 ```
 
 ## 核心命令
 
-### `tarko` / `tarko start`
+### `tarko` / `tarko run`
 
 启动交互式 Web UI，支持实时对话和文件浏览。
 
 ```bash
-tarko start --port 8888 --open
+# 启动交互式 Web UI
+tarko run --port 8888 --open
+# 或使用默认命令
+tarko --port 8888 --open
+
+# 使用指定 Agent
+tarko run ./my-agent.js --port 8888
 ```
 
 ### `tarko serve`
@@ -89,19 +109,22 @@ tarko serve --port 8888
 # API 端点：http://localhost:8888/api/v1/
 ```
 
-### `tarko run`
+### `tarko run --headless`
 
 静默模式运行，结果输出到 stdout，适合脚本集成。
 
 ```bash
 # 文本输出（默认）
-tarko run "分析当前目录" --format text
+tarko run --headless --input "分析当前目录" --format text
 
 # JSON 输出
-tarko run "分析当前目录" --format json
+tarko run --headless --input "分析当前目录" --format json
 
 # 包含日志输出
-tarko run "分析当前目录" --include-logs
+tarko run --headless --input "分析当前目录" --include-logs
+
+# 使用指定 Agent
+tarko run ./my-agent.js --headless --input "查询内容"
 ```
 
 ### `tarko request`

--- a/multimodal/tarko/agent-cli/src/core/cli.ts
+++ b/multimodal/tarko/agent-cli/src/core/cli.ts
@@ -185,8 +185,8 @@ export class AgentCLI {
         },
       )
       .option(
-        '--cache [cache]',
-        'Cache results in server storage (requires server mode) (for headless mode)',
+        '--use-cache [useCache]',
+        'Use cache for headless mode execution (for headless mode)',
         {
           default: true,
         },
@@ -274,7 +274,7 @@ export class AgentCLI {
         quiet: quietMode,
       });
 
-      const useCache = cliArguments.cache !== false;
+      const useCache = cliArguments.useCache !== false;
 
       if (useCache) {
         const { processServerRun } = await import('./commands/run');

--- a/multimodal/tarko/agent-cli/src/core/cli.ts
+++ b/multimodal/tarko/agent-cli/src/core/cli.ts
@@ -116,9 +116,8 @@ export class AgentCLI {
    */
   private registerCoreCommands(cli: CLIInstance): void {
     this.registerServeCommand(cli);
-    this.registerStartCommand(cli);
-    this.registerRequestCommand(cli);
     this.registerRunCommand(cli);
+    this.registerRequestCommand(cli);
     this.registerWorkspaceCommand(cli);
   }
 
@@ -163,31 +162,57 @@ export class AgentCLI {
   }
 
   /**
-   * Register the 'start' command
+   * Register the 'run' command (default command)
    */
-  private registerStartCommand(cli: CLIInstance): void {
-    const startCommand = cli.command('[start]', 'Run Agent in interactive UI');
+  private registerRunCommand(cli: CLIInstance): void {
+    const runCommand = cli.command('[run] [agent]', 'Run Agent in interactive UI or headless mode');
+
+    runCommand
+      .option('--headless', 'Run in headless mode and output results to stdout')
+      .option('--input [...query]', 'Input query to process (for headless mode)')
+      .option(
+        '--format [format]',
+        'Output format: "json" or "text" (default: "text") (for headless mode)',
+        {
+          default: 'text',
+        },
+      )
+      .option(
+        '--include-logs',
+        'Include captured logs in the output (for debugging) (for headless mode)',
+        {
+          default: false,
+        },
+      )
+      .option(
+        '--cache [cache]',
+        'Cache results in server storage (requires server mode) (for headless mode)',
+        {
+          default: true,
+        },
+      );
 
     // Apply common options first
-    let configuredCommand = addCommonOptions(startCommand);
+    let configuredCommand = addCommonOptions(runCommand);
 
     // Apply agent-specific configurations for commands that run agents
     configuredCommand = this.configureAgentCommand(configuredCommand);
-    configuredCommand.action(async (_, cliArguments: AgentCLIArguments = {}) => {
-      this.printLogo();
-      try {
-        const { agentServerInitOptions, isDebug } = await this.processCLIArguments(cliArguments);
-        const { startInteractiveWebUI } = await import('./commands/start');
-        await startInteractiveWebUI({
-          agentServerInitOptions,
-          isDebug,
-          open: cliArguments.open,
-        });
-      } catch (err) {
-        console.error('Failed to start server:', err);
-        process.exit(1);
-      }
-    });
+    configuredCommand.action(
+      async (agent: string | undefined, cliArguments: AgentCLIArguments = {}) => {
+        // If agent is provided as positional argument, use it
+        if (agent) {
+          cliArguments.agent = agent;
+        }
+
+        if (cliArguments.headless) {
+          // Headless mode - same as old 'run' command
+          await this.runHeadlessMode(cliArguments);
+        } else {
+          // Interactive UI mode - same as old 'start' command
+          await this.runInteractiveMode(cliArguments);
+        }
+      },
+    );
   }
 
   /**
@@ -218,80 +243,80 @@ export class AgentCLI {
   }
 
   /**
-   * Register the 'run' command
+   * Handle headless mode execution
    */
-  private registerRunCommand(cli: CLIInstance): void {
-    const runCommand = cli.command('run', 'Run Agent in silent mode and output results to stdout');
+  private async runHeadlessMode(cliArguments: AgentCLIArguments): Promise<void> {
+    try {
+      let input: string;
 
-    runCommand
-      .option('--input [...query]', 'Input query to process (can be omitted when using pipe)')
-      .option('--format [format]', 'Output format: "json" or "text" (default: "text")', {
-        default: 'text',
-      })
-      .option('--include-logs', 'Include captured logs in the output (for debugging)', {
-        default: false,
-      })
-      .option('--cache [cache]', 'Cache results in server storage (requires server mode)', {
-        default: true,
+      if (
+        cliArguments.input &&
+        (Array.isArray(cliArguments.input) ? cliArguments.input.length > 0 : true)
+      ) {
+        input = Array.isArray(cliArguments.input)
+          ? cliArguments.input.join(' ')
+          : cliArguments.input;
+      } else {
+        const stdinInput = await readFromStdin();
+
+        if (!stdinInput) {
+          console.error('Error: No input provided. Use --input parameter or pipe content to stdin');
+          process.exit(1);
+        }
+
+        input = stdinInput;
+      }
+
+      const quietMode = cliArguments.debug ? false : true;
+
+      const { agentServerInitOptions, isDebug } = await this.processCLIArguments({
+        ...cliArguments,
+        quiet: quietMode,
       });
 
-    // Apply common options first
-    let configuredCommand = addCommonOptions(runCommand);
+      const useCache = cliArguments.cache !== false;
 
-    // Apply agent-specific configurations for commands that run agents
-    configuredCommand = this.configureAgentCommand(configuredCommand);
-
-    configuredCommand.action(async (options: AgentCLIArguments = {}) => {
-      try {
-        let input: string;
-
-        if (options.input && (Array.isArray(options.input) ? options.input.length > 0 : true)) {
-          input = Array.isArray(options.input) ? options.input.join(' ') : options.input;
-        } else {
-          const stdinInput = await readFromStdin();
-
-          if (!stdinInput) {
-            console.error(
-              'Error: No input provided. Use --input parameter or pipe content to stdin',
-            );
-            process.exit(1);
-          }
-
-          input = stdinInput;
-        }
-
-        const quietMode = options.debug ? false : true;
-
-        const { agentServerInitOptions, isDebug } = await this.processCLIArguments({
-          ...options,
-          quiet: quietMode,
+      if (useCache) {
+        const { processServerRun } = await import('./commands/run');
+        await processServerRun({
+          agentServerInitOptions,
+          input,
+          format: cliArguments.format as 'json' | 'text',
+          includeLogs: cliArguments.includeLogs || !!cliArguments.debug,
+          isDebug,
         });
-
-        const useCache = options.cache !== false;
-
-        if (useCache) {
-          const { processServerRun } = await import('./commands/run');
-          await processServerRun({
-            agentServerInitOptions,
-            input,
-            format: options.format as 'json' | 'text',
-            includeLogs: options.includeLogs || !!options.debug,
-            isDebug,
-          });
-        } else {
-          const { processSilentRun } = await import('./commands/run');
-          await processSilentRun({
-            agentServerInitOptions,
-            input,
-            format: options.format as 'json' | 'text',
-            includeLogs: options.includeLogs || !!options.debug,
-          });
-        }
-      } catch (err) {
-        console.error('Error:', err instanceof Error ? err.message : String(err));
-        process.exit(1);
+      } else {
+        const { processSilentRun } = await import('./commands/run');
+        await processSilentRun({
+          agentServerInitOptions,
+          input,
+          format: cliArguments.format as 'json' | 'text',
+          includeLogs: cliArguments.includeLogs || !!cliArguments.debug,
+        });
       }
-    });
+    } catch (err) {
+      console.error('Error:', err instanceof Error ? err.message : String(err));
+      process.exit(1);
+    }
+  }
+
+  /**
+   * Handle interactive mode execution
+   */
+  private async runInteractiveMode(cliArguments: AgentCLIArguments): Promise<void> {
+    this.printLogo();
+    try {
+      const { agentServerInitOptions, isDebug } = await this.processCLIArguments(cliArguments);
+      const { startInteractiveWebUI } = await import('./commands/start');
+      await startInteractiveWebUI({
+        agentServerInitOptions,
+        isDebug,
+        open: cliArguments.open,
+      });
+    } catch (err) {
+      console.error('Failed to start server:', err);
+      process.exit(1);
+    }
   }
 
   /**

--- a/multimodal/tarko/interface/src/cli.ts
+++ b/multimodal/tarko/interface/src/cli.ts
@@ -58,14 +58,11 @@ export type AgentCLIArguments = Pick<
   /** Output format for headless mode */
   format?: 'json' | 'text';
 
-  /** Include captured logs in output */
+  /** Include captured logs in output (for headless mode) */
   includeLogs?: boolean;
 
-  /** Cache results in server storage */
-  cache?: boolean;
-
-  /** Workspace directory path */
-  workspace?: string;
+  /** Use cache for headless mode execution (for headless mode) */
+  useCache?: boolean;
 
   // Allow additional properties for extensibility
   [key: string]: any;

--- a/multimodal/tarko/interface/src/cli.ts
+++ b/multimodal/tarko/interface/src/cli.ts
@@ -49,6 +49,24 @@ export type AgentCLIArguments = Pick<
    */
   agent?: string;
 
+  /** Run in headless mode (for run command) */
+  headless?: boolean;
+
+  /** Input query for headless mode */
+  input?: string | string[];
+
+  /** Output format for headless mode */
+  format?: 'json' | 'text';
+
+  /** Include captured logs in output */
+  includeLogs?: boolean;
+
+  /** Cache results in server storage */
+  cache?: boolean;
+
+  /** Workspace directory path */
+  workspace?: string;
+
   // Allow additional properties for extensibility
   [key: string]: any;
 };


### PR DESCRIPTION
## Summary

Update Tarko CLI command semantics to support `tarko run [agent]` for interactive UI and `tarko run --headless` for silent mode.

### Changes
- Changed default command from `tarko [start]` to `tarko [run]`
- Added support for `tarko run [agent]` to load custom agents
- Added `--headless` flag for silent mode execution
- Updated CLI documentation and help text
- Maintained backward compatibility with existing `--agent` flag

### Breaking Changes
- `tarko start` command removed (use `tarko run` instead)
- `tarko run` without `--headless` now starts interactive UI (previously was headless mode)

### Migration
- `tarko start` → `tarko run` or `tarko`
- `tarko run "query"` → `tarko run --headless --input "query"`
- `tarko --agent ./agent.js` → `tarko run ./agent.js`

## Checklist  

<!--  Before submitting the pull request, ensure the following items are checked: -->

- [ ] Added or updated necessary tests (Optional).  
- [ ] Updated documentation to align with changes (Optional).  
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).  
- [x] My change does not involve the above items. 
