### PR TITLE
feat(tarko): auto-append `replay=1` to share URLs

### DIFF
--- a/multimodal/tarko/agent-server/src/utils/share.ts
+++ b/multimodal/tarko/agent-server/src/utils/share.ts
@@ -209,9 +209,11 @@ export class ShareUtils {
 
       const responseData = await response.json();
 
-      // Return share URL
+      // Return share URL with replay parameter
       if (responseData && responseData.url) {
-        return responseData.url;
+        const url = new URL(responseData.url);
+        url.searchParams.set('replay', '1');
+        return url.toString();
       }
 
       throw new Error('Invalid response from share provider');


### PR DESCRIPTION
## Summary

Automatically append `?replay=1` parameter to share URLs in `ShareService.uploadShareHtml()` method.

This ensures that shared links automatically enable replay mode when accessed, improving user experience by directly showing the shared session content.

## Checklist

- [ ] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [x] My change does not involve the above items.