### PR TITLE
fix(tarko): replace @ui-tars/operator-browser with local @gui-agent/operator-browser

### DIFF
--- a/multimodal/tarko/agent/examples/gui-agent/basic.ts
+++ b/multimodal/tarko/agent/examples/gui-agent/basic.ts
@@ -8,7 +8,7 @@
  */
 
 import { LocalBrowser } from '@agent-infra/browser';
-import { BrowserOperator } from '@ui-tars/operator-browser';
+import { BrowserOperator } from '@gui-agent/operator-browser';
 import {
   Agent,
   AgentOptions,

--- a/multimodal/tarko/agent/package.json
+++ b/multimodal/tarko/agent/package.json
@@ -54,7 +54,7 @@
     "@agent-infra/shared": "0.0.2",
     "@agent-infra/browser": "0.1.1",
     "@agent-infra/browser-search": "0.0.5",
-    "@ui-tars/operator-browser": "1.2.2",
+    "@gui-agent/operator-browser": "workspace:*",
     "@rslib/core": "0.10.0",
     "@types/node": "22.15.30",
     "tsx": "^4.19.2",


### PR DESCRIPTION
## Summary

Replace external `@ui-tars/operator-browser` dependency with local `@gui-agent/operator-browser` workspace package in `@tarko/agent`.

Since `operator-browser` is now maintained in this monorepo (ref: #901), `tarko/agent` should use the local workspace package instead of the external npm package.

**Changes:**
- Updated import in `examples/gui-agent/basic.ts`
- Replaced `@ui-tars/operator-browser@1.2.2` with `@gui-agent/operator-browser@workspace:*` in devDependencies

## Checklist

- [ ] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [x] My change does not involve the above items.