### PR TITLE
feat(tarko): adapt devicePixelRatio from metadata in web ui

### DIFF
--- a/multimodal/tarko/agent-web-ui/src/standalone/workspace/renderers/BrowserControlRenderer.tsx
+++ b/multimodal/tarko/agent-web-ui/src/standalone/workspace/renderers/BrowserControlRenderer.tsx
@@ -35,6 +35,7 @@ export const BrowserControlRenderer: React.FC<BrowserControlRendererProps> = ({
     x: number;
     y: number;
   } | null>(null);
+  const [devicePixelRatio, setDevicePixelRatio] = useState<number>(window.devicePixelRatio);
   const imageRef = useRef<HTMLImageElement>(null);
 
   // Extract the visual operation details from panelContent
@@ -112,6 +113,11 @@ export const BrowserControlRenderer: React.FC<BrowserControlRendererProps> = ({
         if (imgContent && 'image_url' in imgContent && imgContent.image_url.url) {
           setRelatedImage(imgContent.image_url.url);
           foundImage = true;
+
+          // Extract devicePixelRatio from environment input metadata if available
+          if (msg.metadata && msg.metadata.type === 'screenshot' && msg.metadata.devicePixelRatio) {
+            setDevicePixelRatio(msg.metadata.devicePixelRatio);
+          }
           break;
         }
       }
@@ -158,17 +164,17 @@ export const BrowserControlRenderer: React.FC<BrowserControlRendererProps> = ({
                   initial={
                     previousMousePosition
                       ? {
-                          left: `${(previousMousePosition.x / imageSize.width) * 100 * window.devicePixelRatio}%`,
-                          top: `${(previousMousePosition.y / imageSize.height) * 100 * window.devicePixelRatio}%`,
+                          left: `${(previousMousePosition.x / imageSize.width) * 100 * devicePixelRatio}%`,
+                          top: `${(previousMousePosition.y / imageSize.height) * 100 * devicePixelRatio}%`,
                         }
                       : {
-                          left: `${(mousePosition.x / imageSize.width) * 100 * window.devicePixelRatio}%`,
-                          top: `${(mousePosition.y / imageSize.height) * 100 * window.devicePixelRatio}%`,
+                          left: `${(mousePosition.x / imageSize.width) * 100 * devicePixelRatio}%`,
+                          top: `${(mousePosition.y / imageSize.height) * 100 * devicePixelRatio}%`,
                         }
                   }
                   animate={{
-                    left: `${(mousePosition.x / imageSize.width) * 100 * window.devicePixelRatio}%`,
-                    top: `${(mousePosition.y / imageSize.height) * 100 * window.devicePixelRatio}%`,
+                    left: `${(mousePosition.x / imageSize.width) * 100 * devicePixelRatio}%`,
+                    top: `${(mousePosition.y / imageSize.height) * 100 * devicePixelRatio}%`,
                   }}
                   transition={{ duration: 0.5, ease: [0.16, 1, 0.3, 1] }}
                   style={{


### PR DESCRIPTION
## Summary

Replaces hardcoded `window.devicePixelRatio` with metadata from `EnvironmentInputEvent` in `BrowserControlRenderer` to unify screenshot coordinates and rendering.

### Changes

- Add state management for `devicePixelRatio` in `BrowserControlRenderer`
- Extract `devicePixelRatio` from environment input metadata when available
- Replace hardcoded `window.devicePixelRatio` with metadata value for mouse cursor positioning
- Falls back to `window.devicePixelRatio` when metadata is not available

### Related

Resolves remaining issue #2 from [PR #1272](https://github.com/bytedance/UI-TARS-desktop/pull/1272)

## Checklist

- [ ] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [x] My change does not involve the above items.