### PR TITLE
fix(tarko): improve json font rendering in dark mode

### DIFF
--- a/multimodal/tarko/agent-web-ui/src/standalone/workspace/renderers/generic/components/JsonContent.tsx
+++ b/multimodal/tarko/agent-web-ui/src/standalone/workspace/renderers/generic/components/JsonContent.tsx
@@ -9,7 +9,7 @@ export const JsonContent: React.FC<JsonContentProps> = ({ data }) => {
 
   return (
     <div className="w-full max-w-full">
-      <pre className="text-xs bg-gray-50 dark:bg-gray-800/50 p-3 rounded font-mono overflow-x-auto overflow-y-auto max-h-96 whitespace-pre-wrap break-words">
+      <pre className="text-xs bg-gray-50 dark:bg-gray-800/50 p-3 rounded font-mono overflow-x-auto overflow-y-auto max-h-96 whitespace-pre-wrap break-words text-gray-800 dark:text-gray-200 antialiased">
         {formattedJson}
       </pre>
     </div>


### PR DESCRIPTION
## Summary

Fixed JSON font rendering issues in dark mode by adding explicit text colors and antialiasing to the `JsonContent` component.

The issue was that JSON content in workspace panels had poor font rendering in dark mode due to missing text color specifications and font smoothing.

**Changes:**
- Added `text-gray-800 dark:text-gray-200` for proper contrast in both light and dark modes
- Added `antialiased` class for better font smoothing

## Checklist

- [x] My change does not involve the above items.