### PR TITLE
fix(tarko): prevent frequent api/v1/models calls by memoizing callbacks

### DIFF
--- a/multimodal/tarko/agent-web-ui/src/standalone/navbar/Navbar.tsx
+++ b/multimodal/tarko/agent-web-ui/src/standalone/navbar/Navbar.tsx
@@ -314,10 +314,12 @@ const DynamicNavbarCenter: React.FC<DynamicNavbarCenterProps> = ({
           activeSessionId={activeSessionId}
           sessionMetadata={sessionMetadata}
           isDarkMode={isDarkMode}
-          onLoadModels={() => apiService.getAvailableModels()}
-          onUpdateModel={(sessionId, provider, modelId) =>
-            apiService.updateSessionModel(sessionId, provider, modelId)
-          }
+          onLoadModels={useCallback(() => apiService.getAvailableModels(), [])}
+          onUpdateModel={useCallback(
+            (sessionId, provider, modelId) =>
+              apiService.updateSessionModel(sessionId, provider, modelId),
+            [],
+          )}
         />
       </div>
     </div>


### PR DESCRIPTION
## Summary

Fixed frequent API calls to `api/v1/models` during SSE responses by memoizing callback functions in `NavbarModelSelector`. The issue was caused by creating new function references on every render, triggering unnecessary re-renders and API calls.

**Root cause**: Arrow functions `() => apiService.getAvailableModels()` and `(sessionId, provider, modelId) => apiService.updateSessionModel(sessionId, provider, modelId)` were being created on every render, causing the `useEffect` dependency array to trigger repeatedly.

**Solution**: Wrapped both callbacks with `useCallback` to maintain stable function references.

## Checklist

- [ ] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [x] My change does not involve the above items.