### PR TITLE
feat(tarko): add codebase metadata to contextual references

### DIFF
--- a/multimodal/tarko/agent-interface/src/agent-run-options.ts
+++ b/multimodal/tarko/agent-interface/src/agent-run-options.ts
@@ -6,6 +6,7 @@
 
 import { ChatCompletionContentPart, ModelProviderName } from '@tarko/model-provider/types';
 import { ToolCallEngineType } from './tool-call-engine';
+import { AgentEventStream } from './agent-event-stream';
 
 /**
  * Base options for running an agent without specifying streaming mode
@@ -50,6 +51,8 @@ export interface AgentRunBaseOptions {
     content: string | ChatCompletionContentPart[];
     /** Optional description of the environment input */
     description?: string;
+    /** Optional metadata for the environment input */
+    metadata?: AgentEventStream.EnvironmentInputMetadata;
   };
   /**
    * Abort signal for canceling the execution

--- a/multimodal/tarko/agent-server/src/api/controllers/queries.ts
+++ b/multimodal/tarko/agent-server/src/api/controllers/queries.ts
@@ -62,6 +62,9 @@ export async function executeQuery(req: Request, res: Response) {
       environmentInput: {
         content: expandedContext,
         description: 'Expanded context from contextual references',
+        metadata: {
+          type: 'codebase',
+        },
       },
     });
 
@@ -113,6 +116,9 @@ export async function executeStreamingQuery(req: Request, res: Response) {
       environmentInput: {
         content: expandedContext,
         description: 'Expanded context from contextual references',
+        metadata: {
+          type: 'codebase',
+        },
       },
     });
 

--- a/multimodal/tarko/agent-server/src/api/controllers/queries.ts
+++ b/multimodal/tarko/agent-server/src/api/controllers/queries.ts
@@ -63,7 +63,7 @@ export async function executeQuery(req: Request, res: Response) {
         content: expandedContext,
         description: 'Expanded context from contextual references',
         metadata: {
-          type: 'codebase',
+          type: 'codebase' as const,
         },
       },
     });
@@ -117,7 +117,7 @@ export async function executeStreamingQuery(req: Request, res: Response) {
         content: expandedContext,
         description: 'Expanded context from contextual references',
         metadata: {
-          type: 'codebase',
+          type: 'codebase' as const,
         },
       },
     });

--- a/multimodal/tarko/agent-server/src/core/AgentSession.ts
+++ b/multimodal/tarko/agent-server/src/core/AgentSession.ts
@@ -200,6 +200,7 @@ export class AgentSession {
     environmentInput?: {
       content: string | ChatCompletionContentPart[];
       description?: string;
+      metadata?: AgentEventStream.EnvironmentInputMetadata;
     };
   }): Promise<AgentQueryResponse> {
     try {
@@ -291,6 +292,7 @@ export class AgentSession {
     environmentInput?: {
       content: string | ChatCompletionContentPart[];
       description?: string;
+      metadata?: AgentEventStream.EnvironmentInputMetadata;
     };
   }): Promise<AsyncIterable<AgentEventStream.Event>> {
     try {

--- a/multimodal/tarko/agent-server/tests/api/queries.test.ts
+++ b/multimodal/tarko/agent-server/tests/api/queries.test.ts
@@ -116,6 +116,9 @@ describe('Queries Controller', () => {
         environmentInput: {
           content: expandedContext,
           description: 'Expanded context from contextual references',
+          metadata: {
+            type: 'codebase',
+          },
         },
       });
 
@@ -151,6 +154,9 @@ describe('Queries Controller', () => {
         environmentInput: {
           content: expandedContext,
           description: 'Expanded context from contextual references',
+          metadata: {
+            type: 'codebase',
+          },
         },
       });
     });
@@ -185,6 +191,9 @@ describe('Queries Controller', () => {
         environmentInput: {
           content: expandedContext,
           description: 'Expanded context from contextual references',
+          metadata: {
+            type: 'codebase',
+          },
         },
       });
     });
@@ -271,6 +280,9 @@ describe('Queries Controller', () => {
         environmentInput: {
           content: expandedContext,
           description: 'Expanded context from contextual references',
+          metadata: {
+            type: 'codebase',
+          },
         },
       });
 

--- a/multimodal/tarko/agent/src/agent/agent.ts
+++ b/multimodal/tarko/agent/src/agent/agent.ts
@@ -389,6 +389,7 @@ Provide concise and accurate responses.`;
           const environmentEvent = this.eventStream.createEvent('environment_input', {
             content: normalizedOptions.environmentInput.content,
             description: normalizedOptions.environmentInput.description || 'Environment context',
+            metadata: normalizedOptions.environmentInput.metadata,
           });
           this.eventStream.sendEvent(environmentEvent);
 
@@ -425,6 +426,7 @@ Provide concise and accurate responses.`;
           const environmentEvent = this.eventStream.createEvent('environment_input', {
             content: normalizedOptions.environmentInput.content,
             description: normalizedOptions.environmentInput.description || 'Environment context',
+            metadata: normalizedOptions.environmentInput.metadata,
           });
           this.eventStream.sendEvent(environmentEvent);
 


### PR DESCRIPTION
## Summary

Adds `codebase` metadata type to contextual references in environment input, enabling proper typing for injected context introduced in [PR #1134](https://github.com/bytedance/UI-TARS-desktop/pull/1134).

### Changes

- Add `metadata` field support to `environmentInput` in `AgentRunBaseOptions`
- Update Agent class to properly pass metadata when creating `environment_input` events
- Add `codebase` metadata type to contextual references in `queries.ts`
- Enables consumers to identify environment input as codebase context for better processing

### Related

Resolves remaining **issue 1** from [PR #1272](https://github.com/bytedance/UI-TARS-desktop/pull/1272)

## Checklist

- [ ] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [x] My change does not involve the above items.