### PR TITLE
fix(tarko): browser shell url bar takes full width without spacing

### DIFF
--- a/multimodal/tarko/agent-web-ui/src/standalone/workspace/WorkspaceDetail.tsx
+++ b/multimodal/tarko/agent-web-ui/src/standalone/workspace/WorkspaceDetail.tsx
@@ -32,8 +32,6 @@ import { DeliverableRenderer } from './renderers/DeliverableRenderer';
 import { DiffRenderer } from './renderers/DiffRenderer';
 import { FileResultRenderer } from './renderers/FileResultRenderer';
 
-
-
 /**
  * Registry of content renderers that handle StandardPanelContent directly
  */
@@ -74,18 +72,29 @@ export const WorkspaceDetail: React.FC = () => {
 
   // Determine initial display mode based on content type and streaming state
   const getInitialDisplayMode = (): FileDisplayMode => {
-    if (!activePanelContent || activePanelContent.type !== 'file' || !activePanelContent.arguments?.path) {
+    if (
+      !activePanelContent ||
+      activePanelContent.type !== 'file' ||
+      !activePanelContent.arguments?.path
+    ) {
       return 'rendered';
     }
 
-    return getDefaultDisplayMode(activePanelContent.arguments.path, Boolean(activePanelContent.isStreaming));
+    return getDefaultDisplayMode(
+      activePanelContent.arguments.path,
+      Boolean(activePanelContent.isStreaming),
+    );
   };
 
   const [displayMode, setDisplayMode] = useState<FileDisplayMode>(getInitialDisplayMode());
 
   // Auto-switch HTML files from source to rendered when streaming completes
   useEffect(() => {
-    if (!activePanelContent || activePanelContent.type !== 'file' || !activePanelContent.arguments?.path) {
+    if (
+      !activePanelContent ||
+      activePanelContent.type !== 'file' ||
+      !activePanelContent.arguments?.path
+    ) {
       return;
     }
 
@@ -282,7 +291,7 @@ export const WorkspaceDetail: React.FC = () => {
           onWorkspaceDisplayModeChange={setWorkspaceDisplayMode}
           showWorkspaceToggle={shouldShowWorkspaceToggle()}
         />
-        <div className="flex-1 overflow-auto p-4 pt-0">{renderContent()}</div>
+        <div className="flex-1 overflow-auto p-4 pt-2">{renderContent()}</div>
       </motion.div>
 
       <ImageModal imageData={zoomedImage} onClose={() => setZoomedImage(null)} />

--- a/multimodal/tarko/agent-web-ui/src/standalone/workspace/renderers/BrowserShell.tsx
+++ b/multimodal/tarko/agent-web-ui/src/standalone/workspace/renderers/BrowserShell.tsx
@@ -35,7 +35,7 @@ export const BrowserShell: React.FC<BrowserShellProps> = ({
         const domain = new URL(url).hostname;
         return domain || title;
       }
-    } catch (e) {}
+    } catch (e) { }
     return title;
   };
 
@@ -57,7 +57,7 @@ export const BrowserShell: React.FC<BrowserShellProps> = ({
           </div>
 
           {/* URL bar with secure indicator */}
-          <div className="flex-1 bg-white dark:bg-gray-700 rounded-md flex items-center px-3 py-1.5 text-xs text-gray-700 dark:text-gray-200 border border-gray-300/30 dark:border-gray-600/40 group hover:border-gray-400/30 dark:hover:border-gray-500/30 transition-colors shadow-inner">
+          <div className="flex-1 overflow-hidden bg-white dark:bg-gray-700 rounded-md flex items-center px-3 py-1.5 text-xs text-gray-700 dark:text-gray-200 border border-gray-300/30 dark:border-gray-600/40 group hover:border-gray-400/30 dark:hover:border-gray-500/30 transition-colors shadow-inner">
             <div className="flex items-center w-full">
               {isSecure ? (
                 <FiLock className="mr-1.5 text-green-500 dark:text-green-400" size={12} />


### PR DESCRIPTION
## Summary

This fixes the issue where the address bar would stretch to fill all available space without any visual breathing room on the right edge.

### Before
<img width="3776" height="940" alt="image" src="https://github.com/user-attachments/assets/6abc9698-c0e2-4a05-995c-16ac5bf10ee2" />

### After

<img width="3768" height="964" alt="image" src="https://github.com/user-attachments/assets/92e35484-f360-4122-8ae8-b850dd3216d2" />


## Checklist

- [x] My change does not involve the above items.