### PR TITLE
feat(tarko): show edit_file path in tool calls

### DIFF
--- a/multimodal/tarko/agent-web-ui/src/standalone/chat/Message/components/ToolCalls.tsx
+++ b/multimodal/tarko/agent-web-ui/src/standalone/chat/Message/components/ToolCalls.tsx
@@ -157,6 +157,13 @@ export const ToolCalls: React.FC<ToolCallsProps> = ({
             return `file: ${fileName}`;
           }
           return status === 'constructing' ? 'preparing file operation...' : '';
+        case 'edit_file':
+          if (args.path) {
+            const normalizedPath = normalizeFilePath(args.path);
+            const fileName = normalizedPath.split(/[/\\]/).pop();
+            return `editing: ${fileName}`;
+          }
+          return status === 'constructing' ? 'preparing edit...' : '';
         default:
           return status === 'constructing' ? 'preparing...' : '';
       }
@@ -191,6 +198,8 @@ export const ToolCalls: React.FC<ToolCallsProps> = ({
         return '"file read"';
       } else if (toolCall.function.name.startsWith('write_')) {
         return '"file saved"';
+      } else if (toolCall.function.name === 'edit_file') {
+        return '"file edited"';
       }
     }
 
@@ -222,6 +231,8 @@ export const ToolCalls: React.FC<ToolCallsProps> = ({
         return 'Read File';
       case 'write_file':
         return 'Write File';
+      case 'edit_file':
+        return 'Edit File';
       default:
         // Title case
         return nameWithSpaces


### PR DESCRIPTION
## Summary

Added support for displaying the `path` parameter in `edit_file` tool calls within the ToolCalls component. Previously, `edit_file` tool calls only showed in the Workspace but lacked path information in the chat interface.

Changes:
- Added `edit_file` case in `getToolDescription()` to show `editing: filename`
- Added `edit_file` case in `getToolDisplayName()` to show "Edit File"
- Added `edit_file` case in `getResultInfo()` to show "file edited" on success

## Checklist

- [ ] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [x] My change does not involve the above items.