### PR TITLE
feat(tarko): add workspace raw mode display

### DIFF
--- a/multimodal/tarko/agent-web-ui/src/common/components/JsonRenderer.tsx
+++ b/multimodal/tarko/agent-web-ui/src/common/components/JsonRenderer.tsx
@@ -1,0 +1,187 @@
+import React, { useState, useCallback } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { FiChevronRight, FiCopy, FiCheck } from 'react-icons/fi';
+
+/**
+ * JsonRenderer - Universal JSON viewer component
+ * 
+ * Extracted from AgentConfigViewer for reusability across the application.
+ * Supports hierarchical tree structure with smooth animations.
+ */
+
+interface JsonItemProps {
+  label: string;
+  value: any;
+  level?: number;
+  isRoot?: boolean;
+}
+
+const JsonItem: React.FC<JsonItemProps> = ({ label, value, level = 0, isRoot = false }) => {
+  const [isExpanded, setIsExpanded] = useState(level < 2); // Auto-expand first 2 levels
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch (error) {
+      console.error('Failed to copy:', error);
+    }
+  }, []);
+
+  const isObject = value && typeof value === 'object' && !Array.isArray(value);
+  const isArray = Array.isArray(value);
+  const isPrimitive = !isObject && !isArray;
+
+  const indentClass = isRoot ? '' : `ml-${Math.min(level * 4, 16)}`;
+
+  if (isPrimitive) {
+    const displayValue = value === null ? 'null' : String(value);
+    const valueColor = 
+      typeof value === 'string' ? 'text-emerald-600 dark:text-emerald-400' :
+      typeof value === 'number' ? 'text-blue-600 dark:text-blue-400' :
+      typeof value === 'boolean' ? 'text-purple-600 dark:text-purple-400' :
+      'text-gray-500 dark:text-gray-400';
+
+    return (
+      <motion.div
+        initial={{ opacity: 0, x: -10 }}
+        animate={{ opacity: 1, x: 0 }}
+        transition={{ delay: level * 0.02 }}
+        className={`${indentClass} flex items-center justify-between group py-1.5 px-3 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors`}
+      >
+        <div className="flex items-center gap-3 min-w-0 flex-1">
+          <span className="text-sm font-medium text-gray-700 dark:text-gray-300 truncate">
+            {label}
+          </span>
+          <span className="text-xs text-gray-400 dark:text-gray-500">:</span>
+          <span className={`text-sm font-mono ${valueColor} truncate`}>
+            {typeof value === 'string' ? `"${displayValue}"` : displayValue}
+          </span>
+        </div>
+        <motion.button
+          whileHover={{ scale: 1.1 }}
+          whileTap={{ scale: 0.95 }}
+          onClick={() => handleCopy(displayValue)}
+          className="opacity-0 group-hover:opacity-100 p-1.5 rounded-md hover:bg-gray-200 dark:hover:bg-gray-700 transition-all"
+          title="Copy value"
+        >
+          {copied ? (
+            <FiCheck size={12} className="text-green-500" />
+          ) : (
+            <FiCopy size={12} className="text-gray-400" />
+          )}
+        </motion.button>
+      </motion.div>
+    );
+  }
+
+  const itemCount = isArray ? value.length : Object.keys(value).length;
+  const typeLabel = isArray ? `Array[${itemCount}]` : `Object{${itemCount}}`;
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, x: -10 }}
+      animate={{ opacity: 1, x: 0 }}
+      transition={{ delay: level * 0.02 }}
+      className={indentClass}
+    >
+      <motion.button
+        whileHover={{ scale: 1.01 }}
+        whileTap={{ scale: 0.99 }}
+        onClick={() => setIsExpanded(!isExpanded)}
+        className="w-full flex items-center gap-2 py-2 px-3 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors group"
+      >
+        <motion.div
+          animate={{ rotate: isExpanded ? 90 : 0 }}
+          transition={{ duration: 0.2 }}
+        >
+          <FiChevronRight size={14} className="text-gray-400" />
+        </motion.div>
+        <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+          {label}
+        </span>
+        <span className="text-xs text-gray-400 dark:text-gray-500 font-mono">
+          {typeLabel}
+        </span>
+      </motion.button>
+      
+      <AnimatePresence>
+        {isExpanded && (
+          <motion.div
+            initial={{ opacity: 0, height: 0 }}
+            animate={{ opacity: 1, height: 'auto' }}
+            exit={{ opacity: 0, height: 0 }}
+            transition={{ duration: 0.2 }}
+            className="overflow-hidden"
+          >
+            <div className="ml-4 border-l border-gray-200 dark:border-gray-700 pl-2">
+              {isArray ? (
+                value.map((item: any, index: number) => (
+                  <JsonItem
+                    key={index}
+                    label={`[${index}]`}
+                    value={item}
+                    level={level + 1}
+                  />
+                ))
+              ) : (
+                Object.entries(value).map(([key, val]) => (
+                  <JsonItem
+                    key={key}
+                    label={key}
+                    value={val}
+                    level={level + 1}
+                  />
+                ))
+              )}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </motion.div>
+  );
+};
+
+interface JsonRendererProps {
+  data: any;
+  className?: string;
+  emptyMessage?: string;
+}
+
+export const JsonRenderer: React.FC<JsonRendererProps> = ({ 
+  data, 
+  className = '',
+  emptyMessage = 'No data available'
+}) => {
+  if (!data || (typeof data === 'object' && Object.keys(data).length === 0)) {
+    return (
+      <div className={`flex items-center justify-center py-8 ${className}`}>
+        <div className="text-center">
+          <div className="text-gray-400 mb-2">📄</div>
+          <p className="text-gray-600 dark:text-gray-400 font-medium">{emptyMessage}</p>
+        </div>
+      </div>
+    );
+  }
+
+  const isRootObject = typeof data === 'object' && !Array.isArray(data);
+  const isRootArray = Array.isArray(data);
+
+  return (
+    <div className={`space-y-1 ${className}`}>
+      {isRootObject ? (
+        Object.entries(data).map(([key, value]) => (
+          <JsonItem key={key} label={key} value={value} isRoot />
+        ))
+      ) : isRootArray ? (
+        data.map((item: any, index: number) => (
+          <JsonItem key={index} label={`[${index}]`} value={item} isRoot />
+        ))
+      ) : (
+        <JsonItem label="value" value={data} isRoot />
+      )}
+    </div>
+  );
+};

--- a/multimodal/tarko/agent-web-ui/src/common/state/atoms/workspace.ts
+++ b/multimodal/tarko/agent-web-ui/src/common/state/atoms/workspace.ts
@@ -1,0 +1,13 @@
+import { atom } from 'jotai';
+
+/**
+ * Workspace display mode types
+ */
+export type WorkspaceDisplayMode = 'interaction' | 'raw';
+
+/**
+ * Current workspace display mode
+ * - 'interaction': Default mode showing processed tool results with UI components
+ * - 'raw': Raw mode showing original tool input/output in JSON format
+ */
+export const workspaceDisplayModeAtom = atom<WorkspaceDisplayMode>('interaction');

--- a/multimodal/tarko/agent-web-ui/src/standalone/sidebar/AgentConfigViewer.tsx
+++ b/multimodal/tarko/agent-web-ui/src/standalone/sidebar/AgentConfigViewer.tsx
@@ -1,8 +1,9 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { FiSettings, FiX, FiChevronRight, FiCopy, FiCheck } from 'react-icons/fi';
+import { FiSettings, FiX } from 'react-icons/fi';
 import { apiService } from '@/common/services/apiService';
 import { SanitizedAgentOptions } from '@/common/types';
+import { JsonRenderer } from '@/common/components/JsonRenderer';
 
 /**
  * AgentConfigViewer - Premium IDE-style configuration viewer
@@ -14,140 +15,6 @@ import { SanitizedAgentOptions } from '@/common/types';
  * - Premium typography and spacing
  * - Professional color scheme with subtle accents
  */
-
-interface ConfigItemProps {
-  label: string;
-  value: any;
-  level?: number;
-}
-
-const ConfigItem: React.FC<ConfigItemProps> = ({ label, value, level = 0 }) => {
-  const [isExpanded, setIsExpanded] = useState(true);
-  const [copied, setCopied] = useState(false);
-
-  const handleCopy = useCallback(async (text: string) => {
-    try {
-      await navigator.clipboard.writeText(text);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1500);
-    } catch (error) {
-      console.error('Failed to copy:', error);
-    }
-  }, []);
-
-  const isObject = value && typeof value === 'object' && !Array.isArray(value);
-  const isArray = Array.isArray(value);
-  const isPrimitive = !isObject && !isArray;
-
-  const indentClass = `ml-${Math.min(level * 4, 16)}`;
-
-  if (isPrimitive) {
-    const displayValue = value === null ? 'null' : String(value);
-    const valueColor = 
-      typeof value === 'string' ? 'text-emerald-600 dark:text-emerald-400' :
-      typeof value === 'number' ? 'text-blue-600 dark:text-blue-400' :
-      typeof value === 'boolean' ? 'text-purple-600 dark:text-purple-400' :
-      'text-gray-500 dark:text-gray-400';
-
-    return (
-      <motion.div
-        initial={{ opacity: 0, x: -10 }}
-        animate={{ opacity: 1, x: 0 }}
-        transition={{ delay: level * 0.05 }}
-        className={`${indentClass} flex items-center justify-between group py-1.5 px-3 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors`}
-      >
-        <div className="flex items-center gap-3 min-w-0 flex-1">
-          <span className="text-sm font-medium text-gray-700 dark:text-gray-300 truncate">
-            {label}
-          </span>
-          <span className="text-xs text-gray-400 dark:text-gray-500">:</span>
-          <span className={`text-sm font-mono ${valueColor} truncate`}>
-            {displayValue}
-          </span>
-        </div>
-        <motion.button
-          whileHover={{ scale: 1.1 }}
-          whileTap={{ scale: 0.95 }}
-          onClick={() => handleCopy(displayValue)}
-          className="opacity-0 group-hover:opacity-100 p-1.5 rounded-md hover:bg-gray-200 dark:hover:bg-gray-700 transition-all"
-          title="Copy value"
-        >
-          {copied ? (
-            <FiCheck size={12} className="text-green-500" />
-          ) : (
-            <FiCopy size={12} className="text-gray-400" />
-          )}
-        </motion.button>
-      </motion.div>
-    );
-  }
-
-  const itemCount = isArray ? value.length : Object.keys(value).length;
-  const typeLabel = isArray ? `Array[${itemCount}]` : `Object{${itemCount}}`;
-
-  return (
-    <motion.div
-      initial={{ opacity: 0, x: -10 }}
-      animate={{ opacity: 1, x: 0 }}
-      transition={{ delay: level * 0.05 }}
-      className={indentClass}
-    >
-      <motion.button
-        whileHover={{ scale: 1.01 }}
-        whileTap={{ scale: 0.99 }}
-        onClick={() => setIsExpanded(!isExpanded)}
-        className="w-full flex items-center gap-2 py-2 px-3 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors group"
-      >
-        <motion.div
-          animate={{ rotate: isExpanded ? 90 : 0 }}
-          transition={{ duration: 0.2 }}
-        >
-          <FiChevronRight size={14} className="text-gray-400" />
-        </motion.div>
-        <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
-          {label}
-        </span>
-        <span className="text-xs text-gray-400 dark:text-gray-500 font-mono">
-          {typeLabel}
-        </span>
-      </motion.button>
-      
-      <AnimatePresence>
-        {isExpanded && (
-          <motion.div
-            initial={{ opacity: 0, height: 0 }}
-            animate={{ opacity: 1, height: 'auto' }}
-            exit={{ opacity: 0, height: 0 }}
-            transition={{ duration: 0.2 }}
-            className="overflow-hidden"
-          >
-            <div className="ml-4 border-l border-gray-200 dark:border-gray-700 pl-2">
-              {isArray ? (
-                value.map((item: any, index: number) => (
-                  <ConfigItem
-                    key={index}
-                    label={`[${index}]`}
-                    value={item}
-                    level={level + 1}
-                  />
-                ))
-              ) : (
-                Object.entries(value).map(([key, val]) => (
-                  <ConfigItem
-                    key={key}
-                    label={key}
-                    value={val}
-                    level={level + 1}
-                  />
-                ))
-              )}
-            </div>
-          </motion.div>
-        )}
-      </AnimatePresence>
-    </motion.div>
-  );
-};
 
 interface AgentConfigViewerProps {
   isOpen: boolean;
@@ -260,11 +127,10 @@ export const AgentConfigViewer: React.FC<AgentConfigViewerProps> = ({ isOpen, on
                 </div>
               </div>
             ) : config && Object.keys(config).length > 0 ? (
-              <div className="space-y-2">
-                {Object.entries(config).map(([key, value]) => (
-                  <ConfigItem key={key} label={key} value={value} />
-                ))}
-              </div>
+              <JsonRenderer 
+                data={config} 
+                emptyMessage="No configuration available"
+              />
             ) : (
               <div className="flex items-center justify-center py-12">
                 <div className="text-center">

--- a/multimodal/tarko/agent-web-ui/src/standalone/workspace/components/RawModeRenderer.tsx
+++ b/multimodal/tarko/agent-web-ui/src/standalone/workspace/components/RawModeRenderer.tsx
@@ -1,0 +1,181 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import { FiCode, FiArrowRight, FiClock } from 'react-icons/fi';
+import { JsonRenderer } from '@/common/components/JsonRenderer';
+import { RawToolMapping } from '@/common/state/atoms/rawEvents';
+import { formatTimestamp } from '@/common/utils/formatters';
+
+interface RawModeRendererProps {
+  toolMapping: RawToolMapping;
+}
+
+export const RawModeRenderer: React.FC<RawModeRendererProps> = ({ toolMapping }) => {
+  const { toolCall, toolResult } = toolMapping;
+
+  return (
+    <div className="space-y-6">
+      {/* Tool Call Section */}
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 overflow-hidden"
+      >
+        <div className="flex items-center gap-3 px-4 py-3 bg-blue-50 dark:bg-blue-900/20 border-b border-blue-100 dark:border-blue-800/30">
+          <div className="w-8 h-8 rounded-lg bg-blue-100 dark:bg-blue-800/30 flex items-center justify-center">
+            <FiCode size={16} className="text-blue-600 dark:text-blue-400" />
+          </div>
+          <div className="flex-1">
+            <h3 className="font-medium text-blue-900 dark:text-blue-100">Tool Call Input</h3>
+            <div className="flex items-center gap-2 text-xs text-blue-600 dark:text-blue-400">
+              <FiClock size={12} />
+              <span>{formatTimestamp(toolCall.timestamp, true)}</span>
+              <span>•</span>
+              <span className="font-mono">{toolCall.toolCallId}</span>
+            </div>
+          </div>
+        </div>
+        <div className="p-4">
+          <div className="space-y-4">
+            <div>
+              <div className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Tool Name</div>
+              <div className="px-3 py-2 bg-gray-50 dark:bg-gray-700/50 rounded-lg font-mono text-sm text-gray-800 dark:text-gray-200">
+                {toolCall.name}
+              </div>
+            </div>
+            {toolCall.arguments && (
+              <div>
+                <div className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Arguments</div>
+                <div className="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-3">
+                  <JsonRenderer 
+                    data={toolCall.arguments} 
+                    emptyMessage="No arguments provided"
+                  />
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </motion.div>
+
+      {/* Arrow Indicator */}
+      <motion.div
+        initial={{ opacity: 0, scale: 0.8 }}
+        animate={{ opacity: 1, scale: 1 }}
+        transition={{ delay: 0.2 }}
+        className="flex justify-center"
+      >
+        <div className="w-10 h-10 rounded-full bg-gray-100 dark:bg-gray-700 flex items-center justify-center">
+          <FiArrowRight size={16} className="text-gray-500 dark:text-gray-400" />
+        </div>
+      </motion.div>
+
+      {/* Tool Result Section */}
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.3 }}
+        className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 overflow-hidden"
+      >
+        <div className={`flex items-center gap-3 px-4 py-3 border-b ${
+          toolResult
+            ? toolResult.error
+              ? 'bg-red-50 dark:bg-red-900/20 border-red-100 dark:border-red-800/30'
+              : 'bg-green-50 dark:bg-green-900/20 border-green-100 dark:border-green-800/30'
+            : 'bg-gray-50 dark:bg-gray-800/50 border-gray-100 dark:border-gray-700/30'
+        }`}>
+          <div className={`w-8 h-8 rounded-lg flex items-center justify-center ${
+            toolResult
+              ? toolResult.error
+                ? 'bg-red-100 dark:bg-red-800/30'
+                : 'bg-green-100 dark:bg-green-800/30'
+              : 'bg-gray-100 dark:bg-gray-700/30'
+          }`}>
+            <FiCode size={16} className={`${
+              toolResult
+                ? toolResult.error
+                  ? 'text-red-600 dark:text-red-400'
+                  : 'text-green-600 dark:text-green-400'
+                : 'text-gray-500 dark:text-gray-400'
+            }`} />
+          </div>
+          <div className="flex-1">
+            <h3 className={`font-medium ${
+              toolResult
+                ? toolResult.error
+                  ? 'text-red-900 dark:text-red-100'
+                  : 'text-green-900 dark:text-green-100'
+                : 'text-gray-700 dark:text-gray-300'
+            }`}>
+              Tool Call Output
+            </h3>
+            {toolResult ? (
+              <div className={`flex items-center gap-2 text-xs ${
+                toolResult.error
+                  ? 'text-red-600 dark:text-red-400'
+                  : 'text-green-600 dark:text-green-400'
+              }`}>
+                <FiClock size={12} />
+                <span>{formatTimestamp(toolResult.timestamp, true)}</span>
+                {toolResult.elapsedMs && (
+                  <>
+                    <span>•</span>
+                    <span>{toolResult.elapsedMs}ms</span>
+                  </>
+                )}
+              </div>
+            ) : (
+              <div className="text-xs text-gray-500 dark:text-gray-400">
+                Waiting for result...
+              </div>
+            )}
+          </div>
+        </div>
+        <div className="p-4">
+          {toolResult ? (
+            <div className="space-y-4">
+              {toolResult.error && (
+                <div>
+                  <div className="text-sm font-medium text-red-700 dark:text-red-300 mb-2">Error</div>
+                  <div className="px-3 py-2 bg-red-50 dark:bg-red-900/20 rounded-lg text-sm text-red-800 dark:text-red-200 font-mono">
+                    {toolResult.error}
+                  </div>
+                </div>
+              )}
+              <div>
+                <div className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Content</div>
+                <div className="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-3">
+                  <JsonRenderer 
+                    data={toolResult.content} 
+                    emptyMessage="No content returned"
+                  />
+                </div>
+              </div>
+              {toolResult._extra && (
+                <div>
+                  <div className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Extra Data</div>
+                  <div className="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-3">
+                    <JsonRenderer 
+                      data={toolResult._extra} 
+                      emptyMessage="No extra data"
+                    />
+                  </div>
+                </div>
+              )}
+            </div>
+          ) : (
+            <div className="flex items-center justify-center py-8">
+              <div className="text-center">
+                <motion.div
+                  animate={{ rotate: 360 }}
+                  transition={{ duration: 2, repeat: Infinity, ease: 'linear' }}
+                  className="w-6 h-6 border-2 border-gray-300 border-t-gray-600 rounded-full mx-auto mb-2"
+                />
+                <p className="text-sm text-gray-500 dark:text-gray-400">Waiting for tool result...</p>
+              </div>
+            </div>
+          )}
+        </div>
+      </motion.div>
+    </div>
+  );
+};

--- a/multimodal/tarko/agent-web-ui/src/standalone/workspace/components/WorkspaceHeader.tsx
+++ b/multimodal/tarko/agent-web-ui/src/standalone/workspace/components/WorkspaceHeader.tsx
@@ -8,6 +8,7 @@ import { StandardPanelContent } from '../types/panelContent';
 import { ToggleSwitch, ToggleSwitchProps } from '../renderers/generic/components/ToggleSwitch';
 import { ShareButton } from './ShareButton';
 import { FileDisplayMode } from '../types';
+import { WorkspaceDisplayMode } from '@/common/state/atoms/workspace';
 
 interface WorkspaceHeaderProps {
   panelContent: StandardPanelContent;
@@ -16,6 +17,10 @@ interface WorkspaceHeaderProps {
   toggleConfig?: ToggleSwitchProps<FileDisplayMode>;
   showFullscreen?: boolean;
   onFullscreen?: () => void;
+  // New props for workspace display mode
+  workspaceDisplayMode?: WorkspaceDisplayMode;
+  onWorkspaceDisplayModeChange?: (mode: WorkspaceDisplayMode) => void;
+  showWorkspaceToggle?: boolean;
 }
 
 export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
@@ -25,6 +30,9 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
   toggleConfig,
   showFullscreen = false,
   onFullscreen,
+  workspaceDisplayMode = 'interaction',
+  onWorkspaceDisplayModeChange,
+  showWorkspaceToggle = false,
 }) => {
   const { getToolIcon } = useTool();
 
@@ -90,7 +98,20 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
       </div>
 
       <div className="ml-4 flex-shrink-0 flex items-center gap-3">
-        {/* Toggle switch */}
+        {/* Workspace display mode toggle */}
+        {showWorkspaceToggle && onWorkspaceDisplayModeChange && (
+          <ToggleSwitch<WorkspaceDisplayMode>
+            value={workspaceDisplayMode}
+            onChange={onWorkspaceDisplayModeChange}
+            options={[
+              { value: 'interaction', label: 'UI' },
+              { value: 'raw', label: 'RAW' }
+            ]}
+            size="sm"
+          />
+        )}
+
+        {/* File display mode toggle */}
         {showToggle && toggleConfig && <ToggleSwitch<FileDisplayMode> {...toggleConfig} />}
 
         {/* Share button */}


### PR DESCRIPTION
## Summary
Adds RAW display mode to workspace for viewing original tool input/output data alongside existing interaction mode.

## Changes
- Extracted reusable `JsonRenderer` component from `AgentConfigViewer`
- Added workspace display mode toggle (UI/RAW) in `WorkspaceHeader`
- Created `RawModeRenderer` for displaying tool call inputs and outputs
- Enhanced `WorkspaceDetail` to support both interaction and raw modes
- Added workspace state management with `workspaceDisplayModeAtom`

## Features
- Toggle between UI (interaction) and RAW modes
- Raw mode shows original tool call arguments and results in JSON format
- Maintains existing functionality in interaction mode
- Clean separation of concerns with reusable components

## Dependencies
- Builds on PR #1118 (rawToolMappingAtom)
- Uses JsonRenderer extracted from PR #1153 pattern