### PR TITLE
fix(agent-tars): add default port 8888 to prevent random port assignment

### DIFF
--- a/multimodal/agent-tars/cli/src/index.ts
+++ b/multimodal/agent-tars/cli/src/index.ts
@@ -51,6 +51,7 @@ const DEFAULT_OPTIONS: Partial<AgentCLIInitOptions> = {
       enableContextualSelector: true,
     },
     server: {
+      port: 8888,
       storage: {
         type: 'sqlite',
         baseDir: path.join(homedir(), AGENT_TARS_CONSTANTS.GLOBAL_STORAGE_DIR),


### PR DESCRIPTION
## Summary

Fixed Agent TARS CLI random port assignment by adding default port 8888.

## Checklist  

- [ ] Added or updated necessary tests (Optional).  
- [ ] Updated documentation to align with changes (Optional).  
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).  
- [x] My change does not involve the above items.