### PR TITLE
feat(tarko-agent): add messageId to thinking events for proper session correlation

### DIFF
--- a/multimodal/tarko/agent-interface/src/agent-event-stream.ts
+++ b/multimodal/tarko/agent-interface/src/agent-event-stream.ts
@@ -154,6 +154,12 @@ export namespace AgentEventStream {
 
     /** Whether the thinking process is complete */
     isComplete?: boolean;
+
+    /**
+     * Unique message identifier that links thinking messages to their session
+     * This allows clients to correlate incremental updates with complete thinking
+     */
+    messageId?: string;
   }
 
   /**
@@ -186,6 +192,12 @@ export namespace AgentEventStream {
 
     /** Whether this is the final reasoning chunk */
     isComplete?: boolean;
+
+    /**
+     * Unique message identifier that links streaming thinking messages to their final thinking
+     * This allows clients to correlate incremental updates with complete thinking
+     */
+    messageId?: string;
   }
 
   /**

--- a/multimodal/tarko/agent/src/agent/runner/llm-processor.ts
+++ b/multimodal/tarko/agent/src/agent/runner/llm-processor.ts
@@ -337,6 +337,7 @@ export class LLMProcessor {
             {
               content: chunkResult.reasoningContent,
               isComplete: Boolean(processingState.finishReason),
+              messageId: messageId, // Add the message ID to correlate thinking sessions
             },
           );
           this.eventStream.sendEvent(thinkingEvent);
@@ -482,6 +483,7 @@ export class LLMProcessor {
       const thinkingEvent = this.eventStream.createEvent('assistant_thinking_message', {
         content: reasoningBuffer,
         isComplete: true,
+        messageId: messageId, // Include the message ID to correlate with streaming events
       });
 
       this.eventStream.sendEvent(thinkingEvent);


### PR DESCRIPTION
## Summary

Adds `messageId` to thinking events in `tarko-agent` for proper session correlation.

## Checklist

- [ ] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [x] My change does not involve the above items.