### PR TITLE
feat(tarko): apply RTL only to file-related tools in tool blocks

### DIFF
--- a/multimodal/tarko/agent-web-ui/src/standalone/chat/Message/components/ActionButton.tsx
+++ b/multimodal/tarko/agent-web-ui/src/standalone/chat/Message/components/ActionButton.tsx
@@ -10,6 +10,7 @@ interface ActionButtonProps {
   statusIcon?: React.ReactNode;
   description?: string;
   elapsedMs?: number;
+  isFileRelated?: boolean;
 }
 
 /**
@@ -23,6 +24,7 @@ export const ActionButton: React.FC<ActionButtonProps> = ({
   statusIcon,
   description,
   elapsedMs,
+  isFileRelated = false,
 }) => {
   // Helper function to format elapsed time for display
   const formatElapsedTime = (ms: number): string => {
@@ -123,7 +125,9 @@ export const ActionButton: React.FC<ActionButtonProps> = ({
 
           {/* Description */}
           {description && (
-            <span className="font-[400] text-xs opacity-70 block sm:inline overflow-hidden whitespace-nowrap text-ellipsis [direction:rtl] [text-align:left]">
+            <span
+              className={`font-[400] text-xs opacity-70 block sm:inline overflow-hidden whitespace-nowrap text-ellipsis ${isFileRelated ? '[direction:rtl] [text-align:left]' : ''}`}
+            >
               {description}
             </span>
           )}

--- a/multimodal/tarko/agent-web-ui/src/standalone/chat/Message/components/ToolCalls.tsx
+++ b/multimodal/tarko/agent-web-ui/src/standalone/chat/Message/components/ToolCalls.tsx
@@ -235,6 +235,18 @@ export const ToolCalls: React.FC<ToolCallsProps> = ({
     }
   };
 
+  // Helper function to determine if a tool is file-related
+  const isFileRelatedTool = (toolName: string) => {
+    const fileTools = [
+      'read_file',
+      'write_file',
+      'edit_file',
+      'list_directory',
+      'str_replace_editor',
+    ];
+    return fileTools.includes(toolName);
+  };
+
   return (
     <div className="mt-2 space-y-1.5">
       {toolCalls.map((toolCall) => {
@@ -258,6 +270,7 @@ export const ToolCalls: React.FC<ToolCallsProps> = ({
             statusIcon={getStatusIcon(status, toolCall.function.name)}
             description={description || browserInfo || undefined}
             elapsedMs={elapsedMs} // Pass elapsed time to ActionButton
+            isFileRelated={isFileRelatedTool(toolCall.function.name)}
           />
         );
       })}


### PR DESCRIPTION



## Summary

Fixes RTL rendering issue where non-file tools like commands were incorrectly displayed with RTL direction.

Previously, all tool descriptions in Tool Call Blocks used `[direction:rtl]` styling, causing commands like `git add .` to render as `. git add` in RTL layout.

Now RTL styling is applied only to file-related tools (`read_file`, `write_file`, `edit_file`, `list_directory`, `str_replace_editor`) where showing complete relative paths is beneficial.

<img width="4400" height="2596" alt="image" src="https://github.com/user-attachments/assets/fddee10d-ea14-4657-8c93-971f0637f70f" />



Ref: https://github.com/bytedance/UI-TARS-desktop/pull/1309

## Checklist

- [ ] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [x] My change does not involve the above items.

