### PR TITLE
fix: prevent model API calls in replay mode

### DIFF
--- a/apps/ui-tars/src/renderer/src/api.ts
+++ b/apps/ui-tars/src/renderer/src/api.ts
@@ -5,6 +5,64 @@
 import { createClient } from '@ui-tars/electron-ipc/renderer';
 import type { Router } from '@main/ipcRoutes';
 
-export const api = createClient<Router>({
+// Check if we're in replay mode
+const isReplayMode = (): boolean => {
+  const urlParams = new URLSearchParams(window.location.search);
+  if (
+    urlParams.get('mode') === 'replay' ||
+    urlParams.get('replay') === 'true'
+  ) {
+    return true;
+  }
+
+  if (
+    window.location.hash.includes('replay') ||
+    window.location.href.includes('replay')
+  ) {
+    return true;
+  }
+
+  if (
+    document.querySelector('[data-replay-mode]') ||
+    document.body.classList.contains('replay-mode')
+  ) {
+    return true;
+  }
+
+  return false;
+};
+
+// Create the base API client
+const baseApi = createClient<Router>({
   ipcInvoke: window.electron.ipcRenderer.invoke,
+});
+
+// Model-related API methods that should be blocked in replay mode
+const modelApiMethods = [
+  'checkModelAvailability',
+  'checkVLMResponseApiSupport',
+  'getAvailableModels',
+];
+
+// Create a proxy to intercept API calls and block model-related calls in replay mode
+export const api = new Proxy(baseApi, {
+  get(target, prop, receiver) {
+    const value = Reflect.get(target, prop, receiver);
+
+    // If it's a model-related API method and we're in replay mode, return a rejected promise
+    if (
+      typeof prop === 'string' &&
+      modelApiMethods.includes(prop) &&
+      isReplayMode()
+    ) {
+      return () => {
+        console.warn(`[Replay Mode] Blocked API call: ${prop}`);
+        return Promise.reject(
+          new Error(`API call ${prop} is disabled in replay mode`),
+        );
+      };
+    }
+
+    return value;
+  },
 });


### PR DESCRIPTION
## Problem

When viewing shared content or operating in replay mode, the application incorrectly attempts to call model-related APIs like `getAvailableModels`, `checkModelAvailability`, and `checkVLMResponseApiSupport`. This results in `TypeError: Failed to fetch` errors because these APIs should not be available in replay contexts.

## Solution

This PR implements comprehensive protection against model API calls in replay mode:

### 1. **Replay Mode Detection**
- Added `isReplayMode()` function that detects replay context through:
  - URL parameters (`mode=replay` or `replay=true`)
  - URL hash containing "replay"
  - DOM elements with `data-replay-mode` attribute
  - Body class `replay-mode`

### 2. **Component-Level Protection**
- **VLM Settings Component**: Skip auto-save, model checking, and response API validation in replay mode
- **Model Availability Check**: Block manual model validation attempts with user-friendly message
- **Response API Toggle**: Prevent API calls when toggling response API support

### 3. **API-Level Protection**
- **Proxy Interceptor**: Automatically blocks model-related API calls at the API client level
- **Graceful Degradation**: Returns meaningful error messages instead of network failures
- **Console Warnings**: Logs blocked API calls for debugging

## Changes

- `apps/ui-tars/src/renderer/src/components/Settings/category/vlm.tsx`:
  - Add replay mode detection
  - Skip auto-save in replay mode
  - Block model checking and response API calls
  - Add user-friendly notifications

- `apps/ui-tars/src/renderer/src/api.ts`:
  - Add API-level proxy protection
  - Block `checkModelAvailability`, `checkVLMResponseApiSupport`, `getAvailableModels`
  - Provide meaningful error messages

## Testing

- ✅ Normal mode: All model API calls work as expected
- ✅ Replay mode: API calls are blocked with appropriate messages
- ✅ User experience: No network errors, clear feedback to users
- ✅ Lint checks: All secretlint and prettier checks pass

## Impact

- **Fixes**: TypeError: Failed to fetch in replay mode
- **Improves**: User experience in shared/replay contexts
- **Maintains**: Full functionality in normal operation mode
- **Adds**: Robust protection against inappropriate API calls