### PR TITLE
feat(tarko): add model id tooltip to navbar

### DIFF
--- a/multimodal/tarko/agent-web-ui/src/standalone/navbar/ModelSelector.tsx
+++ b/multimodal/tarko/agent-web-ui/src/standalone/navbar/ModelSelector.tsx
@@ -10,7 +10,9 @@ import {
   CircularProgress,
   createTheme,
   ThemeProvider,
+  Tooltip,
 } from '@mui/material';
+import { getTooltipProps } from '@/common/components/TooltipConfig';
 
 interface ModelConfig {
   provider: string;
@@ -198,79 +200,88 @@ export const NavbarModelSelector: React.FC<NavbarModelSelectorProps> = ({
       return null;
     }
 
+    const tooltipContent = sessionMetadata?.modelConfig?.modelId
+      ? `Model ID: ${sessionMetadata.modelConfig.modelId}`
+      : '';
+
     return (
       <ThemeProvider theme={muiTheme}>
-        <motion.div whileHover={{ scale: 1.02 }} className={className}>
-          <Box
-            sx={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 0.75,
-              px: 1.25,
-              py: 0.375,
-              height: '28px',
-              minHeight: '28px',
-              background: isDarkMode ? 'rgba(55, 65, 81, 0.3)' : 'rgba(248, 250, 252, 0.8)',
-              backdropFilter: 'blur(8px)',
-              border: isDarkMode
-                ? '1px solid rgba(75, 85, 99, 0.3)'
-                : '1px solid rgba(203, 213, 225, 0.6)',
-              borderRadius: '8px',
-              // maxWidth: '220px',
-              '&:hover': {
-                background: isDarkMode ? 'rgba(55, 65, 81, 0.8)' : 'rgba(241, 245, 249, 0.9)',
-                boxShadow: isDarkMode
-                  ? '0 2px 4px -1px rgba(0, 0, 0, 0.2)'
-                  : '0 2px 4px -1px rgba(0, 0, 0, 0.05)',
-              },
-            }}
-          >
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, minWidth: 0 }}>
-              {sessionMetadata?.modelConfig?.modelId && (
-                <Typography
-                  variant="body2"
-                  sx={{
-                    fontWeight: 500,
-                    fontSize: '12px',
-                    color: isDarkMode ? '#f3f4f6' : '#374151',
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis',
-                    whiteSpace: 'nowrap',
-                  }}
-                  title={getModelDisplayName(sessionMetadata.modelConfig)}
-                >
-                  {getModelDisplayName(sessionMetadata.modelConfig)}
-                </Typography>
-              )}
-              {sessionMetadata?.modelConfig?.provider && sessionMetadata?.modelConfig?.modelId && (
-                <Typography
-                  variant="body2"
-                  sx={{
-                    color: isDarkMode ? '#9ca3af' : '#6b7280',
-                    fontSize: '12px',
-                    flexShrink: 0,
-                  }}
-                >
-                  •
-                </Typography>
-              )}
-              {sessionMetadata?.modelConfig?.provider && (
-                <Typography
-                  variant="body2"
-                  sx={{
-                    fontWeight: 500,
-                    fontSize: '12px',
-                    color: isDarkMode ? '#d1d5db' : '#6b7280',
-                    whiteSpace: 'nowrap',
-                  }}
-                  title={sessionMetadata.modelConfig.provider}
-                >
-                  {sessionMetadata.modelConfig.provider}
-                </Typography>
-              )}
+        <Tooltip
+          {...getTooltipProps('bottom')}
+          title={tooltipContent}
+          disableHoverListener={!tooltipContent}
+        >
+          <motion.div whileHover={{ scale: 1.02 }} className={className}>
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 0.75,
+                px: 1.25,
+                py: 0.375,
+                height: '28px',
+                minHeight: '28px',
+                background: isDarkMode ? 'rgba(55, 65, 81, 0.3)' : 'rgba(248, 250, 252, 0.8)',
+                backdropFilter: 'blur(8px)',
+                border: isDarkMode
+                  ? '1px solid rgba(75, 85, 99, 0.3)'
+                  : '1px solid rgba(203, 213, 225, 0.6)',
+                borderRadius: '8px',
+                // maxWidth: '220px',
+                '&:hover': {
+                  background: isDarkMode ? 'rgba(55, 65, 81, 0.8)' : 'rgba(241, 245, 249, 0.9)',
+                  boxShadow: isDarkMode
+                    ? '0 2px 4px -1px rgba(0, 0, 0, 0.2)'
+                    : '0 2px 4px -1px rgba(0, 0, 0, 0.05)',
+                },
+              }}
+            >
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, minWidth: 0 }}>
+                {sessionMetadata?.modelConfig?.modelId && (
+                  <Typography
+                    variant="body2"
+                    sx={{
+                      fontWeight: 500,
+                      fontSize: '12px',
+                      color: isDarkMode ? '#f3f4f6' : '#374151',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    {getModelDisplayName(sessionMetadata.modelConfig)}
+                  </Typography>
+                )}
+                {sessionMetadata?.modelConfig?.provider &&
+                  sessionMetadata?.modelConfig?.modelId && (
+                    <Typography
+                      variant="body2"
+                      sx={{
+                        color: isDarkMode ? '#9ca3af' : '#6b7280',
+                        fontSize: '12px',
+                        flexShrink: 0,
+                      }}
+                    >
+                      •
+                    </Typography>
+                  )}
+                {sessionMetadata?.modelConfig?.provider && (
+                  <Typography
+                    variant="body2"
+                    sx={{
+                      fontWeight: 500,
+                      fontSize: '12px',
+                      color: isDarkMode ? '#d1d5db' : '#6b7280',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    {sessionMetadata.modelConfig.provider}
+                  </Typography>
+                )}
+              </Box>
             </Box>
-          </Box>
-        </motion.div>
+          </motion.div>
+        </Tooltip>
       </ThemeProvider>
     );
   }
@@ -388,121 +399,134 @@ export const NavbarModelSelector: React.FC<NavbarModelSelectorProps> = ({
     );
   };
 
+  const currentOption = allModelOptions.find((opt) => opt.value === currentModel);
+  const dropdownTooltipContent = currentOption?.modelId ? `Model ID: ${currentOption.modelId}` : '';
+
   return (
     <ThemeProvider theme={muiTheme}>
-      <motion.div whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }} className={className}>
-        <FormControl size="small">
-          <Select
-            value={currentModel}
-            onChange={(event) => handleModelChange(event.target.value)}
-            disabled={isLoading}
-            displayEmpty
-            renderValue={renderValue}
-            size="small"
-            MenuProps={{
-              PaperProps: {
-                style: {
-                  maxHeight: 360,
-                  marginTop: 8,
-                  zIndex: 9999,
-                },
-                sx: {
-                  '@keyframes menuSlideIn': {
-                    '0%': {
-                      opacity: 0,
-                      transform: 'translateY(-8px) scale(0.95)',
-                    },
-                    '100%': {
-                      opacity: 1,
-                      transform: 'translateY(0) scale(1)',
+      <Tooltip
+        {...getTooltipProps('bottom')}
+        title={dropdownTooltipContent}
+        disableHoverListener={!dropdownTooltipContent}
+      >
+        <motion.div whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }} className={className}>
+          <FormControl size="small">
+            <Select
+              value={currentModel}
+              onChange={(event) => handleModelChange(event.target.value)}
+              disabled={isLoading}
+              displayEmpty
+              renderValue={renderValue}
+              size="small"
+              MenuProps={{
+                PaperProps: {
+                  style: {
+                    maxHeight: 360,
+                    marginTop: 8,
+                    zIndex: 9999,
+                  },
+                  sx: {
+                    '@keyframes menuSlideIn': {
+                      '0%': {
+                        opacity: 0,
+                        transform: 'translateY(-8px) scale(0.95)',
+                      },
+                      '100%': {
+                        opacity: 1,
+                        transform: 'translateY(0) scale(1)',
+                      },
                     },
                   },
                 },
-              },
-              anchorOrigin: {
-                vertical: 'bottom',
-                horizontal: 'left',
-              },
-              transformOrigin: {
-                vertical: 'top',
-                horizontal: 'left',
-              },
-              disablePortal: false,
-              TransitionProps: {
-                timeout: 200,
-              },
-            }}
-            sx={{
-              maxWidth: 360,
-            }}
-          >
-            {allModelOptions.map((option, idx) => {
-              return (
-                <MenuItem key={`model-${idx}`} value={option.value}>
-                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, width: '100%' }}>
-                    <Box
-                      sx={{ display: 'flex', alignItems: 'center', gap: 0.5, minWidth: 0, flex: 1 }}
-                    >
-                      <Typography
-                        variant="body2"
+                anchorOrigin: {
+                  vertical: 'bottom',
+                  horizontal: 'left',
+                },
+                transformOrigin: {
+                  vertical: 'top',
+                  horizontal: 'left',
+                },
+                disablePortal: false,
+                TransitionProps: {
+                  timeout: 200,
+                },
+              }}
+              sx={{
+                maxWidth: 360,
+              }}
+            >
+              {allModelOptions.map((option, idx) => {
+                return (
+                  <MenuItem key={`model-${idx}`} value={option.value}>
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, width: '100%' }}>
+                      <Box
                         sx={{
-                          fontWeight: currentModel === option.value ? 600 : 500,
-                          fontSize: '14px',
-                          color:
-                            currentModel === option.value
-                              ? isDarkMode
-                                ? '#a5b4fc'
-                                : '#6366f1'
-                              : isDarkMode
-                                ? '#f3f4f6'
-                                : '#374151',
-                          overflow: 'hidden',
-                          textOverflow: 'ellipsis',
-                          whiteSpace: 'nowrap',
-                        }}
-                        title={option.modelId}
-                      >
-                        {option.modelId}
-                      </Typography>
-                      <Typography
-                        variant="body2"
-                        sx={{
-                          color: isDarkMode ? '#9ca3af' : '#6b7280',
-                          fontSize: '14px',
-                          flexShrink: 0,
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: 0.5,
+                          minWidth: 0,
+                          flex: 1,
                         }}
                       >
-                        •
-                      </Typography>
-                      <Typography
-                        variant="body2"
-                        sx={{
-                          fontWeight: currentModel === option.value ? 600 : 500,
-                          fontSize: '13px',
-                          color:
-                            currentModel === option.value
-                              ? isDarkMode
-                                ? '#a5b4fc'
-                                : '#6366f1'
-                              : isDarkMode
-                                ? '#d1d5db'
-                                : '#6b7280',
-                          overflow: 'hidden',
-                          textOverflow: 'ellipsis',
-                          whiteSpace: 'nowrap',
-                        }}
-                        title={option.provider}
-                      >
-                        {option.provider}
-                      </Typography>
+                        <Typography
+                          variant="body2"
+                          sx={{
+                            fontWeight: currentModel === option.value ? 600 : 500,
+                            fontSize: '14px',
+                            color:
+                              currentModel === option.value
+                                ? isDarkMode
+                                  ? '#a5b4fc'
+                                  : '#6366f1'
+                                : isDarkMode
+                                  ? '#f3f4f6'
+                                  : '#374151',
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap',
+                          }}
+                        >
+                          {option.modelId}
+                        </Typography>
+                        <Typography
+                          variant="body2"
+                          sx={{
+                            color: isDarkMode ? '#9ca3af' : '#6b7280',
+                            fontSize: '14px',
+                            flexShrink: 0,
+                          }}
+                        >
+                          •
+                        </Typography>
+                        <Typography
+                          variant="body2"
+                          sx={{
+                            fontWeight: currentModel === option.value ? 600 : 500,
+                            fontSize: '13px',
+                            color:
+                              currentModel === option.value
+                                ? isDarkMode
+                                  ? '#a5b4fc'
+                                  : '#6366f1'
+                                : isDarkMode
+                                  ? '#d1d5db'
+                                  : '#6b7280',
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap',
+                          }}
+                        >
+                          {option.provider}
+                        </Typography>
+                      </Box>
                     </Box>
-                  </Box>
-                </MenuItem>
-              );
-            })}
-          </Select>
-        </FormControl>
-      </motion.div>
+                  </MenuItem>
+                );
+              })}
+            </Select>
+          </FormControl>
+        </motion.div>
+      </Tooltip>
     </ThemeProvider>
   );
 };


### PR DESCRIPTION
## Summary

Added hover tooltip functionality to the Navbar's Model ID display using the unified `getTooltipProps` configuration from PR #1300.

When hovering over the model selector in the navbar, users now see a tooltip showing "Model ID: [actual-model-id]" for better visibility of the full model identifier.

<img width="2752" height="1216" alt="image" src="https://github.com/user-attachments/assets/d8195f70-16a1-4106-aa7a-e9cc28146d56" />



## Checklist  

- [ ] Added or updated necessary tests (Optional).  
- [ ] Updated documentation to align with changes (Optional).  
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).  
- [x] My change does not involve the above items.