### PR TITLE
fix(tarko): resolve event stream race condition in getEvents API

### DIFF
--- a/multimodal/omni-tars/gui-agent/src/GuiAgentPlugin.ts
+++ b/multimodal/omni-tars/gui-agent/src/GuiAgentPlugin.ts
@@ -78,9 +78,11 @@ export class GuiAgentPlugin extends AgentPlugin {
   // }
 
   async onEachAgentLoopEnd(): Promise<void> {
-    const events = this.agent.getEventStream().getEvents();
+    // Use getRecentEvents instead of getEvents to avoid race conditions with auto-trimming
+    // Check for tool calls in the last 30 seconds (default window)
+    const recentEvents = this.agent.getEventStream().getRecentEvents(30000, ['tool_call']);
     const lastToolCallIsComputerUse = this.findLastMatch<AgentEventStream.Event>(
-      events,
+      recentEvents,
       (item) => item.type === 'tool_call' && item.name === 'browser_vision_control',
     );
     if (!lastToolCallIsComputerUse) {

--- a/multimodal/tarko/agent-interface/src/agent-event-stream.ts
+++ b/multimodal/tarko/agent-interface/src/agent-event-stream.ts
@@ -640,6 +640,12 @@ export namespace AgentEventStream {
     getEventsByType(types: AgentEventStream.EventType[], limit?: number): AgentEventStream.Event[];
 
     /**
+     * Get recent events within a specific time window
+     * This is more reliable for checking recent activity as it's not affected by auto-trimming
+     */
+    getRecentEvents(timeWindowMs?: number, filter?: AgentEventStream.EventType[]): AgentEventStream.Event[];
+
+    /**
      * Subscribe to new events
      */
     subscribe(callback: (event: AgentEventStream.Event) => void): () => void;


### PR DESCRIPTION
## Summary

Resolves a race condition in `AgentEventStreamProcessor.getEvents()` that caused intermittent empty arrays in `GuiAgentPlugin`, preventing screenshot triggers.

**Root Cause**: The `autoTrim` feature in `sendEvent()` removes events when exceeding `maxEvents` (1000), interfering with concurrent `getEvents()` calls.

**Solution**:
- Modified auto-trimming to use conservative threshold (1.2x limit) 
- Added `getRecentEvents()` method for time-based event queries
- Updated `GuiAgentPlugin` to use `getRecentEvents()` for reliable tool call detection

**Files Changed**:
- `multimodal/tarko/agent/src/agent/event-stream.ts`
- `multimodal/tarko/agent-interface/src/agent-event-stream.ts` 
- `multimodal/omni-tars/gui-agent/src/GuiAgentPlugin.ts`

## Checklist

- [x] Added or updated necessary tests (Optional).
- [x] Updated documentation to align with changes (Optional).
- [x] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [ ] My change does not involve the above items.