### PR TITLE
feat(tarko): add url field to screenshot metadata and display in browser shell

### DIFF
--- a/multimodal/agent-tars/core/src/browser/browser-gui-agent.ts
+++ b/multimodal/agent-tars/core/src/browser/browser-gui-agent.ts
@@ -189,11 +189,21 @@ wait()                                         - Wait 5 seconds and take a scree
     // Convert compressed buffer to base64
     const compressedBase64 = `data:image/webp;base64,${compressedBuffer.toString('base64')}`;
 
+    // Get current page URL
+    let currentUrl: string | undefined;
+    try {
+      const page = await this.getPage();
+      currentUrl = page.url();
+    } catch (error) {
+      this.logger.warn('Failed to get current page URL for screenshot metadata:', error);
+    }
+
     return {
       originalSize,
       screenshotTime,
       compressedSize,
       compressedBase64,
+      currentUrl,
     };
   }
 
@@ -239,7 +249,7 @@ wait()                                         - Wait 5 seconds and take a scree
         this.logger.info('Browser not launched yet, skipping screenshot');
         return;
       }
-      const { originalSize, screenshotTime, compressedSize, compressedBase64 } =
+      const { originalSize, screenshotTime, compressedSize, compressedBase64, currentUrl } =
         await this.screenshot();
 
       this.currentScreenshot = compressedBase64;
@@ -257,6 +267,7 @@ wait()                                         - Wait 5 seconds and take a scree
         format: 'webp',
         quality: 20,
         time: `${screenshotTime} ms`,
+        url: currentUrl,
       });
 
       // Calculate image size
@@ -268,6 +279,7 @@ wait()                                         - Wait 5 seconds and take a scree
         height: this.screenHeight,
         size: `${sizeInKB} KB`,
         time: `${screenshotTime} ms`,
+        url: currentUrl,
         compression: `${
           originalSize / 1024 > 1024
             ? (originalSize / 1024 / 1024).toFixed(2) + ' MB'
@@ -288,6 +300,7 @@ wait()                                         - Wait 5 seconds and take a scree
         description: 'Browser Screenshot',
         metadata: {
           type: 'screenshot',
+          url: currentUrl,
         },
       });
 

--- a/multimodal/tarko/agent-interface/src/agent-event-stream.ts
+++ b/multimodal/tarko/agent-interface/src/agent-event-stream.ts
@@ -364,6 +364,8 @@ export namespace AgentEventStream {
    */
   export interface ScreenshotMetadata extends BaseEnvironmentInputMetadata {
     type: 'screenshot';
+    /** URL of the webpage being captured in the screenshot */
+    url?: string;
   }
 
   /**

--- a/multimodal/tarko/agent-web-ui/src/standalone/workspace/renderers/BrowserControlRenderer.tsx
+++ b/multimodal/tarko/agent-web-ui/src/standalone/workspace/renderers/BrowserControlRenderer.tsx
@@ -48,7 +48,14 @@ export const BrowserControlRenderer: React.FC<BrowserControlRendererProps> = ({
   });
 
   // Get screenshots from custom hook
-  const { relatedImage, beforeActionImage, afterActionImage } = useScreenshots({
+  const {
+    relatedImage,
+    beforeActionImage,
+    afterActionImage,
+    relatedImageUrl,
+    beforeActionImageUrl,
+    afterActionImageUrl,
+  } = useScreenshots({
     activeSessionId,
     toolCallId,
     messages,
@@ -69,6 +76,9 @@ export const BrowserControlRenderer: React.FC<BrowserControlRendererProps> = ({
         relatedImage={relatedImage}
         beforeActionImage={beforeActionImage}
         afterActionImage={afterActionImage}
+        relatedImageUrl={relatedImageUrl}
+        beforeActionImageUrl={beforeActionImageUrl}
+        afterActionImageUrl={afterActionImageUrl}
         mousePosition={mousePosition}
         previousMousePosition={previousMousePosition}
         action={action}

--- a/multimodal/tarko/agent-web-ui/src/standalone/workspace/renderers/browser-control/ScreenshotDisplay.tsx
+++ b/multimodal/tarko/agent-web-ui/src/standalone/workspace/renderers/browser-control/ScreenshotDisplay.tsx
@@ -9,6 +9,9 @@ interface ScreenshotDisplayProps {
   relatedImage: string | null;
   beforeActionImage: string | null;
   afterActionImage: string | null;
+  relatedImageUrl?: string | null;
+  beforeActionImageUrl?: string | null;
+  afterActionImageUrl?: string | null;
   mousePosition?: { x: number; y: number } | null;
   previousMousePosition?: { x: number; y: number } | null;
   action?: string;
@@ -19,6 +22,9 @@ export const ScreenshotDisplay: React.FC<ScreenshotDisplayProps> = ({
   relatedImage,
   beforeActionImage,
   afterActionImage,
+  relatedImageUrl,
+  beforeActionImageUrl,
+  afterActionImageUrl,
   mousePosition,
   previousMousePosition,
   action,
@@ -107,7 +113,7 @@ export const ScreenshotDisplay: React.FC<ScreenshotDisplayProps> = ({
                 Before Action
               </span>
             </div>
-            <BrowserShell>
+            <BrowserShell url={beforeActionImageUrl || undefined}>
               {renderImageContent(
                 beforeActionImage,
                 'Browser Screenshot - Before Action',
@@ -122,7 +128,7 @@ export const ScreenshotDisplay: React.FC<ScreenshotDisplayProps> = ({
                 After Action
               </span>
             </div>
-            <BrowserShell>
+            <BrowserShell url={afterActionImageUrl || undefined}>
               {renderImageContent(
                 afterActionImage,
                 'Browser Screenshot - After Action',
@@ -138,7 +144,7 @@ export const ScreenshotDisplay: React.FC<ScreenshotDisplayProps> = ({
 
   // Show single screenshot
   return (
-    <BrowserShell className="mb-4">
+    <BrowserShell className="mb-4" url={relatedImageUrl || undefined}>
       {renderImageContent(
         relatedImage,
         'Browser Screenshot',

--- a/multimodal/tarko/agent-web-ui/src/standalone/workspace/renderers/browser-control/useScreenshots.ts
+++ b/multimodal/tarko/agent-web-ui/src/standalone/workspace/renderers/browser-control/useScreenshots.ts
@@ -20,6 +20,9 @@ export const useScreenshots = ({
   const [relatedImage, setRelatedImage] = useState<string | null>(null);
   const [beforeActionImage, setBeforeActionImage] = useState<string | null>(null);
   const [afterActionImage, setAfterActionImage] = useState<string | null>(null);
+  const [relatedImageUrl, setRelatedImageUrl] = useState<string | null>(null);
+  const [beforeActionImageUrl, setBeforeActionImageUrl] = useState<string | null>(null);
+  const [afterActionImageUrl, setAfterActionImageUrl] = useState<string | null>(null);
 
   // If environment image is provided, use it directly
   useEffect(() => {
@@ -35,6 +38,9 @@ export const useScreenshots = ({
       setRelatedImage(null);
       setBeforeActionImage(null);
       setAfterActionImage(null);
+      setRelatedImageUrl(null);
+      setBeforeActionImageUrl(null);
+      setAfterActionImageUrl(null);
     }
 
     if (!activeSessionId || !toolCallId) return;
@@ -50,6 +56,9 @@ export const useScreenshots = ({
         setRelatedImage(null);
         setBeforeActionImage(null);
         setAfterActionImage(null);
+        setRelatedImageUrl(null);
+        setBeforeActionImageUrl(null);
+        setAfterActionImageUrl(null);
       }
       return;
     }
@@ -67,9 +76,15 @@ export const useScreenshots = ({
           );
 
           if (imgContent && 'image_url' in imgContent && imgContent.image_url.url) {
+            const url =
+              msg.metadata?.type === 'screenshot' && 'url' in msg.metadata
+                ? msg.metadata.url
+                : null;
             setBeforeActionImage(imgContent.image_url.url);
+            setBeforeActionImageUrl(url || null);
             if (currentStrategy === 'beforeAction') {
               setRelatedImage(imgContent.image_url.url);
+              setRelatedImageUrl(url || null);
             }
             foundBeforeImage = true;
             break;
@@ -88,9 +103,15 @@ export const useScreenshots = ({
           );
 
           if (imgContent && 'image_url' in imgContent && imgContent.image_url.url) {
+            const url =
+              msg.metadata?.type === 'screenshot' && 'url' in msg.metadata
+                ? msg.metadata.url
+                : null;
             setAfterActionImage(imgContent.image_url.url);
+            setAfterActionImageUrl(url || null);
             if (currentStrategy === 'afterAction') {
               setRelatedImage(imgContent.image_url.url);
+              setRelatedImageUrl(url || null);
             }
             foundAfterImage = true;
             break;
@@ -106,36 +127,38 @@ export const useScreenshots = ({
           `[BrowserControlRenderer] No valid screenshot found before toolCallId: ${toolCallId}. Clearing screenshot display.`,
         );
         setRelatedImage(null);
+        setRelatedImageUrl(null);
       } else if (currentStrategy === 'afterAction' && !foundAfterImage) {
         console.warn(
           `[BrowserControlRenderer] No valid screenshot found after toolCallId: ${toolCallId}. Clearing screenshot display.`,
         );
         setRelatedImage(null);
+        setRelatedImageUrl(null);
       } else if (currentStrategy === 'both') {
         // For 'both' strategy, use the after action image as primary if available
         if (foundAfterImage) {
           setRelatedImage(afterActionImage);
+          setRelatedImageUrl(afterActionImageUrl);
         } else if (foundBeforeImage) {
           setRelatedImage(beforeActionImage);
+          setRelatedImageUrl(beforeActionImageUrl);
         } else {
           console.warn(
             `[BrowserControlRenderer] No valid screenshots found for toolCallId: ${toolCallId}. Clearing screenshot display.`,
           );
           setRelatedImage(null);
+          setRelatedImageUrl(null);
         }
       }
     }
-  }, [
-    activeSessionId,
-    messages,
-    toolCallId,
-    environmentImage,
-    currentStrategy,
-  ]);
+  }, [activeSessionId, messages, toolCallId, environmentImage, currentStrategy]);
 
   return {
     relatedImage,
     beforeActionImage,
     afterActionImage,
+    relatedImageUrl,
+    beforeActionImageUrl,
+    afterActionImageUrl,
   };
 };


### PR DESCRIPTION
## Summary

Adds URL display functionality to the `BrowserControlRenderer` by extending `ScreenshotMetadata` with an optional `url` field and updating the browser GUI agent to capture and include the current page URL in screenshot metadata.

**Changes:**
- Extended `ScreenshotMetadata` interface in `@tarko/agent-interface` to include optional `url` field
- Updated `browser-gui-agent.ts` to capture current page URL and include it in screenshot metadata
- Modified `useScreenshots` hook to extract and track URL metadata for all screenshot strategies
- Updated `ScreenshotDisplay` component to pass URL data to `BrowserShell` for display
- Supports all screenshot strategies: `both`, `beforeAction`, and `afterAction`

**Key files modified:**
- `multimodal/tarko/agent-interface/src/agent-event-stream.ts`
- `multimodal/agent-tars/core/src/browser/browser-gui-agent.ts`
- `multimodal/tarko/agent-web-ui/src/standalone/workspace/renderers/browser-control/useScreenshots.ts`
- `multimodal/tarko/agent-web-ui/src/standalone/workspace/renderers/BrowserControlRenderer.tsx`
- `multimodal/tarko/agent-web-ui/src/standalone/workspace/renderers/browser-control/ScreenshotDisplay.tsx`

## Checklist

- [ ] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [x] My change does not involve the above items.