### PR TITLE
feat(tarko): trim leading newlines from thinking message content (#1333)

### DIFF
--- a/multimodal/tarko/agent-web-ui/src/common/state/actions/eventProcessors/handlers/MessageHandler.ts
+++ b/multimodal/tarko/agent-web-ui/src/common/state/actions/eventProcessors/handlers/MessageHandler.ts
@@ -6,6 +6,10 @@ import { activePanelContentAtom, isProcessingAtom } from '@/common/state/atoms/u
 import { shouldUpdatePanelContent } from '../utils/panelContentUpdater';
 import { ChatCompletionContentPartImage } from '@tarko/agent-interface';
 
+// Constants for thinking message newline trimming performance
+const LEADING_NEWLINES_REGEX = /^\n+/;
+const NEWLINE_CHAR = '\n';
+
 export class UserMessageHandler implements EventHandler<AgentEventStream.UserMessageEvent> {
   canHandle(event: AgentEventStream.Event): event is AgentEventStream.UserMessageEvent {
     return event.type === 'user_message';
@@ -285,14 +289,14 @@ export class ThinkingMessageHandler
         if (event.type === 'assistant_streaming_thinking_message') {
           // For streaming thinking messages, append to existing thinking content
           // Only trim leading newlines if this is the first chunk (thinking is empty)
-          const contentToAdd = (message.thinking || '').length === 0 && event.content.startsWith('\n')
-            ? event.content.replace(/^\n+/, '')
+          const contentToAdd = (message.thinking || '').length === 0 && event.content.startsWith(NEWLINE_CHAR)
+            ? event.content.replace(LEADING_NEWLINES_REGEX, '')
             : event.content;
           newThinking = (message.thinking || '') + contentToAdd;
         } else {
           // For final thinking messages, only trim if content starts with newline
-          newThinking = event.content.startsWith('\n')
-            ? event.content.replace(/^\n+/, '')
+          newThinking = event.content.startsWith(NEWLINE_CHAR)
+            ? event.content.replace(LEADING_NEWLINES_REGEX, '')
             : event.content;
         }
 
@@ -311,8 +315,8 @@ export class ThinkingMessageHandler
           role: 'assistant',
           content: '',
           timestamp: event.timestamp,
-          thinking: event.content.startsWith('\n')
-            ? event.content.replace(/^\n+/, '')
+          thinking: event.content.startsWith(NEWLINE_CHAR)
+            ? event.content.replace(LEADING_NEWLINES_REGEX, '')
             : event.content,
           messageId: eventMessageId,
           isStreaming: event.type === 'assistant_streaming_thinking_message' && !event.isComplete,


### PR DESCRIPTION
## Summary

Fixes rendering issue where `assistant_thinking_message` and `assistant_streaming_thinking_message` content starts with leading newlines, causing ugly display in the UI.

### Before

<img width="1280" height="492" alt="image" src="https://github.com/user-attachments/assets/146c0cfd-e989-40a4-9d55-bc8524763a44" />

### After
<img width="1280" height="460" alt="image" src="https://github.com/user-attachments/assets/1ff97095-810b-421d-a672-b91d6eb6c789" />


## Checklist

- [ ] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [x] My change does not involve the above items.