### PR TITLE
fix(tarko): hide workspace navigation items in replay mode

### DIFF
--- a/multimodal/tarko/agent-web-ui/src/standalone/workspace/WorkspaceDetail.tsx
+++ b/multimodal/tarko/agent-web-ui/src/standalone/workspace/WorkspaceDetail.tsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion';
 import { FiCode, FiEye } from 'react-icons/fi';
 import { useAtom } from 'jotai';
 import { useSession } from '@/common/hooks/useSession';
+import { useReplayMode } from '@/common/hooks/useReplayMode';
 import { ResearchReportRenderer } from './renderers/ResearchReportRenderer';
 import { WorkspaceHeader } from './components/WorkspaceHeader';
 import { RawModeRenderer } from './components/RawModeRenderer';
@@ -65,6 +66,7 @@ const CONTENT_RENDERERS: Record<
  */
 export const WorkspaceDetail: React.FC = () => {
   const { activePanelContent, setActivePanelContent, activeSessionId } = useSession();
+  const { isReplayMode } = useReplayMode();
   const [workspaceDisplayMode, setWorkspaceDisplayMode] = useAtom(workspaceDisplayModeAtom);
   const [rawToolMapping] = useAtom(rawToolMappingAtom);
   const [zoomedImage, setZoomedImage] = useState<ZoomedImageData | null>(null);
@@ -290,6 +292,7 @@ export const WorkspaceDetail: React.FC = () => {
           workspaceDisplayMode={workspaceDisplayMode}
           onWorkspaceDisplayModeChange={setWorkspaceDisplayMode}
           showWorkspaceToggle={shouldShowWorkspaceToggle()}
+          isReplayMode={isReplayMode}
         />
         <div className="flex-1 overflow-auto p-4 pt-2">{renderContent()}</div>
       </motion.div>

--- a/multimodal/tarko/agent-web-ui/src/standalone/workspace/components/WorkspaceHeader.tsx
+++ b/multimodal/tarko/agent-web-ui/src/standalone/workspace/components/WorkspaceHeader.tsx
@@ -22,6 +22,7 @@ interface WorkspaceHeaderProps {
   workspaceDisplayMode?: WorkspaceDisplayMode;
   onWorkspaceDisplayModeChange?: (mode: WorkspaceDisplayMode) => void;
   showWorkspaceToggle?: boolean;
+  isReplayMode?: boolean;
 }
 
 export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
@@ -34,6 +35,7 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
   workspaceDisplayMode = 'interaction',
   onWorkspaceDisplayModeChange,
   showWorkspaceToggle = false,
+  isReplayMode = false,
 }) => {
   const { getToolIcon } = useTool();
   const workspaceNavItems = getWorkspaceNavItems();
@@ -106,7 +108,7 @@ export const WorkspaceHeader: React.FC<WorkspaceHeaderProps> = ({
 
       <div className="ml-4 flex-shrink-0 flex items-center gap-3">
         {/* Workspace navigation items */}
-        {workspaceNavItems.length > 0 && (
+        {!isReplayMode && workspaceNavItems.length > 0 && (
           <div className="flex items-center gap-2">
             {workspaceNavItems.map((navItem) => (
               <motion.button


### PR DESCRIPTION
## Summary

Hides workspace navigation items in replay mode to maintain consistent UI behavior. The `WorkspaceHeader` component now conditionally renders workspace navigation items only when not in replay mode, similar to how the sidebar is hidden.

**Changes:**
- Added `isReplayMode` prop to [`WorkspaceHeader`](https://github.com/bytedance/UI-TARS-desktop/blob/fix/hide-workspace-nav-in-replay-mode/multimodal/tarko/agent-web-ui/src/standalone/workspace/components/WorkspaceHeader.tsx) component
- Modified workspace navigation rendering logic to check `!isReplayMode` condition
- Updated [`WorkspaceDetail`](https://github.com/bytedance/UI-TARS-desktop/blob/fix/hide-workspace-nav-in-replay-mode/multimodal/tarko/agent-web-ui/src/standalone/workspace/WorkspaceDetail.tsx) to use `useReplayMode` hook and pass replay state to header

Close: #1349

## Checklist

- [x] My change does not involve the above items.