### PR TITLE
feat(agent-tars): upgrade mcp-server packages to 1.2.20

### DIFF
--- a/multimodal/agent-tars/core/package.json
+++ b/multimodal/agent-tars/core/package.json
@@ -29,9 +29,9 @@
   },
   "devDependencies": {
     "@gui-agent/operator-browser": "workspace:*",
-    "@agent-infra/mcp-server-browser": "1.1.10",
-    "@agent-infra/mcp-server-commands": "1.1.10",
-    "@agent-infra/mcp-server-filesystem": "1.1.10",
+    "@agent-infra/mcp-server-browser": "1.2.20",
+    "@agent-infra/mcp-server-commands": "1.2.20",
+    "@agent-infra/mcp-server-filesystem": "1.2.20",
     "@agent-infra/search": "0.0.5",
     "@agent-infra/browser": "0.1.1",
     "@agent-infra/browser-search": "0.0.5",


### PR DESCRIPTION
## Summary

Upgrades `@agent-infra/mcp-server-*` packages in `@agent-tars/core` from `1.1.10` to `1.2.20` to align with the MCP client upgrade in PR #1271.

**Reference:** https://github.com/bytedance/UI-TARS-desktop/pull/1271

## Checklist

- [ ] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [x] My change does not involve the above items.