### PR TITLE
fix(tarko): hide workspace panel on mobile layout

### DIFF
--- a/multimodal/tarko/agent-web-ui/src/standalone/app/Layout/index.tsx
+++ b/multimodal/tarko/agent-web-ui/src/standalone/app/Layout/index.tsx
@@ -71,17 +71,11 @@ export const Layout: React.FC<LayoutProps> = ({ isReplayMode: propIsReplayMode }
             </div>
           </div>
 
-          {/* Mobile layout: vertical split */}
+          {/* Mobile layout: chat only */}
           <div className="md:hidden flex flex-col gap-3 flex-1 min-h-0">
             <div className="flex-1 flex flex-col overflow-hidden min-h-0">
               <Shell className="h-full rounded-xl shadow-lg shadow-gray-200/50 dark:shadow-gray-950/20">
                 <ChatPanel />
-              </Shell>
-            </div>
-
-            <div className="flex-1 flex flex-col overflow-hidden min-h-0">
-              <Shell className="h-full rounded-xl shadow-lg shadow-gray-200/50 dark:shadow-gray-950/20">
-                <WorkspacePanel />
               </Shell>
             </div>
           </div>


### PR DESCRIPTION
## Summary

Hide `WorkspacePanel` on mobile devices to improve mobile layout readability. Previously mobile layout used vertical split showing both chat and workspace panels, which made reading difficult on small screens.

## Checklist

- [ ] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [x] My change does not involve the above items.