### PR TITLE
fix(tarko): improve script execution ui layout and styling

### DIFF
--- a/multimodal/tarko/agent-web-ui/src/standalone/workspace/components/TerminalOutput.tsx
+++ b/multimodal/tarko/agent-web-ui/src/standalone/workspace/components/TerminalOutput.tsx
@@ -35,10 +35,10 @@ export const TerminalOutput: React.FC<TerminalOutputProps> = ({
           <span>{title}</span>
           {exitCode !== undefined && (
             <span
-              className={`ml-2 px-1.5 py-0.5 rounded text-[10px] ${
+              className={`ml-2 px-1 py-0.5 rounded text-[9px] font-mono ${
                 isError
-                  ? 'bg-red-900/30 text-red-400 border border-red-800/50'
-                  : 'bg-green-900/30 text-green-400 border border-green-800/50'
+                  ? 'bg-red-500/10 text-red-400'
+                  : 'bg-green-500/10 text-green-400'
               }`}
             >
               exit {exitCode}

--- a/multimodal/tarko/agent-web-ui/src/standalone/workspace/renderers/ScriptResultRenderer.tsx
+++ b/multimodal/tarko/agent-web-ui/src/standalone/workspace/renderers/ScriptResultRenderer.tsx
@@ -147,10 +147,10 @@ export const ScriptResultRenderer: React.FC<ScriptResultRendererProps> = ({ pane
         >
           <TerminalOutput
             title={(
-              <>
+              <div className="flex items-center gap-1.5 whitespace-nowrap">
                 <FiPlay size={10} />
                 <span>Script Execution - {interpreter}</span>
-              </>
+              </div>
             )}
             command={(
               <>


### PR DESCRIPTION
## Summary

Fixed UI issues in `ScriptResultRenderer` where icon and text were wrapping awkwardly, and improved exit code styling in `TerminalOutput` component.

### Before

<img width="3416" height="832" alt="image" src="https://github.com/user-attachments/assets/7ff49cfd-80b4-44ec-9283-bb3e259166b8" />


### After

<img width="3416" height="1148" alt="image" src="https://github.com/user-attachments/assets/e5a7c705-66fd-4d5f-8219-7173e066a904" />


## Checklist

- [x] My change does not involve the above items.