### PR TITLE
fix(tarko): enable line wrapping for command stdout/stderr

### DIFF
--- a/multimodal/tarko/agent-web-ui/src/standalone/workspace/renderers/CommandResultRenderer.tsx
+++ b/multimodal/tarko/agent-web-ui/src/standalone/workspace/renderers/CommandResultRenderer.tsx
@@ -134,16 +134,16 @@ export const CommandResultRenderer: React.FC<CommandResultRendererProps> = ({ pa
                 </div>
               )}
 
-              {/* Output section - disable auto-wrapping */}
+              {/* Output section - enable line wrapping */}
               {stdout && (
-                <pre className="whitespace-pre overflow-x-visible text-gray-200 mt-3 ml-3">
+                <pre className="whitespace-pre-wrap text-gray-200 mt-3 ml-3">
                   {stdout}
                 </pre>
               )}
 
               {/* Error output */}
               {stderr && (
-                <pre className="whitespace-pre overflow-x-visible text-red-400 my-3 ml-3">
+                <pre className="whitespace-pre-wrap text-red-400 my-3 ml-3">
                   {stderr}
                 </pre>
               )}


### PR DESCRIPTION
## Summary

Fixed Web UI Command stdout rendering to enable line wrapping instead of requiring horizontal scrolling.

Changed `whitespace-pre overflow-x-visible` to `whitespace-pre-wrap` for both stdout and stderr output in CommandResultRenderer.

## Checklist  

- [ ] Added or updated necessary tests (Optional).  
- [ ] Updated documentation to align with changes (Optional).  
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).  
- [x] My change does not involve the above items.