### PR TITLE
docs: fix missing useI18n import in NotFoundLayout

### DIFF
--- a/multimodal/websites/docs/src/components/NotFoundLayout.tsx
+++ b/multimodal/websites/docs/src/components/NotFoundLayout.tsx
@@ -1,7 +1,10 @@
+import { useI18n } from 'rspress/runtime';
 import { isInSSR } from '../shared/env';
 import { ActionCard } from './ActionCard';
 
 export function NotFoundLayout() {
+  const t = useI18n<typeof import('i18n')>();
+  
   if (isInSSR()) {
     return null;
   }


### PR DESCRIPTION
## Summary

Fixed 404 page white screen issue in `websites/docs` by adding missing `useI18n` import in `NotFoundLayout` component.

The component was using `t()` function for translations without importing `useI18n` from `rspress/runtime`, causing `ReferenceError: t is not defined` in browser console.

## Checklist

- [ ] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [x] My change does not involve the above items.