### PR TITLE
feat(tarko): using backward-only screenshot association

### DIFF
--- a/multimodal/tarko/agent-web-ui/src/standalone/chat/Message/index.tsx
+++ b/multimodal/tarko/agent-web-ui/src/standalone/chat/Message/index.tsx
@@ -17,8 +17,7 @@ import { useAtomValue } from 'jotai';
 import { replayStateAtom } from '@/common/state/atoms/replay';
 import { ReportFileEntry } from './components/ReportFileEntry';
 import { messagesAtom } from '@/common/state/atoms/message';
-import { FiMonitor } from 'react-icons/fi';
-import { ActionButton } from './components/ActionButton';
+
 
 interface MessageProps {
   message: MessageType;
@@ -75,33 +74,7 @@ export const Message: React.FC<MessageProps> = ({
     }
   };
 
-  // Handle click on final assistant response to show latest environment state
-  const handleFinalResponseClick = () => {
-    if (!activeSessionId || !isFinalAssistantResponse) return;
 
-    const sessionMessages = allMessages[activeSessionId] || [];
-
-    // Find the most recent environment input
-    for (let i = sessionMessages.length - 1; i >= 0; i--) {
-      const msg = sessionMessages[i];
-      if (msg.role === 'environment' && Array.isArray(msg.content)) {
-        const imageContent = msg.content.find(
-          (item) => item.type === 'image_url' && item.image_url && item.image_url.url,
-        );
-
-        if (imageContent) {
-          setActivePanelContent({
-            type: 'image',
-            source: msg.content,
-            title: msg.description || 'Final Environment State',
-            timestamp: msg.timestamp,
-            environmentId: msg.id,
-          });
-          break;
-        }
-      }
-    }
-  };
 
   // Render content based on type
   const renderContent = () => {
@@ -158,10 +131,7 @@ export const Message: React.FC<MessageProps> = ({
       baseClasses = 'message-assistant';
     }
 
-    // Add smoother click styles
-    if (isFinalAssistantResponse) {
-      baseClasses += ' cursor-pointer';
-    }
+
 
     return baseClasses;
   };
@@ -176,24 +146,7 @@ export const Message: React.FC<MessageProps> = ({
     return imageContents.length > 0 && textContents.length === 0;
   }, [message.content]);
 
-  // Check if there's environment state to display
-  const hasEnvironmentState = React.useMemo(() => {
-    if (!activeSessionId || !isFinalAssistantResponse || !allMessages[activeSessionId])
-      return false;
 
-    const sessionMessages = allMessages[activeSessionId] || [];
-    if (sessionMessages.length === 0) return false;
-
-    // Check if there is a latest environment image input message
-    const lastMessage = sessionMessages[sessionMessages.length - 1];
-    return (
-      lastMessage.role === 'environment' &&
-      Array.isArray(lastMessage.content) &&
-      lastMessage.content.some(
-        (item) => item.type === 'image_url' && item.image_url && item.image_url.url,
-      )
-    );
-  }, [activeSessionId, isFinalAssistantResponse, allMessages]);
 
   // Determine which prose class should be used, based on message type and dark mode
   const getProseClasses = () => {
@@ -232,15 +185,7 @@ export const Message: React.FC<MessageProps> = ({
 
             <div className={getProseClasses()}>{renderContent()}</div>
 
-            {isFinalAssistantResponse && hasEnvironmentState && (
-              <div className="mt-2">
-                <ActionButton
-                  icon={<FiMonitor size={14} />}
-                  label="view final environment state"
-                  onClick={handleFinalResponseClick}
-                />
-              </div>
-            )}
+
 
             {isFinalAnswer && message.title && typeof message.content === 'string' && (
               <ReportFileEntry

--- a/multimodal/tarko/agent-web-ui/src/standalone/workspace/renderers/BrowserControlRenderer.tsx
+++ b/multimodal/tarko/agent-web-ui/src/standalone/workspace/renderers/BrowserControlRenderer.tsx
@@ -71,7 +71,7 @@ export const BrowserControlRenderer: React.FC<BrowserControlRendererProps> = ({
     }
   }, [environmentImage]);
 
-  // Smart screenshot association based on tool type
+  // Find the next environment input (screenshot) after this operation
   useEffect(() => {
     // Initialize: clear current screenshot if no direct environment image provided
     if (!environmentImage) {
@@ -91,102 +91,28 @@ export const BrowserControlRenderer: React.FC<BrowserControlRendererProps> = ({
       return;
     }
 
-    // Get current tool name
-    const currentToolCall = sessionMessages[currentToolCallIndex]?.toolCalls?.find(
-      (tc) => tc.id === toolCallId,
-    );
-    const toolName = currentToolCall?.function?.name;
-
     let foundImage = false;
 
-    // Tool-specific screenshot association strategy
-    const isPostOperationTool = toolName === 'open_computer' || toolName === 'navigate';
+    // Search for screenshots AFTER the current tool call
+    for (let i = currentToolCallIndex + 1; i < sessionMessages.length; i++) {
+      const msg = sessionMessages[i];
+      if (msg.role === 'environment' && Array.isArray(msg.content)) {
+        const imgContent = msg.content.find(
+          (c) => typeof c === 'object' && 'type' in c && c.type === 'image_url',
+        );
 
-    if (isPostOperationTool) {
-      // For tools like open_computer/navigate: search AFTER the operation
-      console.log(`[BrowserControlRenderer] Detected ${toolName}, searching for post-operation screenshot...`);
-      
-      for (let i = currentToolCallIndex + 1; i < sessionMessages.length; i++) {
-        const msg = sessionMessages[i];
-        if (msg.role === 'environment' && Array.isArray(msg.content)) {
-          const imgContent = msg.content.find(
-            (c) => typeof c === 'object' && 'type' in c && c.type === 'image_url',
-          );
-
-          if (imgContent && 'image_url' in imgContent && imgContent.image_url.url) {
-            setRelatedImage(imgContent.image_url.url);
-            foundImage = true;
-            console.log(`[BrowserControlRenderer] Found post-operation screenshot for ${toolName}`);
-            break;
-          }
-        }
-      }
-    } else {
-      // For vision-based tools: search BEFORE the operation (original logic)
-      console.log(`[BrowserControlRenderer] Detected ${toolName || 'browser_vision_control'}, searching for pre-operation screenshot...`);
-      
-      for (let i = currentToolCallIndex - 1; i >= 0; i--) {
-        const msg = sessionMessages[i];
-        if (msg.role === 'environment' && Array.isArray(msg.content)) {
-          const imgContent = msg.content.find(
-            (c) => typeof c === 'object' && 'type' in c && c.type === 'image_url',
-          );
-
-          if (imgContent && 'image_url' in imgContent && imgContent.image_url.url) {
-            setRelatedImage(imgContent.image_url.url);
-            foundImage = true;
-            console.log(`[BrowserControlRenderer] Found pre-operation screenshot for ${toolName || 'browser_vision_control'}`);
-            break;
-          }
+        if (imgContent && 'image_url' in imgContent && imgContent.image_url.url) {
+          setRelatedImage(imgContent.image_url.url);
+          foundImage = true;
+          break;
         }
       }
     }
 
-    // Fallback strategy if primary search fails
-    if (!foundImage && !environmentImage) {
-      console.log(`[BrowserControlRenderer] Primary strategy failed for ${toolName}, trying fallback...`);
-      
-      if (isPostOperationTool) {
-        // Fallback: search before operation
-        for (let i = currentToolCallIndex - 1; i >= 0; i--) {
-          const msg = sessionMessages[i];
-          if (msg.role === 'environment' && Array.isArray(msg.content)) {
-            const imgContent = msg.content.find(
-              (c) => typeof c === 'object' && 'type' in c && c.type === 'image_url',
-            );
-
-            if (imgContent && 'image_url' in imgContent && imgContent.image_url.url) {
-              setRelatedImage(imgContent.image_url.url);
-              foundImage = true;
-              console.log(`[BrowserControlRenderer] Fallback: found pre-operation screenshot for ${toolName}`);
-              break;
-            }
-          }
-        }
-      } else {
-        // Fallback: search after operation
-        for (let i = currentToolCallIndex + 1; i < sessionMessages.length; i++) {
-          const msg = sessionMessages[i];
-          if (msg.role === 'environment' && Array.isArray(msg.content)) {
-            const imgContent = msg.content.find(
-              (c) => typeof c === 'object' && 'type' in c && c.type === 'image_url',
-            );
-
-            if (imgContent && 'image_url' in imgContent && imgContent.image_url.url) {
-              setRelatedImage(imgContent.image_url.url);
-              foundImage = true;
-              console.log(`[BrowserControlRenderer] Fallback: found post-operation screenshot for ${toolName || 'browser_vision_control'}`);
-              break;
-            }
-          }
-        }
-      }
-    }
-
-    // If no valid screenshot found, clear the display
+    // If no valid screenshot found after the tool call, clear the display
     if (!foundImage && !environmentImage) {
       console.warn(
-        `[BrowserControlRenderer] No valid screenshot found for ${toolName || 'unknown tool'} (toolCallId: ${toolCallId})`,
+        `[BrowserControlRenderer] No valid screenshot found after toolCallId: ${toolCallId}. Clearing screenshot display.`,
       );
       setRelatedImage(null);
     }


### PR DESCRIPTION
## Summary

This pull request removes the "view final environment state" button from the chat message UI and updates the logic in `BrowserControlRenderer` to search for environment screenshots after, rather than before, the current tool call. These changes streamline the user interface and correct the screenshot retrieval logic.

**UI cleanup and feature removal:**
- Removed the "view final environment state" button and all related logic from the chat `Message` component, including click handlers, state checks, and associated imports. This simplifies the message UI and eliminates unused code. [[1]](diffhunk://#diff-2d5a5085277b5368f98d33930e0b979db0a869fcf54c63b515cfcfce85081c2cL20-R20) [[2]](diffhunk://#diff-2d5a5085277b5368f98d33930e0b979db0a869fcf54c63b515cfcfce85081c2cL78-L104) [[3]](diffhunk://#diff-2d5a5085277b5368f98d33930e0b979db0a869fcf54c63b515cfcfce85081c2cL161-R134) [[4]](diffhunk://#diff-2d5a5085277b5368f98d33930e0b979db0a869fcf54c63b515cfcfce85081c2cL179-L196) [[5]](diffhunk://#diff-2d5a5085277b5368f98d33930e0b979db0a869fcf54c63b515cfcfce85081c2cL235-R188)

**Screenshot retrieval logic correction:**
- Updated `BrowserControlRenderer` to search for environment screenshots (such as browser screenshots) after the current tool call instead of before, ensuring the correct image is displayed in the workspace renderer. Also updated related comments and warning messages for clarity. [[1]](diffhunk://#diff-25639e567c87a2c3e1da0538ef7e367133ae12bc0bf4ca8cadc8e45f04532bdaL74-R74) [[2]](diffhunk://#diff-25639e567c87a2c3e1da0538ef7e367133ae12bc0bf4ca8cadc8e45f04532bdaL96-R97) [[3]](diffhunk://#diff-25639e567c87a2c3e1da0538ef7e367133ae12bc0bf4ca8cadc8e45f04532bdaL112-R115)

## Checklist

- [ ] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [x] My change does not involve the above items.