### PR TITLE
feat(tarko): defaults background to white for html renderer

### DIFF
--- a/multimodal/tarko/agent-web-ui/src/standalone/workspace/components/FullscreenModal.tsx
+++ b/multimodal/tarko/agent-web-ui/src/standalone/workspace/components/FullscreenModal.tsx
@@ -81,12 +81,13 @@ export const FullscreenModal: React.FC<FullscreenModalProps> = ({ data, onClose 
         {/* Content */}
         <div className="flex-1 overflow-auto">
           {isHtmlFile && data.displayMode === 'rendered' ? (
-            <div className="h-full">
+            <div className="h-full bg-white">
               <iframe
                 srcDoc={data.content}
                 className="w-full h-full border-0"
                 title="HTML Preview"
                 sandbox="allow-scripts allow-same-origin"
+                style={{ backgroundColor: 'white' }}
               />
             </div>
           ) : (

--- a/multimodal/tarko/agent-web-ui/src/standalone/workspace/components/ThrottledHtmlRenderer.tsx
+++ b/multimodal/tarko/agent-web-ui/src/standalone/workspace/components/ThrottledHtmlRenderer.tsx
@@ -85,6 +85,11 @@ export const ThrottledHtmlRenderer: React.FC<ThrottledHtmlRendererProps> = ({
         iframeDoc.write(stableContent);
         iframeDoc.close();
 
+        // Ensure white background for HTML content
+        if (iframeDoc.body) {
+          iframeDoc.body.style.backgroundColor = 'white';
+        }
+
         setLastRenderedContent(stableContent);
       } catch (error) {
         console.warn('Failed to update iframe content:', error);
@@ -121,7 +126,7 @@ export const ThrottledHtmlRenderer: React.FC<ThrottledHtmlRendererProps> = ({
 
   return (
     <div
-      className={`border border-gray-200/50 dark:border-gray-700/30 rounded-lg overflow-hidden bg-white dark:bg-gray-900/30 ${className}`}
+      className={`border border-gray-200/50 dark:border-gray-700/30 rounded-lg overflow-hidden bg-white ${className}`}
     >
       <iframe
         ref={iframeRef}


### PR DESCRIPTION
## Summary

Set default white background for HTML rendering mode to ensure proper display of model-generated HTML content.

### Before

<img width="4400" height="2618" alt="image" src="https://github.com/user-attachments/assets/e44b2596-498d-4cc8-840e-4a57aa07a749" />


### After

<img width="4400" height="2612" alt="image" src="https://github.com/user-attachments/assets/62be11b3-092b-42dd-bc69-71317b698498" />




## Checklist

- [ ] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [x] My change does not involve the above items.