### PR TITLE
feat(tarko): one-click copy raw tool data

### DIFF
--- a/multimodal/tarko/agent-web-ui/src/common/components/JsonRenderer.tsx
+++ b/multimodal/tarko/agent-web-ui/src/common/components/JsonRenderer.tsx
@@ -196,17 +196,17 @@ interface JsonRendererProps {
   emptyMessage?: string;
 }
 
-export const JsonRenderer: React.FC<JsonRendererProps> = ({
-  data,
-  className = '',
-  emptyMessage = 'No data available',
-}) => {
-  const { copied, handleCopy } = useCopy();
+export interface JsonRendererRef {
+  copyAll: () => string;
+}
 
-  const handleCopyAll = useCallback(() => {
-    const jsonString = JSON.stringify(data, null, 2);
-    handleCopy(jsonString);
-  }, [data, handleCopy]);
+export const JsonRenderer = React.forwardRef<JsonRendererRef, JsonRendererProps>((
+  { data, className = '', emptyMessage = 'No data available' },
+  ref
+) => {
+  React.useImperativeHandle(ref, () => ({
+    copyAll: () => JSON.stringify(data, null, 2)
+  }), [data]);
 
   if (!data || (typeof data === 'object' && Object.keys(data).length === 0)) {
     return (
@@ -223,31 +223,18 @@ export const JsonRenderer: React.FC<JsonRendererProps> = ({
   const isRootArray = Array.isArray(data);
 
   return (
-    <div className={`group ${className}`}>
-      <div className="flex items-center justify-between mb-2">
-        <div className="text-xs text-gray-500 dark:text-gray-400 font-mono">JSON</div>
-        <div className="opacity-0 group-hover:opacity-100 transition-opacity">
-          <CopyButton
-            onCopy={handleCopyAll}
-            copied={copied}
-            title="Copy raw JSON"
-            size={14}
-          />
-        </div>
-      </div>
-      <div className="space-y-2">
-        {isRootObject ? (
-          Object.entries(data).map(([itemKey, value]) => (
-            <JsonItem key={itemKey} label={itemKey} value={value} isRoot />
-          ))
-        ) : isRootArray ? (
-          data.map((item: any, index: number) => (
-            <JsonItem key={`root-${index}`} label={`[${index}]`} value={item} isRoot />
-          ))
-        ) : (
-          <JsonItem label="value" value={data} isRoot />
-        )}
-      </div>
+    <div className={`space-y-2 ${className}`}>
+      {isRootObject ? (
+        Object.entries(data).map(([itemKey, value]) => (
+          <JsonItem key={itemKey} label={itemKey} value={value} isRoot />
+        ))
+      ) : isRootArray ? (
+        data.map((item: any, index: number) => (
+          <JsonItem key={`root-${index}`} label={`[${index}]`} value={item} isRoot />
+        ))
+      ) : (
+        <JsonItem label="value" value={data} isRoot />
+      )}
     </div>
   );
-};
+});

--- a/multimodal/tarko/agent-web-ui/src/common/components/JsonRenderer.tsx
+++ b/multimodal/tarko/agent-web-ui/src/common/components/JsonRenderer.tsx
@@ -179,6 +179,19 @@ export const JsonRenderer: React.FC<JsonRendererProps> = ({
   className = '',
   emptyMessage = 'No data available',
 }) => {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopyAll = useCallback(async () => {
+    try {
+      const jsonString = JSON.stringify(data, null, 2);
+      await navigator.clipboard.writeText(jsonString);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch (error) {
+      console.error('Failed to copy JSON:', error);
+    }
+  }, [data]);
+
   if (!data || (typeof data === 'object' && Object.keys(data).length === 0)) {
     return (
       <div className={`flex items-center justify-center py-8 ${className}`}>
@@ -194,18 +207,33 @@ export const JsonRenderer: React.FC<JsonRendererProps> = ({
   const isRootArray = Array.isArray(data);
 
   return (
-    <div className={`space-y-2 ${className}`}>
-      {isRootObject ? (
-        Object.entries(data).map(([itemKey, value]) => (
-          <JsonItem key={itemKey} label={itemKey} value={value} isRoot />
-        ))
-      ) : isRootArray ? (
-        data.map((item: any, index: number) => (
-          <JsonItem key={`root-${index}`} label={`[${index}]`} value={item} isRoot />
-        ))
-      ) : (
-        <JsonItem label="value" value={data} isRoot />
-      )}
+    <div className={`relative group ${className}`}>
+      <motion.button
+        whileHover={{ scale: 1.05 }}
+        whileTap={{ scale: 0.95 }}
+        onClick={handleCopyAll}
+        className="absolute top-2 right-2 z-10 p-2 rounded-md bg-white/90 dark:bg-gray-700/90 hover:bg-white dark:hover:bg-gray-700 transition-all opacity-0 group-hover:opacity-100 shadow-sm border border-gray-200 dark:border-gray-600"
+        title="Copy raw JSON"
+      >
+        {copied ? (
+          <FiCheck size={14} className="text-green-500" />
+        ) : (
+          <FiCopy size={14} className="text-gray-500 dark:text-gray-400" />
+        )}
+      </motion.button>
+      <div className="space-y-2">
+        {isRootObject ? (
+          Object.entries(data).map(([itemKey, value]) => (
+            <JsonItem key={itemKey} label={itemKey} value={value} isRoot />
+          ))
+        ) : isRootArray ? (
+          data.map((item: any, index: number) => (
+            <JsonItem key={`root-${index}`} label={`[${index}]`} value={item} isRoot />
+          ))
+        ) : (
+          <JsonItem label="value" value={data} isRoot />
+        )}
+      </div>
     </div>
   );
 };

--- a/multimodal/tarko/agent-web-ui/src/common/components/JsonRenderer.tsx
+++ b/multimodal/tarko/agent-web-ui/src/common/components/JsonRenderer.tsx
@@ -223,14 +223,17 @@ export const JsonRenderer: React.FC<JsonRendererProps> = ({
   const isRootArray = Array.isArray(data);
 
   return (
-    <div className={`relative group ${className}`}>
-      <div className="absolute top-4 right-4 z-10 opacity-0 group-hover:opacity-100 transition-opacity">
-        <CopyButton
-          onCopy={handleCopyAll}
-          copied={copied}
-          title="Copy raw JSON"
-          className="bg-white/90 dark:bg-gray-700/90 hover:bg-white dark:hover:bg-gray-700 shadow-sm border border-gray-200 dark:border-gray-600"
-        />
+    <div className={`group ${className}`}>
+      <div className="flex items-center justify-between mb-2">
+        <div className="text-xs text-gray-500 dark:text-gray-400 font-mono">JSON</div>
+        <div className="opacity-0 group-hover:opacity-100 transition-opacity">
+          <CopyButton
+            onCopy={handleCopyAll}
+            copied={copied}
+            title="Copy raw JSON"
+            size={14}
+          />
+        </div>
       </div>
       <div className="space-y-2">
         {isRootObject ? (


### PR DESCRIPTION
## Summary

Adds one-click copy functionality to `JsonContent` component for copying raw JSON data.

<img width="3512" height="3112" alt="image" src="https://github.com/user-attachments/assets/71ae9cb6-7faa-460d-add5-78b8d088eed9" />


Builds on https://github.com/bytedance/UI-TARS-desktop/pull/1167 to enhance JSON renderer with copy button that appears on hover and provides visual feedback when clicked.

## Checklist

- [ ] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [x] My change does not involve the above items.