### PR TITLE
feat(tarko): adjust maxIterations default to 1000

### DIFF
--- a/multimodal/agent-tars/core/examples/default.ts
+++ b/multimodal/agent-tars/core/examples/default.ts
@@ -18,7 +18,7 @@ export const DEFUALT_OPTIONS: AgentTARSOptions = {
     apiKey: process.env.ARK_API_KEY,
   },
   toolCallEngine: 'prompt_engineering',
-  maxIterations: 100,
+
   // temperature: 0,
   thinking: {
     type: 'disabled',

--- a/multimodal/agent-tars/core/src/shared/config-utils.ts
+++ b/multimodal/agent-tars/core/src/shared/config-utils.ts
@@ -26,7 +26,6 @@ export const AGENT_TARS_DEFAULT_OPTIONS: AgentTARSOptions = {
   },
   mcpImpl: 'in-memory',
   mcpServers: {},
-  maxIterations: 100,
   maxTokens: 8192,
   enableStreamingToolCallEvents: true,
 };

--- a/multimodal/gui-agent/agent-sdk/src/SeedGUIAgent.ts
+++ b/multimodal/gui-agent/agent-sdk/src/SeedGUIAgent.ts
@@ -47,7 +47,7 @@ export class SeedGUIAgent extends Agent {
       tools: [],
       toolCallEngine: SeedGUIAgentToolCallEngine,
       model: model,
-      maxIterations: maxLoopCount ?? 100,
+      ...(maxLoopCount && { maxIterations: maxLoopCount }),
       logLevel: LogLevel.ERROR,
     });
 

--- a/multimodal/omni-tars/core/src/ComposableAgent.ts
+++ b/multimodal/omni-tars/core/src/ComposableAgent.ts
@@ -32,7 +32,6 @@ export class ComposableAgent extends Agent {
     super({
       // instructions: SYSTEM_PROMPT,
       instructions: composer.generateSystemPrompt(),
-      maxIterations: optionsWithoutPlugins.maxIterations || 100,
       //Remove plugins to prevent circular reference from reporting errors
       ...optionsWithoutPlugins,
     });

--- a/multimodal/tarko/agent-interface/src/agent-options.ts
+++ b/multimodal/tarko/agent-interface/src/agent-options.ts
@@ -152,8 +152,10 @@ export interface AgentToolOptions {
 export interface AgentLoopOptions {
   /**
    * Maximum number of iterations of the agent.
+   * Modern LLM models have improved agentic loop-horizon task capabilities,
+   * allowing for more complex multi-step reasoning processes.
    *
-   * @defaultValue `50`
+   * @defaultValue `1000`
    */
   maxIterations?: number;
 }

--- a/multimodal/tarko/agent/src/agent/agent.ts
+++ b/multimodal/tarko/agent/src/agent/agent.ts
@@ -88,7 +88,7 @@ export class Agent<T extends AgentOptions = AgentOptions>
     super(options as T);
 
     this.instructions = options.instructions || this.getDefaultPrompt();
-    this.maxIterations = options.maxIterations ?? 10;
+    this.maxIterations = options.maxIterations ?? 1000;
     this.maxTokens = options.maxTokens;
     this.name = options.name ?? 'Anonymous';
     this.id = options.id ?? '@tarko/agent';


### PR DESCRIPTION
## Summary

Adjusts the default `maxIterations` value from 10 to 1000 in `@tarko/agent` and removes unnecessary explicit configurations from `@agent-tars/core` and `@omni-tars/core`.

Modern LLM models have significantly improved agentic loop-horizon task capabilities, allowing for more complex multi-step reasoning processes. The increased default value of 1000 provides sufficient iterations for complex tasks while the explicit configurations in higher-level agents are no longer needed.

**Changes:**
- Updated default `maxIterations` from 10 to 1000 in `multimodal/tarko/agent/src/agent/agent.ts`
- Updated field documentation in `multimodal/tarko/agent-interface/src/agent-options.ts`
- Removed explicit `maxIterations: 100` from `@agent-tars/core` and `@omni-tars/core`
- Updated GUI agent to only set `maxIterations` when explicitly provided
- Removed unnecessary `maxIterations` from example configurations

## Checklist

- [x] My change does not involve the above items.