### PR TITLE
chore(tarko): override strikethrough (del) to render as normal text

### DIFF
--- a/multimodal/tarko/agent-web-ui/src/sdk/markdown-renderer/hooks/useMarkdownComponents.tsx
+++ b/multimodal/tarko/agent-web-ui/src/sdk/markdown-renderer/hooks/useMarkdownComponents.tsx
@@ -66,6 +66,9 @@ export const useMarkdownComponents = ({ onImageClick }: UseMarkdownComponentsPro
 
       // Images
       img: ({ src, alt }) => <InteractiveImage src={src} alt={alt} onClick={onImageClick} />,
+
+      // Override strikethrough (del) to render as normal text
+      del: ({ children }) => <span>{children}</span>,
     }),
     [onImageClick],
   );


### PR DESCRIPTION
## Summary

Override strikethrough (del) markdown element to render as normal text in Tarko agent web UI.

## Checklist

- [x] My change does not involve the above items.