### PR TITLE
feat(tarko): add webUIConfig support to AgentConstructor

### DIFF
--- a/multimodal/tarko/agent-cli/src/core/commands/start.ts
+++ b/multimodal/tarko/agent-cli/src/core/commands/start.ts
@@ -50,7 +50,9 @@ export async function startInteractiveWebUI(
   // Set up UI if static path is provided
   if (webui.staticPath) {
     const app = server.getApp();
-    setupUI(app, isDebug, webui.staticPath, webui);
+    const agentConstructorWebConfig = server.getAgentConstructorWebConfig();
+    const mergedWebUIConfig = { ...webui, ...agentConstructorWebConfig };
+    setupUI(app, isDebug, webui.staticPath, mergedWebUIConfig);
   }
 
   const port = appConfig.server!.port!;
@@ -113,7 +115,7 @@ function setupUI(
   app: express.Application,
   isDebug = false,
   staticPath: string,
-  webui: AgentWebUIImplementation,
+  webui: AgentWebUIImplementation & Record<string, any>,
 ): void {
   if (isDebug) {
     logger.debug(`Using static files from: ${staticPath}`);

--- a/multimodal/tarko/agent-interface/src/agent-constructor.ts
+++ b/multimodal/tarko/agent-interface/src/agent-constructor.ts
@@ -12,4 +12,7 @@ import { AgentOptions } from './agent-options';
 export type AgentConstructor<
   T extends IAgent = IAgent,
   U extends AgentOptions = AgentOptions,
-> = (new (options: U) => T) & { label?: string };
+> = (new (options: U) => T) & { 
+  label?: string;
+  webUIConfig?: Record<string, any>;
+};

--- a/multimodal/tarko/agent-server/src/server.ts
+++ b/multimodal/tarko/agent-server/src/server.ts
@@ -117,6 +117,14 @@ export class AgentServer<T extends AgentAppConfig = AgentAppConfig> {
   }
 
   /**
+   * Get the Web UI config from Agent Constructor
+   * @returns Web UI config or undefined
+   */
+  getAgentConstructorWebConfig(): Record<string, any> | undefined {
+    return this.currentAgentResolution?.agentConstructor.webUIConfig;
+  }
+
+  /**
    * Get the label of current agent
    */
   getCurrentWorkspace(): string {


### PR DESCRIPTION
## Summary

Enable Agent Server to resolve Web UI configuration from Agent Constructor static property, allowing runtime Web UI customization without tarko.config.ts dependency.

**Changes:**
- Add `webUIConfig` optional property to `AgentConstructor` type
- Add `getAgentConstructorWebConfig()` method to `AgentServer`
- Merge `appConfig.webui` with constructor config in `setupUI`

## Checklist

- [ ] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [x] My change does not involve the above items.