### PR TITLE
fix(agent-tars): correct webui property name to webuiConfig

### DIFF
--- a/multimodal/agent-tars/core/src/agent-tars.ts
+++ b/multimodal/agent-tars/core/src/agent-tars.ts
@@ -51,7 +51,7 @@ export class AgentTARS<T extends AgentTARSOptions = AgentTARSOptions> extends MC
   /**
    * Default Web UI configuration for Agent TARS
    */
-  static webui: AgentWebUIImplementation = {
+  static webuiConfig: AgentWebUIImplementation = {
     logo: 'https://lf3-static.bytednsdoc.com/obj/eden-cn/zyha-aulnh/ljhwZthlaukjlkulzlp/appicon.png',
     title: 'Agent TARS',
     subtitle: 'Offering seamless integration with a wide range of real-world tools.',


### PR DESCRIPTION
## Summary

Fixed incorrect property name in `@agent-tars/core` - changed `webui` to `webuiConfig` to match the expected interface.

## Checklist  

- [ ] Added or updated necessary tests (Optional).  
- [ ] Updated documentation to align with changes (Optional).  
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).  
- [x] My change does not involve the above items.