### PR TITLE
fix(tarko): resolve infinite re-render in BrowserControlRenderer hooks

### DIFF
--- a/multimodal/tarko/agent-web-ui/src/standalone/workspace/renderers/browser-control/useMousePosition.ts
+++ b/multimodal/tarko/agent-web-ui/src/standalone/workspace/renderers/browser-control/useMousePosition.ts
@@ -58,7 +58,7 @@ export const useMousePosition = ({
         );
       }
     }
-  }, [activeSessionId, toolCallId, toolResults, mousePosition]);
+  }, [activeSessionId, toolCallId, toolResults]);
 
   return { mousePosition, previousMousePosition };
 };

--- a/multimodal/tarko/agent-web-ui/src/standalone/workspace/renderers/browser-control/useScreenshots.ts
+++ b/multimodal/tarko/agent-web-ui/src/standalone/workspace/renderers/browser-control/useScreenshots.ts
@@ -131,8 +131,6 @@ export const useScreenshots = ({
     toolCallId,
     environmentImage,
     currentStrategy,
-    afterActionImage,
-    beforeActionImage,
   ]);
 
   return {


### PR DESCRIPTION
## Summary

Fixed infinite re-render issue in `BrowserControlRenderer` by removing state dependencies from `useEffect` dependency arrays in `useMousePosition` and `useScreenshots` hooks.

The issue was caused by:
- `useMousePosition` hook including `mousePosition` in its dependency array, causing it to re-trigger when it updates the state
- `useScreenshots` hook including `afterActionImage` and `beforeActionImage` in its dependency array, causing similar infinite loops

Removed these state variables from dependency arrays since they are outputs of the effects, not inputs.

## Checklist

- [x] My change does not involve the above items.