### PR TITLE
feat(tarko): implement immediate user message rendering with deduplication

### DIFF
--- a/multimodal/tarko/agent-web-ui/src/common/state/actions/eventProcessors/handlers/MessageHandler.ts
+++ b/multimodal/tarko/agent-web-ui/src/common/state/actions/eventProcessors/handlers/MessageHandler.ts
@@ -3,7 +3,10 @@ import { EventHandler, EventHandlerContext } from '../types';
 import { AgentEventStream, Message } from '@/common/types';
 import { messagesAtom } from '@/common/state/atoms/message';
 import { sessionPanelContentAtom, sessionAgentStatusAtom } from '@/common/state/atoms/ui';
-import { shouldUpdatePanelContent, shouldUpdateProcessingState } from '../utils/panelContentUpdater';
+import {
+  shouldUpdatePanelContent,
+  shouldUpdateProcessingState,
+} from '../utils/panelContentUpdater';
 
 // Constants for thinking message newline trimming performance
 const LEADING_NEWLINES_REGEX = /^\n+/;
@@ -30,9 +33,15 @@ export class UserMessageHandler implements EventHandler<AgentEventStream.UserMes
 
     set(messagesAtom, (prev: Record<string, Message[]>) => {
       const sessionMessages = prev[sessionId] || [];
+
+      // Remove any temporary user messages to prevent duplicates
+      const filteredMessages = sessionMessages.filter(
+        (msg) => !(msg.role === 'user' && msg.isTemporary),
+      );
+
       return {
         ...prev,
-        [sessionId]: [...sessionMessages, userMessage],
+        [sessionId]: [...filteredMessages, userMessage],
       };
     });
 

--- a/multimodal/tarko/agent-web-ui/src/common/types/index.ts
+++ b/multimodal/tarko/agent-web-ui/src/common/types/index.ts
@@ -46,6 +46,7 @@ export interface Message {
   title?: string; // Added for research report title
   ttftMs?: number; // Time to First Token (TTFT) in milliseconds
   ttltMs?: number; // Total response time in milliseconds
+  isTemporary?: boolean; // Mark temporary messages for deduplication
 
   // System message specific properties
   level?: 'info' | 'warning' | 'error';

--- a/multimodal/tarko/agent-web-ui/src/standalone/chat/ChatPanel.tsx
+++ b/multimodal/tarko/agent-web-ui/src/standalone/chat/ChatPanel.tsx
@@ -68,18 +68,10 @@ export const ChatPanel: React.FC = () => {
 
   const researchReport = findResearchReport();
 
-  // Determine UI state
-  const shouldShowEmptyState = () => {
-    if (!currentSessionId || currentSessionId === 'creating') return false;
-    if (activeMessages.length > 0) return false;
-    if (isReplayMode && replayState.events.length > 0 && replayState.currentEventIndex === -1) {
-      return true;
-    }
-    return true;
-  };
-
-  const showEmptyState = shouldShowEmptyState();
+  // Simplified state logic
   const isCreatingSession = !currentSessionId || currentSessionId === 'creating';
+  const hasMessages = activeMessages.length > 0;
+  const showEmptyState = !isCreatingSession && !hasMessages;
 
   // Render session creating state
   if (isCreatingSession) {
@@ -98,8 +90,6 @@ export const ChatPanel: React.FC = () => {
           isReplayMode={isReplayMode}
           onReconnect={checkServerStatus}
         />
-
-
 
         {showEmptyState ? (
           <EmptyState replayState={replayState} isReplayMode={isReplayMode} />


### PR DESCRIPTION
## Summary

Refactors chat state management to fix user message rendering delays and simplify state logic.

**Problem**: User messages only appeared after server `user_message` event, causing delays and persistent EmptyState.

**Solution**: Immediate user message rendering with server-side deduplication using `isTemporary` flag.

**Changes**:
- Add `isTemporary` field to `Message` type for deduplication
- Update `UserMessageHandler` to filter temporary messages when server event arrives
- Simplify `ChatPanel` state logic by removing complex `shouldShowEmptyState` function
- Update `sendMessageAction` to immediately add user messages to state

**Result**: Better UX with instant message feedback while maintaining data consistency.

## Checklist

- [x] My change does not involve the above items.