### PR TITLE
fix(tarko-cli): prevent console interceptor recursion in debug mode

### DIFF
--- a/multimodal/tarko/agent-cli/src/utils/console-interceptor.ts
+++ b/multimodal/tarko/agent-cli/src/utils/console-interceptor.ts
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { logger } from './misc';
-
 interface ConsoleInterceptorOptions {
   silent?: boolean;
   capture?: boolean;


### PR DESCRIPTION
## Summary

Fixed infinite loop issue when running `tarko run --headless --debug` by preventing console interceptor recursion.

**Root Cause**: The `ConsoleInterceptor` used `logger.debug()` calls in three places:
- `start()` method
- `stop()` method  
- `createInterceptor()` method

**Recursion Chain**:
1. `logger.debug()` internally calls `console.*` methods
2. `console.*` methods are intercepted by `ConsoleInterceptor`
3. Interceptor calls `logger.debug()` again
4. Infinite recursion: `logger.debug()` → `console.*` → `createInterceptor` → `logger.debug()` → ...

**Solution**: Replace `logger.debug()` with `this.originalConsole.error()` to use the original console methods directly, avoiding interception.

**Changes**: Only 3 lines modified - minimal and precise fix.

## Checklist

- [x] My change does not involve the above items.