### PR TITLE
fix(tarko): move StrategySwitch after ScreenshotDisplay to prevent flicker

### DIFF
--- a/multimodal/tarko/agent-web-ui/src/standalone/workspace/renderers/BrowserControlRenderer.tsx
+++ b/multimodal/tarko/agent-web-ui/src/standalone/workspace/renderers/BrowserControlRenderer.tsx
@@ -65,11 +65,6 @@ export const BrowserControlRenderer: React.FC<BrowserControlRendererProps> = ({
 
   return (
     <div className="space-y-3">
-      {/* Strategy Switch Controls */}
-      {guiAgentConfig.enableScreenshotRenderStrategySwitch && (
-        <StrategySwitch currentStrategy={currentStrategy} onStrategyChange={setCurrentStrategy} />
-      )}
-
       {/* Screenshot section */}
       <ScreenshotDisplay
         strategy={currentStrategy}
@@ -83,6 +78,11 @@ export const BrowserControlRenderer: React.FC<BrowserControlRendererProps> = ({
         previousMousePosition={previousMousePosition}
         action={action}
       />
+
+      {/* Strategy Switch Controls */}
+      {guiAgentConfig.enableScreenshotRenderStrategySwitch && (
+        <StrategySwitch currentStrategy={currentStrategy} onStrategyChange={setCurrentStrategy} />
+      )}
 
       {/* Visual operation details card */}
       {guiAgentConfig.renderGUIAction && (

--- a/multimodal/tarko/agent-web-ui/src/standalone/workspace/renderers/browser-control/StrategySwitch.tsx
+++ b/multimodal/tarko/agent-web-ui/src/standalone/workspace/renderers/browser-control/StrategySwitch.tsx
@@ -37,7 +37,7 @@ export const StrategySwitch: React.FC<StrategySwitchProps> = ({
   const tooltipProps = getTooltipProps('bottom');
 
   return (
-    <div className="flex items-center justify-center mt-4">
+    <div className="flex items-center justify-center">
       <div className="inline-flex rounded-md" role="group">
         {strategies.map((strategy, index) => {
           const config = strategyConfig[strategy];


### PR DESCRIPTION
## Summary

Moves `StrategySwitch` rendering after `ScreenshotDisplay` in `BrowserControlRenderer` to prevent visual flicker when switching between `browser_navigate` and `EnvironmentInputEvent` that both render Browser Screenshots.

The issue occurred because both events render screenshot content, and having the strategy switch positioned before the screenshot caused visual inconsistency during transitions.

## Checklist

- [ ] Added or updated necessary tests (Optional).  
- [ ] Updated documentation to align with changes (Optional).  
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).  
- [x] My change does not involve the above items. 
