### PR TITLE
fix(tarko): export defineConfig from interface

### DIFF
--- a/multimodal/tarko/interface/src/index.ts
+++ b/multimodal/tarko/interface/src/index.ts
@@ -12,3 +12,4 @@ export * from './web-ui-implementation';
 export * from './constants';
 export * from './storage-implementation';
 export * from './agent-status';
+export * from './define-config';


### PR DESCRIPTION
## Summary

Fixed missing TypeScript type hints for `defineConfig` by adding export to interface index.

## Checklist  

- [ ] Added or updated necessary tests (Optional).  
- [ ] Updated documentation to align with changes (Optional).  
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).  
- [x] My change does not involve the above items.