### PR TITLE
refactor(tarko): simplify screenshot display state management

### DIFF
--- a/multimodal/omni-tars/omni-agent/src/index.ts
+++ b/multimodal/omni-tars/omni-agent/src/index.ts
@@ -58,8 +58,8 @@ export default class OmniTARSAgent extends ComposableAgent {
     },
     guiAgent: {
       defaultScreenshotRenderStrategy: 'afterAction',
-      enableScreenshotRenderStrategySwitch: false,
-      renderGUIAction: false,
+      enableScreenshotRenderStrategySwitch: true,
+      renderGUIAction: true,
     },
     layout: {
       enableLayoutSwitchButton: true,


### PR DESCRIPTION
## Summary

Simplify `ScreenshotDisplay` state management and improve fallback logic for `afterAction` strategy. Replace complex `useState` with `useMemo` for better performance and cleaner code.

**Key Changes:**
- Replace `useState` with `useMemo` in `useScreenshots` hook for better performance
- Simplify screenshot fallback logic - when `afterActionImage` is not available in `afterAction` strategy, automatically fallback to `beforeActionImage`
- Remove redundant state management and complex effect dependencies
- Improve mouse cursor display logic
- Better error handling and logging

## Checklist

- [x] Added or updated necessary tests (Optional).
- [x] Updated documentation to align with changes (Optional).
- [x] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [ ] My change does not involve the above items.