### PR TITLE
fix(tarko): update session title in correct metadata structure

### DIFF
--- a/multimodal/tarko/agent-web-ui/src/common/state/actions/sessionActions.ts
+++ b/multimodal/tarko/agent-web-ui/src/common/state/actions/sessionActions.ts
@@ -350,7 +350,15 @@ export const sendMessageAction = atom(
 
         set(sessionsAtom, (prev) =>
           prev.map((session) =>
-            session.id === activeSessionId ? { ...session, name: summary } : session,
+            session.id === activeSessionId
+              ? {
+                  ...session,
+                  metadata: {
+                    ...session.metadata,
+                    name: summary,
+                  },
+                }
+              : session,
           ),
         );
       }


### PR DESCRIPTION
## Summary

Fixed Sidebar Session title not updating after user input by correcting the session metadata structure update logic.

The issue was in `sendMessageAction` where session title was being set directly on the session object instead of in the correct `metadata.name` property according to the `SessionItemInfo` interface.

**Before**: Session title would not update in sidebar after user prompt
**After**: Session title updates correctly in sidebar after user prompt

## Checklist

- [ ] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [x] My change does not involve the above items.