### PR TITLE
fix(tarko): add safety check for agent.dispose in session cleanup

### DIFF
--- a/multimodal/tarko/agent-server/src/core/AgentSession.ts
+++ b/multimodal/tarko/agent-server/src/core/AgentSession.ts
@@ -451,7 +451,9 @@ export class AgentSession {
     }
 
     // Clean up agent resources
-    await this.agent.dispose();
+    if (this.agent && typeof this.agent.dispose === 'function') {
+      await this.agent.dispose();
+    }
 
     if (this.agioProvider) {
       // This ensures that all buffered analytics events are sent before the session is terminated.


### PR DESCRIPTION
## Summary

Fixes session deletion error by adding safety check for `agent.dispose` method in `AgentSession.cleanup()`.

The error occurred because some agent instances don't properly implement the `dispose` method, causing `TypeError: this.agent.dispose is not a function` when deleting sessions.

## Checklist

- [ ] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [x] My change does not involve the above items.