### PR TITLE
fix(tarko): remove environment input rendering in workspace

### DIFF
--- a/multimodal/tarko/agent-web-ui/src/standalone/chat/Message/components/MultimodalContent.tsx
+++ b/multimodal/tarko/agent-web-ui/src/standalone/chat/Message/components/MultimodalContent.tsx
@@ -7,6 +7,7 @@ interface MultimodalContentProps {
   content: ChatCompletionContentPart[];
   timestamp: number;
   setActivePanelContent: any;
+  messageRole?: string;
 }
 
 /**
@@ -21,6 +22,7 @@ export const MultimodalContent: React.FC<MultimodalContentProps> = ({
   content,
   timestamp,
   setActivePanelContent,
+  messageRole,
 }) => {
   // Filter out image and text content
   const imageContents = content.filter((part) => part.type === 'image_url');
@@ -28,6 +30,9 @@ export const MultimodalContent: React.FC<MultimodalContentProps> = ({
 
   // Image-only case - optimize layout
   const isImageOnly = imageContents.length > 0 && textContents.length === 0;
+  
+  // Don't make environment images clickable - they should only be handled by BrowserControlRenderer
+  const isEnvironmentMessage = messageRole === 'environment';
 
   return (
     <>
@@ -39,16 +44,16 @@ export const MultimodalContent: React.FC<MultimodalContentProps> = ({
           {imageContents.map((part, index) => (
             <motion.div
               key={`image-${index}`}
-              whileHover={{ scale: 1.02 }}
-              onClick={() =>
+              whileHover={!isEnvironmentMessage ? { scale: 1.02 } : {}}
+              onClick={!isEnvironmentMessage ? () =>
                 setActivePanelContent({
                   type: 'image',
                   source: part.image_url.url,
                   title: 'Image',
                   timestamp,
-                })
+                }) : undefined
               }
-              className="relative group cursor-pointer inline-block"
+              className={`relative group inline-block ${!isEnvironmentMessage ? 'cursor-pointer' : ''}`}
             >
               {/* Render the actual image thumbnail */}
               <img

--- a/multimodal/tarko/agent-web-ui/src/standalone/chat/Message/index.tsx
+++ b/multimodal/tarko/agent-web-ui/src/standalone/chat/Message/index.tsx
@@ -81,6 +81,7 @@ export const Message: React.FC<MessageProps> = ({
           content={message.content as ChatCompletionContentPart[]}
           timestamp={message.timestamp}
           setActivePanelContent={setActivePanelContent}
+          messageRole={message.role}
         />
       );
     }


### PR DESCRIPTION
## Summary

Fixed redundant Browser Screenshot rendering in workspace by preventing `environment_input` images from being clickable in chat messages. Only `BrowserControlRenderer` should handle browser screenshots through the tool result flow.

**Problem**: GUI Agent tasks showed duplicate Browser Screenshot states - one from `environment_input` events and another from `browser_vision_control` tool results.

**Solution**: Modified `MultimodalContent` component to disable click interactions for environment message images, ensuring only `BrowserControlRenderer` handles browser screenshots.

## Checklist

- [x] My change does not involve the above items.