### PR TITLE
feat(tarko): unify think rendering with markdown renderer

### DIFF
--- a/multimodal/tarko/agent-web-ui/src/standalone/chat/Message/components/ThinkingToggle.tsx
+++ b/multimodal/tarko/agent-web-ui/src/standalone/chat/Message/components/ThinkingToggle.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { FiChevronDown, FiChevronRight } from 'react-icons/fi';
+import { FiChevronRight } from 'react-icons/fi';
+import { MarkdownRenderer } from '@/sdk/markdown-renderer';
 
 interface ThinkingToggleProps {
   thinking: string;
@@ -65,8 +66,8 @@ export const ThinkingToggle: React.FC<ThinkingToggleProps> = ({
             transition={{ duration: 0.3, ease: 'easeInOut' }}
             className="overflow-hidden"
           >
-            <div className="mt-3 ml-6 text-[15px] leading-relaxed text-gray-700 dark:text-gray-400">
-              <div className="whitespace-pre-wrap">{thinking}</div>
+            <div className="mt-3 ml-6 prose dark:prose-invert prose-sm max-w-none text-xs">
+              <MarkdownRenderer content={thinking} />
             </div>
           </motion.div>
         )}


### PR DESCRIPTION
## Summary

Unified Think rendering to use `MarkdownRenderer` instead of plain text, aligning with Message component styling and functionality.

### Before

<img width="3708" height="1516" alt="image" src="https://github.com/user-attachments/assets/d9f18bfa-9c86-4953-876f-548e27cee8bf" />

### After
<img width="3700" height="1652" alt="image" src="https://github.com/user-attachments/assets/3a5800f4-811b-4020-9255-835e30fab2fb" />


## Checklist

- [x] Added or updated necessary tests (Optional).
- [x] Updated documentation to align with changes (Optional).
- [x] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [ ] My change does not involve the above items.