### PR TITLE
fix(tarko-cli): `--thinking` does not work

### DIFF
--- a/multimodal/tarko/agent-cli/src/config/builder.ts
+++ b/multimodal/tarko/agent-cli/src/config/builder.ts
@@ -70,6 +70,7 @@ export function buildAppConfig<
     apiKey,
     baseURL,
     shareProvider,
+    thinking,
     // Extract tool filter options
     tool,
     // Extract MCP server filter options
@@ -80,7 +81,13 @@ export function buildAppConfig<
   } = cliArguments;
 
   // Handle deprecated options
-  const deprecatedOptions = { provider, apiKey: apiKey || undefined, baseURL, shareProvider }; // secretlint-disable-line @secretlint/secretlint-rule-pattern
+  const deprecatedOptions = {
+    provider,
+    apiKey: apiKey || undefined,
+    baseURL,
+    shareProvider,
+    thinking,
+  }; // secretlint-disable-line @secretlint/secretlint-rule-pattern
   const deprecatedKeys = Object.entries(deprecatedOptions)
     .filter(([, value]) => value !== undefined)
     .map(([optionName]) => optionName);
@@ -132,9 +139,10 @@ function handleCoreDeprecatedOptions(
     apiKey?: string;
     baseURL?: string;
     shareProvider?: string;
+    thinking?: boolean;
   },
 ): void {
-  const { provider, apiKey: deprecatedApiKey, baseURL, shareProvider } = deprecated; // secretlint-disable-line @secretlint/secretlint-rule-pattern
+  const { provider, apiKey: deprecatedApiKey, baseURL, shareProvider, thinking } = deprecated; // secretlint-disable-line @secretlint/secretlint-rule-pattern
 
   // Handle deprecated model configuration
   if (provider || deprecatedApiKey || baseURL) {
@@ -169,6 +177,19 @@ function handleCoreDeprecatedOptions(
 
     if (!config.share.provider) {
       config.share.provider = shareProvider;
+    }
+  }
+
+  if (thinking) {
+    if (typeof thinking === 'boolean') {
+      config.thinking = {
+        type: thinking ? 'enabled' : 'disabled',
+      };
+    } else if (typeof thinking === 'object') {
+      config.thinking = {
+        type: 'disabled',
+        ...(config.thinking || {}),
+      };
     }
   }
 }

--- a/multimodal/tarko/agent-cli/src/config/builder.ts
+++ b/multimodal/tarko/agent-cli/src/config/builder.ts
@@ -186,10 +186,7 @@ function handleCoreDeprecatedOptions(
         type: thinking ? 'enabled' : 'disabled',
       };
     } else if (typeof thinking === 'object') {
-      config.thinking = {
-        type: 'disabled',
-        ...(config.thinking || {}),
-      };
+      config.thinking = thinking;
     }
   }
 }

--- a/multimodal/tarko/agent/src/agent/agent.ts
+++ b/multimodal/tarko/agent/src/agent/agent.ts
@@ -140,7 +140,17 @@ export class Agent<T extends AgentOptions = AgentOptions>
 
     this.temperature = options.temperature ?? 0.7;
     this.top_p = options.top_p;
-    this.reasoningOptions = options.thinking ?? { type: 'disabled' };
+
+    if (options.thinking) {
+      if (typeof options.thinking !== 'object') {
+        throw new Error(
+          `Invalid thinking option, expected an object, but got ${JSON.stringify(options.thinking)}`,
+        );
+      }
+      this.reasoningOptions = { type: 'disabled' };
+    } else {
+      this.reasoningOptions = { type: 'disabled' };
+    }
 
     // Initialize the resolved model early if possible
     this.initializeEarlyResolvedModel();

--- a/multimodal/tarko/agent/src/agent/agent.ts
+++ b/multimodal/tarko/agent/src/agent/agent.ts
@@ -147,7 +147,7 @@ export class Agent<T extends AgentOptions = AgentOptions>
           `Invalid thinking option, expected an object, but got ${JSON.stringify(options.thinking)}`,
         );
       }
-      this.reasoningOptions = { type: 'disabled' };
+      this.reasoningOptions = options.thinking;
     } else {
       this.reasoningOptions = { type: 'disabled' };
     }

--- a/multimodal/tarko/interface/src/cli.ts
+++ b/multimodal/tarko/interface/src/cli.ts
@@ -26,6 +26,7 @@ export type AgentCLIArguments = Pick<
   apiKey?: string;
   baseURL?: string;
   shareProvider?: string;
+  thinking?: boolean;
 
   /** Configuration file paths or URLs */
   config?: string[];


### PR DESCRIPTION
## Summary

Fixes `--thinking` option not working in `tarko-cli` since it passed wrong options to Agent Kernel.

## Refs

Seed 1.5 VL Error:

> Error in agent execution: Error: 400 The parameter `` specified in the request are not valid: we could not parse the JSON body of your request. Request id: 021756308745160daa05a91ab0f5c619c670634a3049ce3b86e57


## Checklist

- [ ] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [x] My change does not involve the above items.