### PR TITLE
feat(tarko): auto-scroll for replay position changes

### DIFF
--- a/multimodal/tarko/agent-web-ui/src/standalone/chat/ChatPanel.tsx
+++ b/multimodal/tarko/agent-web-ui/src/standalone/chat/ChatPanel.tsx
@@ -45,6 +45,7 @@ export const ChatPanel: React.FC = () => {
       threshold: 50,
       dependencies: [activeMessages],
       sessionId: currentSessionId,
+      isReplayMode,
     });
 
   // Find research report in session

--- a/multimodal/tarko/agent-web-ui/src/standalone/chat/hooks/useScrollToBottom.ts
+++ b/multimodal/tarko/agent-web-ui/src/standalone/chat/hooks/useScrollToBottom.ts
@@ -5,7 +5,7 @@ import { replayStateAtom } from '@/common/state/atoms/replay';
 // Constants
 const SCROLL_CHECK_DELAY = 100; // ms - delay for DOM updates
 const SCROLL_ANIMATION_DELAY = 300; // ms - delay to account for smooth scroll animation
-const REPLAY_AUTO_SCROLL_DELAY = 200; // ms - delay for auto-scroll in replay mode
+const REPLAY_AUTO_SCROLL_DELAY = 50; // ms - delay for auto-scroll in replay mode
 
 interface UseScrollToBottomOptions {
   threshold?: number; // Distance from bottom to consider "at bottom"

--- a/multimodal/tarko/agent-web-ui/src/standalone/chat/hooks/useScrollToBottom.ts
+++ b/multimodal/tarko/agent-web-ui/src/standalone/chat/hooks/useScrollToBottom.ts
@@ -1,13 +1,17 @@
 import { useRef, useEffect, useState, useCallback } from 'react';
+import { useAtomValue } from 'jotai';
+import { replayStateAtom } from '@/common/state/atoms/replay';
 
 // Constants
 const SCROLL_CHECK_DELAY = 100; // ms - delay for DOM updates
 const SCROLL_ANIMATION_DELAY = 300; // ms - delay to account for smooth scroll animation
+const REPLAY_AUTO_SCROLL_DELAY = 200; // ms - delay for auto-scroll in replay mode
 
 interface UseScrollToBottomOptions {
   threshold?: number; // Distance from bottom to consider "at bottom"
   dependencies?: React.DependencyList; // Dependencies to trigger re-check (e.g., messages)
   sessionId?: string; // Session ID to reset state on session change
+  isReplayMode?: boolean; // Whether we're in replay mode
 }
 
 interface UseScrollToBottomReturn {
@@ -24,18 +28,21 @@ interface UseScrollToBottomReturn {
  * - Shows scroll-to-bottom indicator when user has scrolled up
  * - Manual scroll to bottom functionality
  * - Properly handles session switching
- * - No automatic scrolling behavior
+ * - Auto-scroll behavior ONLY in replay mode
  */
 export const useScrollToBottom = ({
   threshold = 100,
   dependencies = [],
   sessionId,
+  isReplayMode = false,
 }: UseScrollToBottomOptions = {}): UseScrollToBottomReturn => {
   const messagesContainerRef = useRef<HTMLDivElement>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const [showScrollToBottom, setShowScrollToBottom] = useState(false);
   const isScrollingRef = useRef(false);
   const lastSessionIdRef = useRef<string | undefined>(sessionId);
+  const replayState = useAtomValue(replayStateAtom);
+  const lastEventIndexRef = useRef<number>(-1);
 
   // Check if container is at bottom
   const checkIsAtBottom = useCallback(() => {
@@ -88,7 +95,25 @@ export const useScrollToBottom = ({
       // Hide button immediately when reaching bottom after scroll
       setShowScrollToBottom(false);
     }, SCROLL_ANIMATION_DELAY);
-  }, [threshold]);
+  }, []);
+
+  // Auto-scroll to bottom for replay mode
+  const autoScrollToBottom = useCallback(() => {
+    const container = messagesContainerRef.current;
+    if (!container) return;
+    
+    isScrollingRef.current = true;
+    
+    container.scrollTo({
+      top: container.scrollHeight,
+      behavior: 'smooth'
+    });
+    
+    // Reset scrolling flag after animation completes
+    setTimeout(() => {
+      isScrollingRef.current = false;
+    }, SCROLL_ANIMATION_DELAY);
+  }, []);
 
   // Delayed scroll check helper
   const scheduleScrollCheck = useCallback(() => {
@@ -135,6 +160,26 @@ export const useScrollToBottom = ({
     const timer = scheduleScrollCheck();
     return () => clearTimeout(timer);
   }, [scheduleScrollCheck, ...dependencies]);
+
+  // Auto-scroll in replay mode when new events are processed
+  useEffect(() => {
+    if (!isReplayMode || !replayState.isActive) {
+      lastEventIndexRef.current = -1;
+      return;
+    }
+
+    // Only auto-scroll when a new event is processed (index increases)
+    if (replayState.currentEventIndex > lastEventIndexRef.current) {
+      lastEventIndexRef.current = replayState.currentEventIndex;
+      
+      // Schedule auto-scroll after DOM updates
+      const timer = setTimeout(() => {
+        autoScrollToBottom();
+      }, REPLAY_AUTO_SCROLL_DELAY);
+      
+      return () => clearTimeout(timer);
+    }
+  }, [isReplayMode, replayState.isActive, replayState.currentEventIndex, autoScrollToBottom]);
 
   return {
     messagesContainerRef,

--- a/multimodal/tarko/agent-web-ui/src/standalone/chat/hooks/useScrollToBottom.ts
+++ b/multimodal/tarko/agent-web-ui/src/standalone/chat/hooks/useScrollToBottom.ts
@@ -161,15 +161,16 @@ export const useScrollToBottom = ({
     return () => clearTimeout(timer);
   }, [scheduleScrollCheck, ...dependencies]);
 
-  // Auto-scroll in replay mode when new events are processed
+  // Auto-scroll in replay mode when event index changes (including jumps)
   useEffect(() => {
     if (!isReplayMode || !replayState.isActive) {
       lastEventIndexRef.current = -1;
       return;
     }
 
-    // Only auto-scroll when a new event is processed (index increases)
-    if (replayState.currentEventIndex > lastEventIndexRef.current) {
+    // Auto-scroll whenever the event index changes in replay mode
+    // This covers both sequential playback and manual jumps/seeks
+    if (replayState.currentEventIndex !== lastEventIndexRef.current) {
       lastEventIndexRef.current = replayState.currentEventIndex;
       
       // Schedule auto-scroll after DOM updates


### PR DESCRIPTION
## Summary

Fixes auto-scroll behavior in Replay mode to follow all position changes, not just sequential playback.

Previously, auto-scroll only triggered when `currentEventIndex` increased during sequential playback. This caused poor UX when users jumped to different positions via timeline scrubbing or control buttons - the view wouldn't scroll to bottom.

Now auto-scroll triggers for any `currentEventIndex` change in Replay mode, ensuring users always see the latest content regardless of how they navigate.

## Checklist  

- [ ] Added or updated necessary tests (Optional).  
- [ ] Updated documentation to align with changes (Optional).  
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).  
- [x] My change does not involve the above items.