### PR TITLE
feat(agent-tars): add static webui config to core

### DIFF
--- a/multimodal/agent-tars/cli/src/index.ts
+++ b/multimodal/agent-tars/cli/src/index.ts
@@ -37,19 +37,6 @@ const DEFAULT_OPTIONS: Partial<AgentCLIInitOptions> = {
       type: 'module',
       constructor: AgentTARS,
     },
-    webui: {
-      logo: 'https://lf3-static.bytednsdoc.com/obj/eden-cn/zyha-aulnh/ljhwZthlaukjlkulzlp/appicon.png',
-      title: 'Agent TARS',
-      subtitle: 'Offering seamless integration with a wide range of real-world tools.',
-      welcomTitle: 'An multimodal AI agent',
-      welcomePrompts: [
-        'Search for the latest GUI Agent papers',
-        'Find information about UI TARS',
-        'Tell me the top 5 most popular projects on ProductHunt today',
-        'Please book me the earliest flight from Hangzhou to Shenzhen on 10.1',
-      ],
-      enableContextualSelector: true,
-    },
     server: {
       storage: {
         type: 'sqlite',

--- a/multimodal/agent-tars/core/src/agent-tars.ts
+++ b/multimodal/agent-tars/core/src/agent-tars.ts
@@ -39,6 +39,7 @@ import * as filesystemModule from '@agent-infra/mcp-server-filesystem';
 import * as commandsModule from '@agent-infra/mcp-server-commands';
 
 import { WorkspacePathResolver } from './shared/workspace-path-resolver';
+import { AgentWebUIImplementation } from '@agent-tars/interface';
 
 /**
  * A Agent TARS that uses in-memory MCP tool call
@@ -46,6 +47,23 @@ import { WorkspacePathResolver } from './shared/workspace-path-resolver';
  */
 export class AgentTARS<T extends AgentTARSOptions = AgentTARSOptions> extends MCPAgent<T> {
   static label = '@agent-tars/core';
+  
+  /**
+   * Default Web UI configuration for Agent TARS
+   */
+  static webui: AgentWebUIImplementation = {
+    logo: 'https://lf3-static.bytednsdoc.com/obj/eden-cn/zyha-aulnh/ljhwZthlaukjlkulzlp/appicon.png',
+    title: 'Agent TARS',
+    subtitle: 'Offering seamless integration with a wide range of real-world tools.',
+    welcomTitle: 'An multimodal AI agent',
+    welcomePrompts: [
+      'Search for the latest GUI Agent papers',
+      'Find information about UI TARS',
+      'Tell me the top 5 most popular projects on ProductHunt today',
+      'Please book me the earliest flight from Hangzhou to Shenzhen on 10.1',
+    ],
+    enableContextualSelector: true,
+  };
   private workspace: string;
   // FIXME: remove it since options is strict type already
   private tarsOptions: AgentTARSOptions;


### PR DESCRIPTION
## Summary

Migrate Agent TARS webui configuration from `@agent-tars/cli` to `@agent-tars/core` to ensure webui config works in both CLI mode and `tarko run agent-tars` mode.

**Changes:**
- Add static `webui` property to `AgentTARS` class in `@agent-tars/core`
- Remove webui config from CLI `DEFAULT_OPTIONS` in `@agent-tars/cli`
- Import `AgentWebUIImplementation` type from `@agent-tars/interface`

**Problem:** Agent TARS webui configuration only worked in CLI mode but not when using `tarko run agent-tars`

**Solution:** Move webui config to the core Agent class so it's available regardless of how the agent is invoked

## Checklist

- [x] My change does not involve the above items.