### PR TITLE
fix(tarko): support new str_replace_editor response structure

### DIFF
--- a/multimodal/tarko/agent-web-ui/src/common/utils/tool-renderers/renderer-conditions/str_replace_editor.ts
+++ b/multimodal/tarko/agent-web-ui/src/common/utils/tool-renderers/renderer-conditions/str_replace_editor.ts
@@ -6,7 +6,7 @@ export const strReplaceEditorRendererCondition: FunctionToolToRendererCondition 
 ): string | null => {
   if (toolName === 'str_replace_editor') {
     /**
-     * NEW: Direct response structure (current format):
+     * NEW: panelContent.content structure (current format):
      * {
      *   "output": "File created successfully at: /home/gem/lynx_cross_platform_framework_report.md",
      *   "error": null,
@@ -17,7 +17,7 @@ export const strReplaceEditorRendererCondition: FunctionToolToRendererCondition 
      * }
      */
     if (typeof content === 'object' && content !== null) {
-      // Handle new direct response structure
+      // Handle new panelContent.content structure
       if ('output' in content && 'path' in content && 'prev_exist' in content) {
         // File edit operation (has both old and new content)
         if (content.prev_exist && content.old_content && content.new_content) {

--- a/multimodal/tarko/agent-web-ui/src/common/utils/tool-renderers/renderer-conditions/str_replace_editor.ts
+++ b/multimodal/tarko/agent-web-ui/src/common/utils/tool-renderers/renderer-conditions/str_replace_editor.ts
@@ -6,8 +6,41 @@ export const strReplaceEditorRendererCondition: FunctionToolToRendererCondition 
 ): string | null => {
   if (toolName === 'str_replace_editor') {
     /**
-     *
-     * Object case (always FAIL for now):
+     * NEW: Direct response structure (current format):
+     * {
+     *   "output": "File created successfully at: /home/gem/lynx_cross_platform_framework_report.md",
+     *   "error": null,
+     *   "path": "/home/gem/lynx_cross_platform_framework_report.md",
+     *   "prev_exist": false,
+     *   "old_content": null,
+     *   "new_content": "...markdown text..."
+     * }
+     */
+    if (typeof content === 'object' && content !== null) {
+      // Handle new direct response structure
+      if ('output' in content && 'path' in content && 'prev_exist' in content) {
+        // File edit operation (has both old and new content)
+        if (content.prev_exist && content.old_content && content.new_content) {
+          return 'diff_result';
+        }
+
+        // File creation operation (has new content but no old content)
+        if (content.new_content) {
+          return 'file_result';
+        }
+
+        // Error case or other operations
+        if (content.error) {
+          return 'command_result';
+        }
+
+        // Default to command result for other cases
+        return 'command_result';
+      }
+    }
+
+    /**
+     * LEGACY: Object case (wrapped in panelContent):
      *
      * {
      *    "panelContent": {


### PR DESCRIPTION
## Summary

Added support for new `str_replace_editor` `panelContent.content` structure while preserving legacy code.

New supported structure:
```json
{
  "output": "File created successfully at: /home/gem/lynx_cross_platform_framework_report.md",
  "error": null,
  "path": "/home/gem/lynx_cross_platform_framework_report.md",
  "prev_exist": false,
  "old_content": null,
  "new_content": "...markdown text..."
}
```

Routing logic:
- File edit (has `old_content` and `new_content`) → `diff_result` renderer
- File creation (has only `new_content`) → `file_result` renderer  
- Error case (has `error`) → `command_result` renderer

## Checklist

- [x] My change does not involve the above items.