### PR TITLE
refactor(tarko): unify language detection logic across renderers

### DIFF
--- a/multimodal/tarko/agent-web-ui/src/common/utils/language/index.ts
+++ b/multimodal/tarko/agent-web-ui/src/common/utils/language/index.ts
@@ -1,0 +1,7 @@
+export {
+  getLanguageFromFileName,
+  getLanguageFromInterpreter,
+  getExtensionFromLanguage,
+  isLanguageSupported,
+  getLanguageDisplayName,
+} from './languageDetection';

--- a/multimodal/tarko/agent-web-ui/src/common/utils/language/languageDetection.ts
+++ b/multimodal/tarko/agent-web-ui/src/common/utils/language/languageDetection.ts
@@ -1,0 +1,254 @@
+/**
+ * Unified language detection utilities for code editors and syntax highlighting
+ */
+
+/**
+ * Comprehensive file extension to language mapping
+ */
+const EXTENSION_TO_LANGUAGE: Record<string, string> = {
+  // JavaScript/TypeScript
+  js: 'javascript',
+  jsx: 'javascript',
+  ts: 'typescript',
+  tsx: 'typescript',
+  mjs: 'javascript',
+  cjs: 'javascript',
+  
+  // Python
+  py: 'python',
+  pyw: 'python',
+  pyi: 'python',
+  
+  // Web technologies
+  html: 'html',
+  htm: 'html',
+  css: 'css',
+  scss: 'scss',
+  sass: 'sass',
+  less: 'less',
+  
+  // Data formats
+  json: 'json',
+  xml: 'xml',
+  yaml: 'yaml',
+  yml: 'yaml',
+  toml: 'toml',
+  
+  // Documentation
+  md: 'markdown',
+  markdown: 'markdown',
+  rst: 'restructuredtext',
+  
+  // Shell scripts
+  sh: 'shell',
+  bash: 'shell',
+  zsh: 'shell',
+  fish: 'shell',
+  
+  // Other languages
+  java: 'java',
+  kt: 'kotlin',
+  scala: 'scala',
+  go: 'go',
+  rs: 'rust',
+  cpp: 'cpp',
+  cc: 'cpp',
+  cxx: 'cpp',
+  'c++': 'cpp',
+  c: 'c',
+  h: 'c',
+  hpp: 'cpp',
+  cs: 'csharp',
+  php: 'php',
+  rb: 'ruby',
+  swift: 'swift',
+  dart: 'dart',
+  lua: 'lua',
+  r: 'r',
+  sql: 'sql',
+  
+  // Config files
+  ini: 'ini',
+  cfg: 'ini',
+  conf: 'ini',
+  env: 'shell',
+  
+  // Docker
+  dockerfile: 'dockerfile',
+  
+  // Others
+  txt: 'plaintext',
+  log: 'plaintext',
+};
+
+/**
+ * Interpreter to language mapping for script execution
+ */
+const INTERPRETER_TO_LANGUAGE: Record<string, string> = {
+  python: 'python',
+  python3: 'python',
+  py: 'python',
+  
+  node: 'javascript',
+  nodejs: 'javascript',
+  
+  bash: 'shell',
+  sh: 'shell',
+  zsh: 'shell',
+  fish: 'shell',
+  
+  ruby: 'ruby',
+  rb: 'ruby',
+  
+  php: 'php',
+  java: 'java',
+  go: 'go',
+  rust: 'rust',
+  
+  cpp: 'cpp',
+  'c++': 'cpp',
+  gcc: 'c',
+  clang: 'c',
+  
+  csharp: 'csharp',
+  dotnet: 'csharp',
+  
+  swift: 'swift',
+  dart: 'dart',
+  lua: 'lua',
+  r: 'r',
+};
+
+/**
+ * Language to file extension mapping for generating filenames
+ */
+const LANGUAGE_TO_EXTENSION: Record<string, string> = {
+  javascript: 'js',
+  typescript: 'ts',
+  python: 'py',
+  java: 'java',
+  go: 'go',
+  rust: 'rs',
+  cpp: 'cpp',
+  c: 'c',
+  csharp: 'cs',
+  php: 'php',
+  ruby: 'rb',
+  swift: 'swift',
+  dart: 'dart',
+  lua: 'lua',
+  r: 'r',
+  shell: 'sh',
+  html: 'html',
+  css: 'css',
+  scss: 'scss',
+  sass: 'sass',
+  less: 'less',
+  json: 'json',
+  xml: 'xml',
+  yaml: 'yaml',
+  markdown: 'md',
+  sql: 'sql',
+  dockerfile: 'dockerfile',
+  ini: 'ini',
+  plaintext: 'txt',
+};
+
+/**
+ * Get language identifier from filename
+ * @param fileName - The filename or path
+ * @returns Language identifier for Monaco Editor
+ */
+export function getLanguageFromFileName(fileName: string): string {
+  if (!fileName) return 'plaintext';
+  
+  // Extract the file extension
+  const ext = fileName.split('.').pop()?.toLowerCase() || '';
+  
+  // Handle special cases
+  if (fileName.toLowerCase().includes('dockerfile')) {
+    return 'dockerfile';
+  }
+  
+  return EXTENSION_TO_LANGUAGE[ext] || 'plaintext';
+}
+
+/**
+ * Get language identifier from interpreter name
+ * @param interpreter - The interpreter or runtime name
+ * @returns Language identifier for Monaco Editor
+ */
+export function getLanguageFromInterpreter(interpreter: string): string {
+  if (!interpreter) return 'plaintext';
+  
+  const normalizedInterpreter = interpreter.toLowerCase().trim();
+  return INTERPRETER_TO_LANGUAGE[normalizedInterpreter] || 'plaintext';
+}
+
+/**
+ * Get file extension from language identifier
+ * @param language - The language identifier
+ * @returns File extension (without dot)
+ */
+export function getExtensionFromLanguage(language: string): string {
+  if (!language) return 'txt';
+  
+  return LANGUAGE_TO_EXTENSION[language] || 'txt';
+}
+
+/**
+ * Check if a language supports syntax highlighting
+ * @param language - The language identifier
+ * @returns True if the language is supported by Monaco Editor
+ */
+export function isLanguageSupported(language: string): boolean {
+  const supportedLanguages = new Set([
+    'javascript', 'typescript', 'python', 'java', 'go', 'rust',
+    'cpp', 'c', 'csharp', 'php', 'ruby', 'swift', 'dart', 'lua',
+    'r', 'shell', 'html', 'css', 'scss', 'sass', 'less', 'json',
+    'xml', 'yaml', 'markdown', 'sql', 'dockerfile', 'ini'
+  ]);
+  
+  return supportedLanguages.has(language);
+}
+
+/**
+ * Get a human-readable display name for a language
+ * @param language - The language identifier
+ * @returns Human-readable language name
+ */
+export function getLanguageDisplayName(language: string): string {
+  const displayNames: Record<string, string> = {
+    javascript: 'JavaScript',
+    typescript: 'TypeScript',
+    python: 'Python',
+    java: 'Java',
+    go: 'Go',
+    rust: 'Rust',
+    cpp: 'C++',
+    c: 'C',
+    csharp: 'C#',
+    php: 'PHP',
+    ruby: 'Ruby',
+    swift: 'Swift',
+    dart: 'Dart',
+    lua: 'Lua',
+    r: 'R',
+    shell: 'Shell',
+    html: 'HTML',
+    css: 'CSS',
+    scss: 'SCSS',
+    sass: 'Sass',
+    less: 'Less',
+    json: 'JSON',
+    xml: 'XML',
+    yaml: 'YAML',
+    markdown: 'Markdown',
+    sql: 'SQL',
+    dockerfile: 'Dockerfile',
+    ini: 'INI',
+    plaintext: 'Plain Text',
+  };
+  
+  return displayNames[language] || language.charAt(0).toUpperCase() + language.slice(1);
+}

--- a/multimodal/tarko/agent-web-ui/src/sdk/code-editor/DiffViewer.tsx
+++ b/multimodal/tarko/agent-web-ui/src/sdk/code-editor/DiffViewer.tsx
@@ -3,6 +3,7 @@ import { DiffEditor } from '@monaco-editor/react';
 import type { editor } from 'monaco-editor';
 import parseDiff from 'parse-diff';
 import { normalizeFilePath } from '@/common/utils/pathNormalizer';
+import { getLanguageFromFileName } from '@/common/utils/language';
 import { CodeEditorHeader } from './CodeEditorHeader';
 import './MonacoCodeEditor.css';
 
@@ -13,22 +14,7 @@ interface DiffViewerProps {
   className?: string;
 }
 
-// Get language from filename
-function getLanguage(fileName: string): string {
-  const ext = fileName.split('.').pop()?.toLowerCase() || '';
-  const langMap: Record<string, string> = {
-    js: 'javascript',
-    jsx: 'javascript',
-    ts: 'typescript',
-    tsx: 'typescript',
-    py: 'python',
-    html: 'html',
-    css: 'css',
-    json: 'json',
-    md: 'markdown',
-  };
-  return langMap[ext] || 'plaintext';
-}
+
 
 const EDITOR_OPTIONS: editor.IStandaloneDiffEditorConstructionOptions = {
   readOnly: true,
@@ -117,7 +103,7 @@ export const DiffViewer: React.FC<DiffViewerProps> = ({
     }
   }, [diffContent, fileName]);
 
-  const language = getLanguage(displayFileName);
+  const language = getLanguageFromFileName(displayFileName);
 
   const handleCopy = () => {
     navigator.clipboard.writeText(diffContent);

--- a/multimodal/tarko/agent-web-ui/src/standalone/workspace/renderers/FileResultRenderer.tsx
+++ b/multimodal/tarko/agent-web-ui/src/standalone/workspace/renderers/FileResultRenderer.tsx
@@ -5,6 +5,7 @@ import { MessageContent } from './generic/components/MessageContent';
 import { DisplayMode } from './generic/types';
 import { MonacoCodeEditor } from '@/sdk/code-editor';
 import { useStableCodeContent } from '@/common/hooks/useStableValue';
+import { getLanguageFromFileName } from '@/common/utils/language';
 import { ThrottledHtmlRenderer } from '../components/ThrottledHtmlRenderer';
 
 // Constants
@@ -46,38 +47,7 @@ export const FileResultRenderer: React.FC<FileResultRendererProps> = ({
   const isStreaming = panelContent.isStreaming || false;
 
   // Get language for code highlighting
-  const getLanguage = (): string => {
-    const langMap: Record<string, string> = {
-      js: 'javascript',
-      jsx: 'jsx',
-      ts: 'typescript',
-      tsx: 'tsx',
-      py: 'python',
-      rb: 'ruby',
-      java: 'java',
-      html: 'html',
-      css: 'css',
-      json: 'json',
-      yaml: 'yaml',
-      yml: 'yaml',
-      md: 'markdown',
-      xml: 'xml',
-      sh: 'bash',
-      bash: 'bash',
-      go: 'go',
-      c: 'c',
-      cpp: 'cpp',
-      rs: 'rust',
-      php: 'php',
-      sql: 'sql',
-      scss: 'scss',
-      less: 'less',
-      vue: 'vue',
-      svelte: 'svelte',
-    };
-
-    return langMap[fileExtension] || fileExtension || 'text';
-  };
+  const language = getLanguageFromFileName(fileName);
 
   // Format file size
   function formatBytes(bytes: number): string {
@@ -124,7 +94,7 @@ export const FileResultRenderer: React.FC<FileResultRendererProps> = ({
             <div className="p-0">
               <MonacoCodeEditor
                 code={stableContent}
-                language={getLanguage()}
+                language={language}
                 fileName={fileName}
                 filePath={filePath}
                 fileSize={approximateSize}

--- a/multimodal/tarko/agent-web-ui/src/standalone/workspace/renderers/ScriptResultRenderer.tsx
+++ b/multimodal/tarko/agent-web-ui/src/standalone/workspace/renderers/ScriptResultRenderer.tsx
@@ -3,6 +3,7 @@ import { StandardPanelContent } from '../types/panelContent';
 import { motion } from 'framer-motion';
 import { FiPlay, FiCode, FiTerminal } from 'react-icons/fi';
 import { CodeEditor } from '@/sdk/code-editor';
+import { getLanguageFromInterpreter, getExtensionFromLanguage } from '@/common/utils/language';
 import { FileDisplayMode } from '../types';
 
 interface ScriptResultRendererProps {
@@ -22,39 +23,7 @@ const highlightCommand = (command: string) => {
   );
 };
 
-/**
- * Language to file extension mapping
- */
-const LANGUAGE_EXTENSIONS: Record<string, string> = {
-  javascript: 'js',
-  typescript: 'ts',
-  python: 'py',
-};
 
-/**
- * Get language identifier for syntax highlighting
- */
-const getLanguageFromInterpreter = (interpreter: string): string => {
-  const languageMap: Record<string, string> = {
-    python: 'python',
-    python3: 'python',
-    node: 'javascript',
-    nodejs: 'javascript',
-    bash: 'bash',
-    sh: 'bash',
-    ruby: 'ruby',
-    php: 'php',
-    java: 'java',
-    go: 'go',
-    rust: 'rust',
-    cpp: 'cpp',
-    'c++': 'cpp',
-    gcc: 'c',
-    clang: 'c',
-  };
-
-  return languageMap[interpreter.toLowerCase()] || 'text';
-};
 
 /**
  * Renders script execution results with professional code editor and terminal output
@@ -139,7 +108,7 @@ export const ScriptResultRenderer: React.FC<ScriptResultRendererProps> = ({ pane
           <CodeEditor
             code={script || ''}
             language={language}
-            fileName={`script.${LANGUAGE_EXTENSIONS[language]}`}
+            fileName={`script.${getExtensionFromLanguage(language)}`}
             showLineNumbers={true}
             maxHeight={displayMode === 'both' ? '40vh' : '80vh'}
           />


### PR DESCRIPTION
## Summary

Unified language detection logic across all renderer components by creating a centralized language detection utility.

**Changes:**
- Created `@/common/utils/language` module with comprehensive language detection functions
- Replaced duplicate `getLanguage` functions in `DiffViewer`, `ScriptResultRenderer`, and `FileResultRenderer`
- Added support for more file extensions and interpreters
- Provided utility functions: `getLanguageFromFileName`, `getLanguageFromInterpreter`, `getExtensionFromLanguage`, etc.

**Benefits:**
- Eliminates code duplication across multiple renderers
- Provides consistent language detection behavior
- Easier to maintain and extend language support
- More comprehensive file extension coverage

## Checklist

- [ ] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [x] My change does not involve the above items.