### PR TITLE
fix(tarko): handle CLI parameter order for agent argument

### DIFF
--- a/multimodal/tarko/agent-cli/src/core/cli.ts
+++ b/multimodal/tarko/agent-cli/src/core/cli.ts
@@ -200,8 +200,15 @@ export class AgentCLI {
     configuredCommand.action(
       async (agent: string | undefined, cliArguments: AgentCLIArguments = {}) => {
         // If agent is provided as positional argument, use it
-        if (agent) {
+        if (agent && typeof cliArguments === 'object') {
           cliArguments.agent = agent;
+        }
+
+        // Handle case where cliArguments might be a string (when only one argument is passed)
+        if (typeof cliArguments === 'string') {
+          // This happens when user runs "tarko --agent ./" - the agent parameter becomes cliArguments
+          const actualAgent = agent || cliArguments;
+          cliArguments = { agent: actualAgent } as AgentCLIArguments;
         }
 
         if (cliArguments.headless) {

--- a/multimodal/tarko/agent-cli/src/core/cli.ts
+++ b/multimodal/tarko/agent-cli/src/core/cli.ts
@@ -213,6 +213,10 @@ export class AgentCLI {
       
       // If agent is provided as positional argument, use it
       if (agent && typeof agent === 'string') {
+        // Warn if both positional agent and --agent flag are provided
+        if (cliArguments.agent && cliArguments.agent !== agent) {
+          console.warn(`Warning: Both positional agent '${agent}' and --agent flag '${cliArguments.agent}' provided. Using positional agent '${agent}'.`);
+        }
         cliArguments.agent = agent;
       }
 

--- a/multimodal/tarko/agent-cli/src/core/cli.ts
+++ b/multimodal/tarko/agent-cli/src/core/cli.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 /*
  * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
  * SPDX-License-Identifier: Apache-2.0
@@ -204,18 +205,20 @@ export class AgentCLI {
       // - tarko run              -> args = ['run', undefined, cliArguments]
       // - tarko run ./           -> args = ['run', './', cliArguments]
       // - tarko ./               -> args = [undefined, './', cliArguments]
-      
+
       // The last argument is always the parsed CLI options object
       const cliArguments: AgentCLIArguments = args[args.length - 1] || {};
-      
+
       // The second-to-last argument is the agent parameter
       const agent = args[args.length - 2];
-      
+
       // If agent is provided as positional argument, use it
       if (agent && typeof agent === 'string') {
         // Warn if both positional agent and --agent flag are provided
         if (cliArguments.agent && cliArguments.agent !== agent) {
-          console.warn(`Warning: Both positional agent '${agent}' and --agent flag '${cliArguments.agent}' provided. Using positional agent '${agent}'.`);
+          console.warn(
+            `Warning: Both positional agent '${agent}' and --agent flag '${cliArguments.agent}' provided. Using positional agent '${agent}'.`,
+          );
         }
         cliArguments.agent = agent;
       }

--- a/multimodal/tarko/agent-cli/src/core/cli.ts
+++ b/multimodal/tarko/agent-cli/src/core/cli.ts
@@ -197,47 +197,33 @@ export class AgentCLI {
 
     // Apply agent-specific configurations for commands that run agents
     configuredCommand = this.configureAgentCommand(configuredCommand);
-    configuredCommand.action(
-      async (...args: any[]) => {
-        // Handle dynamic arguments due to optional positional parameters [run] [agent]
-        // CAC passes arguments in different ways depending on what's provided:
-        // - tarko --agent ./        -> args = [cliArguments]
-        // - tarko run              -> args = [undefined, cliArguments] 
-        // - tarko run ./           -> args = ['./'] or args = ['./', cliArguments]
-        // - tarko ./               -> args = ['./'] or args = ['./', cliArguments]
-        
-        let agent: string | undefined;
-        let cliArguments: AgentCLIArguments = {};
-        
-        // The last argument is always the parsed CLI options object
-        const lastArg = args[args.length - 1];
-        if (typeof lastArg === 'object' && lastArg !== null && !Array.isArray(lastArg)) {
-          cliArguments = lastArg;
-          // Remove the options object from args to process positional arguments
-          args = args.slice(0, -1);
-        }
-        
-        // Process remaining positional arguments
-        // Filter out undefined values and take the last string as agent
-        const positionalArgs = args.filter(arg => arg !== undefined && typeof arg === 'string');
-        if (positionalArgs.length > 0) {
-          agent = positionalArgs[positionalArgs.length - 1];
-        }
-        
-        // If agent is provided as positional argument, use it
-        if (agent) {
-          cliArguments.agent = agent;
-        }
+    configuredCommand.action(async (...args: any[]) => {
+      // Handle dynamic arguments due to optional positional parameters [run] [agent]
+      // CAC passes arguments in this pattern:
+      // - tarko --agent ./        -> args = [undefined, undefined, cliArguments]
+      // - tarko run              -> args = ['run', undefined, cliArguments]
+      // - tarko run ./           -> args = ['run', './', cliArguments]
+      // - tarko ./               -> args = [undefined, './', cliArguments]
+      
+      // The last argument is always the parsed CLI options object
+      const cliArguments: AgentCLIArguments = args[args.length - 1] || {};
+      
+      // The second-to-last argument is the agent parameter
+      const agent = args[args.length - 2];
+      
+      // If agent is provided as positional argument, use it
+      if (agent && typeof agent === 'string') {
+        cliArguments.agent = agent;
+      }
 
-        if (cliArguments.headless) {
-          // Headless mode - same as old 'run' command
-          await this.runHeadlessMode(cliArguments);
-        } else {
-          // Interactive UI mode - same as old 'start' command
-          await this.runInteractiveMode(cliArguments);
-        }
-      },
-    );
+      if (cliArguments.headless) {
+        // Headless mode - same as old 'run' command
+        await this.runHeadlessMode(cliArguments);
+      } else {
+        // Interactive UI mode - same as old 'start' command
+        await this.runInteractiveMode(cliArguments);
+      }
+    });
   }
 
   /**


### PR DESCRIPTION
## Summary

Fix CLI parameter handling issue where `tarko --agent ./` command failed due to incorrect parameter order processing in the run command action handler after PR #1158.

**Problem**: After PR #1158 introduced new CLI command structure, the `tarko --agent ./` syntax stopped working because the CLI argument parsing incorrectly handled CAC's dynamic parameter passing for optional positional parameters `[run] [agent]`.

**Root Cause**: CAC library passes arguments in a specific pattern for optional positional parameters:
- `tarko --agent ./` → `args = [undefined, undefined, cliArguments]`
- `tarko run` → `args = ['run', undefined, cliArguments]`
- `tarko run ./` → `args = ['run', './', cliArguments]`
- `tarko ./` → `args = [undefined, './', cliArguments]`

**Supported Syntax**:
- `tarko --agent ./` (legacy syntax) ✅
- `tarko run ./` (new syntax) ✅
- `tarko ./` (simplified syntax) ✅

**Warning Example**:
```bash
$ tarko run ./agent1.js --agent ./agent2.js
Warning: Both positional agent './agent1.js' and --agent flag './agent2.js' provided. Using positional agent './agent1.js'.
```

## Checklist  

- [ ] Added or updated necessary tests (Optional).  
- [ ] Updated documentation to align with changes (Optional).  
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).  
- [x] My change does not involve the above items.