### PR TITLE
fix(tarko): image data missing in workspace

### DIFF
--- a/multimodal/tarko/agent-web-ui/src/standalone/workspace/renderers/ImageRenderer.tsx
+++ b/multimodal/tarko/agent-web-ui/src/standalone/workspace/renderers/ImageRenderer.tsx
@@ -158,8 +158,16 @@ function extractImageData(panelContent: StandardPanelContent): {
       }
     }
 
-    // Check if source is a data URL or direct URL
-    // Handle cases like: { "type": "image", "source": "data:image/webp;base64,UklGRvgpAA...", "title": "Image", "timestamp": 1756996184111 }
+    /**
+     * Check if source is a data URL or direct URL
+     * Handle cases like:
+     * {
+     *   "type": "image",
+     *   "source": "data:image/webp;base64,UklGRvgpAA...",
+     *   "title": "Image",
+     *   "timestamp": 1756996184111
+     * }
+     */
     if (typeof panelContent.source === 'string') {
       if (panelContent.source.startsWith('data:')) {
         // Extract MIME type from data URL


### PR DESCRIPTION
## Summary

Fixed `ImageRenderer` to properly handle data URLs in `panelContent.source` field, resolving "Image data missing" error in workspace when users paste images.

The issue occurred because `extractImageData` function didn't handle the case where `panelContent.source` contains a complete data URL like `data:image/webp;base64,...`. Added proper data URL detection and MIME type extraction.

### Before

<img width="4400" height="2622" alt="image" src="https://github.com/user-attachments/assets/ef6cdec1-9d11-4783-84fa-f35b48a69a68" />

### After

<img width="4400" height="2614" alt="image" src="https://github.com/user-attachments/assets/88127ddf-91fd-4c56-b652-fec87bfd4f82" />


## Checklist

- [x] My change does not involve the above items.