### PR TITLE
fix(tarko): persist agent web ui config in share

### DIFF
--- a/multimodal/tarko/agent-cli/src/core/commands/start.ts
+++ b/multimodal/tarko/agent-cli/src/core/commands/start.ts
@@ -12,7 +12,7 @@ import {
   isAgentWebUIImplementationType,
   AgentWebUIImplementation,
 } from '@tarko/interface';
-import { AgentServer, AgentServerOptions, express } from '@tarko/agent-server';
+import { AgentServer, AgentServerOptions, express, mergeWebUIConfig } from '@tarko/agent-server';
 import boxen from 'boxen';
 import chalk from 'chalk';
 import gradient from 'gradient-string';
@@ -50,8 +50,7 @@ export async function startInteractiveWebUI(
   // Set up UI if static path is provided
   if (webui.staticPath) {
     const app = server.getApp();
-    const agentConstructorWebConfig = server.getAgentConstructorWebConfig();
-    const mergedWebUIConfig = { ...webui, ...agentConstructorWebConfig };
+    const mergedWebUIConfig = mergeWebUIConfig(webui, server);
     setupUI(app, isDebug, webui.staticPath, mergedWebUIConfig);
   }
 

--- a/multimodal/tarko/agent-server/src/api/controllers/sessions.ts
+++ b/multimodal/tarko/agent-server/src/api/controllers/sessions.ts
@@ -327,7 +327,7 @@ export async function shareSession(req: Request, res: Response) {
 
   try {
     const server = req.app.locals.server;
-    const shareService = new ShareService(server.appConfig, server.storageProvider);
+    const shareService = new ShareService(server.appConfig, server.storageProvider, server);
 
     // Get agent instance if session is active (for slug generation)
     const agent = server.sessions[sessionId]?.agent;

--- a/multimodal/tarko/agent-server/src/api/controllers/share.ts
+++ b/multimodal/tarko/agent-server/src/api/controllers/share.ts
@@ -11,6 +11,6 @@ import { ShareService } from '../../services';
  */
 export function getShareConfig(req: Request, res: Response) {
   const server = req.app.locals.server;
-  const shareService = new ShareService(server.appConfig, server.storageProvider);
+  const shareService = new ShareService(server.appConfig, server.storageProvider, server);
   res.status(200).json(shareService.getShareConfig());
 }

--- a/multimodal/tarko/agent-server/src/services/ShareService.ts
+++ b/multimodal/tarko/agent-server/src/services/ShareService.ts
@@ -12,6 +12,7 @@ import fs from 'fs';
 import path from 'path';
 import { ensureHttps } from '../utils';
 import type { AgentServerVersionInfo, IAgent, AgentAppConfig } from '../types';
+import type { AgentServer } from '../server';
 
 /**
  * ShareService - Centralized service for handling session sharing
@@ -26,6 +27,7 @@ export class ShareService {
   constructor(
     private appConfig: AgentAppConfig,
     private storageProvider: StorageProvider | null,
+    private server?: AgentServer,
   ) {}
 
   /**
@@ -351,11 +353,16 @@ export class ShareService {
         throw new Error('Cannot found static path.');
       }
 
+      // Merge web UI config with agent constructor config (same as start.ts)
+      const agentConstructorWebConfig = this.server?.getAgentConstructorWebConfig();
+      const mergedWebUIConfig = { ...this.appConfig.webui, ...agentConstructorWebConfig };
+
       return ShareUtils.generateShareHtml(
         events,
         metadata,
         this.appConfig.webui.staticPath,
         versionInfo,
+        mergedWebUIConfig,
       );
     }
 

--- a/multimodal/tarko/agent-server/src/services/ShareService.ts
+++ b/multimodal/tarko/agent-server/src/services/ShareService.ts
@@ -11,6 +11,7 @@ import { SlugGenerator } from '../utils/slug-generator';
 import fs from 'fs';
 import path from 'path';
 import { ensureHttps } from '../utils';
+import { mergeWebUIConfig } from '../utils/webui';
 import type { AgentServerVersionInfo, IAgent, AgentAppConfig } from '../types';
 import type { AgentServer } from '../server';
 
@@ -353,9 +354,8 @@ export class ShareService {
         throw new Error('Cannot found static path.');
       }
 
-      // Merge web UI config with agent constructor config (same as start.ts)
-      const agentConstructorWebConfig = this.server?.getAgentConstructorWebConfig();
-      const mergedWebUIConfig = { ...this.appConfig.webui, ...agentConstructorWebConfig };
+      // Merge web UI config with agent constructor config
+      const mergedWebUIConfig = mergeWebUIConfig(this.appConfig.webui, this.server);
 
       return ShareUtils.generateShareHtml(
         events,

--- a/multimodal/tarko/agent-server/src/utils/index.ts
+++ b/multimodal/tarko/agent-server/src/utils/index.ts
@@ -7,3 +7,4 @@ export * from './error-handler';
 export * from './workspace-static-server';
 export * from './url';
 export * from './agent-resolver';
+export * from './webui';

--- a/multimodal/tarko/agent-server/src/utils/share.ts
+++ b/multimodal/tarko/agent-server/src/utils/share.ts
@@ -24,6 +24,7 @@ export class ShareUtils {
    * @param metadata Session metadata
    * @param staticPath Path to static web UI files
    * @param serverInfo Optional server version info
+   * @param webUIConfig Optional web UI configuration to inject
    * @returns Generated HTML content
    */
   static generateShareHtml(
@@ -31,6 +32,7 @@ export class ShareUtils {
     metadata: SessionItemInfo,
     staticPath: string,
     serverInfo?: AgentServerVersionInfo,
+    webUIConfig?: Record<string, any>,
   ): string {
     if (!staticPath) {
       throw new Error('Cannot found static path.');
@@ -48,7 +50,8 @@ export class ShareUtils {
       const safeMetadataJson = this.safeJsonStringify(metadata);
       const safeVersionJson = serverInfo ? this.safeJsonStringify(serverInfo) : null;
 
-      // Inject session data, event stream, and version info
+      // Inject session data, event stream, version info, and web UI config
+      const safeWebUIConfigJson = webUIConfig ? this.safeJsonStringify(webUIConfig) : null;
       const scriptTag = `<script>
         window.AGENT_REPLAY_MODE = true;
         window.AGENT_SESSION_DATA = ${safeMetadataJson};
@@ -56,6 +59,11 @@ export class ShareUtils {
           safeVersionJson
             ? `
         window.AGENT_VERSION_INFO = ${safeVersionJson};`
+            : ''
+        }${
+          safeWebUIConfigJson
+            ? `
+        window.AGENT_WEB_UI_CONFIG = ${safeWebUIConfigJson};`
             : ''
         }
       </script>

--- a/multimodal/tarko/agent-server/src/utils/webui/config.ts
+++ b/multimodal/tarko/agent-server/src/utils/webui/config.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { AgentWebUIImplementation } from '@tarko/interface';
+import type { AgentServer } from '../../server';
+
+/**
+ * Merge web UI config with agent constructor config
+ * This ensures consistent configuration merging across different contexts
+ * @param baseWebUIConfig Base web UI configuration from app config
+ * @param server Optional agent server instance to get constructor config
+ * @returns Merged web UI configuration
+ */
+export function mergeWebUIConfig(
+  baseWebUIConfig: AgentWebUIImplementation,
+  server?: AgentServer,
+): AgentWebUIImplementation & Record<string, any> {
+  const agentConstructorWebConfig = server?.getAgentConstructorWebConfig();
+  return { ...baseWebUIConfig, ...agentConstructorWebConfig };
+}

--- a/multimodal/tarko/agent-server/src/utils/webui/index.ts
+++ b/multimodal/tarko/agent-server/src/utils/webui/index.ts
@@ -1,0 +1,6 @@
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from './config';


### PR DESCRIPTION
## Summary

Fixes issue where `AGENT_WEB_UI_CONFIG` was not persisted in shared links, causing replay mode to lose configuration.

## Checklist

- [x] Added or updated necessary tests (Optional).
- [x] Updated documentation to align with changes (Optional).
- [x] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [ ] My change does not involve the above items.