### PR TITLE
fix(tarko): scroll-to-bottom indicator session switching and edge cases

### DIFF
--- a/multimodal/tarko/agent-web-ui/src/standalone/chat/ChatPanel.tsx
+++ b/multimodal/tarko/agent-web-ui/src/standalone/chat/ChatPanel.tsx
@@ -44,6 +44,7 @@ export const ChatPanel: React.FC = () => {
     useScrollToBottom({
       threshold: 50,
       dependencies: [activeMessages],
+      sessionId: currentSessionId,
     });
 
   // Find research report in session

--- a/multimodal/tarko/agent-web-ui/src/standalone/chat/hooks/useScrollToBottom.ts
+++ b/multimodal/tarko/agent-web-ui/src/standalone/chat/hooks/useScrollToBottom.ts
@@ -2,10 +2,12 @@ import { useRef, useEffect, useState, useCallback } from 'react';
 
 // Constants
 const SCROLL_CHECK_DELAY = 100; // ms - delay for DOM updates
+const SCROLL_ANIMATION_DELAY = 300; // ms - delay to account for smooth scroll animation
 
 interface UseScrollToBottomOptions {
   threshold?: number; // Distance from bottom to consider "at bottom"
   dependencies?: React.DependencyList; // Dependencies to trigger re-check (e.g., messages)
+  sessionId?: string; // Session ID to reset state on session change
 }
 
 interface UseScrollToBottomReturn {
@@ -21,15 +23,19 @@ interface UseScrollToBottomReturn {
  * Features:
  * - Shows scroll-to-bottom indicator when user has scrolled up
  * - Manual scroll to bottom functionality
+ * - Properly handles session switching
  * - No automatic scrolling behavior
  */
 export const useScrollToBottom = ({
   threshold = 100,
   dependencies = [],
+  sessionId,
 }: UseScrollToBottomOptions = {}): UseScrollToBottomReturn => {
   const messagesContainerRef = useRef<HTMLDivElement>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const [showScrollToBottom, setShowScrollToBottom] = useState(false);
+  const isScrollingRef = useRef(false);
+  const lastSessionIdRef = useRef<string | undefined>(sessionId);
 
   // Check if container is at bottom
   const checkIsAtBottom = useCallback(() => {
@@ -37,7 +43,10 @@ export const useScrollToBottom = ({
     if (!container) return false;
     
     const { scrollTop, scrollHeight, clientHeight } = container;
-    return scrollHeight - scrollTop - clientHeight <= threshold;
+    const distanceFromBottom = scrollHeight - scrollTop - clientHeight;
+    
+    // Account for sub-pixel differences and rounding errors
+    return distanceFromBottom <= Math.max(threshold, 1);
   }, [threshold]);
 
   // Smooth scroll to bottom
@@ -45,11 +54,22 @@ export const useScrollToBottom = ({
     const container = messagesContainerRef.current;
     if (!container) return;
     
+    isScrollingRef.current = true;
+    
     container.scrollTo({
       top: container.scrollHeight,
       behavior: 'smooth'
     });
-  }, []);
+    
+    // Reset scrolling flag after animation completes
+    setTimeout(() => {
+      isScrollingRef.current = false;
+      // Force a scroll check after animation to ensure correct state
+      setTimeout(() => {
+        handleScroll();
+      }, SCROLL_CHECK_DELAY);
+    }, SCROLL_ANIMATION_DELAY);
+  }, [handleScroll]);
 
   // Handle scroll events
   const handleScroll = useCallback(() => {
@@ -58,10 +78,15 @@ export const useScrollToBottom = ({
     
     const { scrollTop, scrollHeight, clientHeight } = container;
     const distanceFromBottom = scrollHeight - scrollTop - clientHeight;
-    const atBottom = distanceFromBottom <= threshold;
+    const atBottom = distanceFromBottom <= Math.max(threshold, 1);
     
-    // Show button when NOT at bottom and there's content to scroll
-    const shouldShow = !atBottom && scrollHeight > clientHeight;
+    // Only show button when:
+    // 1. NOT at bottom
+    // 2. There's scrollable content (scrollHeight > clientHeight)
+    // 3. Not currently programmatically scrolling
+    const hasScrollableContent = scrollHeight > clientHeight + 10; // Add small buffer
+    const shouldShow = !atBottom && hasScrollableContent && !isScrollingRef.current;
+    
     setShowScrollToBottom(shouldShow);
   }, [threshold]);
 
@@ -72,6 +97,22 @@ export const useScrollToBottom = ({
     }, SCROLL_CHECK_DELAY);
     return timer;
   }, [handleScroll]);
+
+  // Reset state when session changes
+  useEffect(() => {
+    if (sessionId !== lastSessionIdRef.current) {
+      lastSessionIdRef.current = sessionId;
+      setShowScrollToBottom(false);
+      isScrollingRef.current = false;
+      
+      // Schedule a check after session content loads
+      const timer = setTimeout(() => {
+        handleScroll();
+      }, SCROLL_CHECK_DELAY * 2);
+      
+      return () => clearTimeout(timer);
+    }
+  }, [sessionId, handleScroll]);
 
   // Set up scroll event listener
   useEffect(() => {


### PR DESCRIPTION
## Summary

Fixes scroll-to-bottom indicator issues introduced in #1402 where:
1. Switching sessions shows indicator when content is at bottom
2. Indicator persists when already scrolled to bottom

**Root Causes**:
- No state reset when switching sessions
- Edge cases in scroll detection logic
- Race conditions between programmatic scrolling and state updates

**Solution**:
- Added `sessionId` tracking to reset state on session changes
- Improved scroll detection with better threshold handling and sub-pixel accuracy
- Added programmatic scrolling flag to prevent indicator during smooth scroll
- Enhanced scrollable content detection with buffer

**Changes**:
- Updated `useScrollToBottom` hook with session-aware state management
- Passed `currentSessionId` from `ChatPanel` to enable session change detection
- Fixed circular dependency in scroll check scheduling

## Checklist

- [ ] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [x] My change does not involve the above items.