### PR TITLE
fix(agent-tars): move required deps from devDependencies to dependencies

### DIFF
--- a/multimodal/agent-tars/core/package.json
+++ b/multimodal/agent-tars/core/package.json
@@ -23,11 +23,11 @@
   },
   "dependencies": {
     "@tarko/shared-utils": "workspace:*",
-    "@tarko/shared-media-utils": "workspace:*"
+    "@tarko/shared-media-utils": "workspace:*",
+    "@tarko/mcp-agent": "workspace:*",
+    "@agent-tars/interface": "workspace:*"
   },
   "devDependencies": {
-    "@tarko/mcp-agent": "workspace:*",
-    "@agent-tars/interface": "workspace:*",
     "@gui-agent/operator-browser": "workspace:*",
     "@agent-infra/mcp-server-browser": "1.1.10",
     "@agent-infra/mcp-server-commands": "1.1.10",


### PR DESCRIPTION
## Summary

Fix missing dependencies in @agent-tars/core package by moving @agent-tars/interface and @tarko/mcp-agent from devDependencies to dependencies since they are re-exported in the public API (close: #1254)

## Checklist

- [ ] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [x] My change does not involve the above items.