### PR TITLE
fix(tarko): allow workspace panel updates in replay mode

### DIFF
--- a/multimodal/tarko/agent-web-ui/src/common/state/actions/eventProcessors/utils/panelContentUpdater.ts
+++ b/multimodal/tarko/agent-web-ui/src/common/state/actions/eventProcessors/utils/panelContentUpdater.ts
@@ -1,6 +1,5 @@
 import { Getter } from 'jotai';
 import { activeSessionIdAtom } from '@/common/state/atoms/session';
-import { replayStateAtom } from '@/common/state/atoms/replay';
 
 /**
  * Helper function to validate if the event belongs to the current active session
@@ -8,13 +7,11 @@ import { replayStateAtom } from '@/common/state/atoms/replay';
  */
 export function shouldUpdatePanelContent(get: Getter, sessionId: string): boolean {
   const activeSessionId = get(activeSessionIdAtom);
-  const replayState = get(replayStateAtom);
 
   // Don't update panel content if:
   // 1. No active session
   // 2. Event is from a different session than the active one
-  // 3. In replay mode (replay handles its own content updates)
-  if (!activeSessionId || sessionId !== activeSessionId || replayState.isActive) {
+  if (!activeSessionId || sessionId !== activeSessionId) {
     return false;
   }
 


### PR DESCRIPTION
## Summary

Fixed Workspace Panel not updating in Replay mode by removing the `replayState.isActive` check in `shouldUpdatePanelContent()`. The issue was caused by the panel content updater incorrectly blocking updates during replay, preventing Tool Results from being displayed in the Workspace Panel.

## Checklist

- [ ] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [x] My change does not involve the above items.