### PR TITLE
chore: fix changelog filter scopes and restore missing entries

### DIFF
--- a/multimodal/CHANGELOG.md
+++ b/multimodal/CHANGELOG.md
@@ -51,18 +51,101 @@
 
 * **agent-tars:** strict-typed gui agent procotol ([#1295](https://github.com/bytedance/UI-TARS-desktop/pull/1295)) ([4aa9d78](https://github.com/bytedance/UI-TARS-desktop/commit/4aa9d786)) [@ULIVZ](https://github.com/ULIVZ)
 * **agent-tars:** add static webui config to core ([#1266](https://github.com/bytedance/UI-TARS-desktop/pull/1266)) ([5ba0564](https://github.com/bytedance/UI-TARS-desktop/commit/5ba0564e)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** refactor chat panel ui ([#1375](https://github.com/bytedance/UI-TARS-desktop/pull/1375)) ([70c28fa](https://github.com/bytedance/UI-TARS-desktop/commit/70c28fac3)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** reuse chat input in home page ([#1313](https://github.com/bytedance/UI-TARS-desktop/pull/1313)) ([350364d](https://github.com/bytedance/UI-TARS-desktop/commit/350364d0f)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** add model id tooltip to navbar ([#1370](https://github.com/bytedance/UI-TARS-desktop/pull/1370)) ([4da9abb](https://github.com/bytedance/UI-TARS-desktop/commit/4da9abb0c)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** implement session state isolation ([#1357](https://github.com/bytedance/UI-TARS-desktop/pull/1357)) ([6f15635](https://github.com/bytedance/UI-TARS-desktop/commit/6f15635d2)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** unify think rendering with markdown renderer ([#1353](https://github.com/bytedance/UI-TARS-desktop/pull/1353)) ([3a1d53c](https://github.com/bytedance/UI-TARS-desktop/commit/3a1d53c1e)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** remove independent environment input rendering in final state ([#1346](https://github.com/bytedance/UI-TARS-desktop/pull/1346)) ([db2515d](https://github.com/bytedance/UI-TARS-desktop/commit/db2515d28)) [@ULIVZ](https://github.com/ULIVZ)
+* **o-agent:** native think ([#1371](https://github.com/bytedance/UI-TARS-desktop/pull/1371)) ([195c875](https://github.com/bytedance/UI-TARS-desktop/commit/195c8750b)) [@ULIVZ](https://github.com/ULIVZ)
 
 ### Bug Fixes
 
 * **agent-server:** add safety check for agent.dispose in session cleanup ([#1291](https://github.com/bytedance/UI-TARS-desktop/pull/1291)) ([97ef7ad](https://github.com/bytedance/UI-TARS-desktop/commit/97ef7adb)) [@ULIVZ](https://github.com/ULIVZ)
 * **agent-tars:** correct webui property name to webuiConfig ([#1267](https://github.com/bytedance/UI-TARS-desktop/pull/1267)) ([4a5f2fc](https://github.com/bytedance/UI-TARS-desktop/commit/4a5f2fc4)) [@ULIVZ](https://github.com/ULIVZ)
 * **agent-tars:** move required deps from devDependencies to dependencies ([#1255](https://github.com/bytedance/UI-TARS-desktop/pull/1255)) ([24e6acf](https://github.com/bytedance/UI-TARS-desktop/commit/24e6acff)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** image data missing in workspace ([#1373](https://github.com/bytedance/UI-TARS-desktop/pull/1373)) ([2a79e1d](https://github.com/bytedance/UI-TARS-desktop/commit/2a79e1db4)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** resolve infinite recursion in layoutModeAtom ([#1356](https://github.com/bytedance/UI-TARS-desktop/pull/1356)) ([91e4016](https://github.com/bytedance/UI-TARS-desktop/commit/91e40169d)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** downgrade react-router-dom to v6 for compatibility ([#1355](https://github.com/bytedance/UI-TARS-desktop/pull/1355)) ([5c5887f](https://github.com/bytedance/UI-TARS-desktop/commit/5c5887f07)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** fallback to beforeActionImage in afterAction strategy to prevent flickering ([#1352](https://github.com/bytedance/UI-TARS-desktop/pull/1352)) ([6190fea](https://github.com/bytedance/UI-TARS-desktop/commit/6190feae0)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** hide workspace navigation items in replay mode ([#1350](https://github.com/bytedance/UI-TARS-desktop/pull/1350)) ([ccb2262](https://github.com/bytedance/UI-TARS-desktop/commit/ccb226208)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** persist agent web ui config in share ([#1347](https://github.com/bytedance/UI-TARS-desktop/pull/1347)) ([c190d00](https://github.com/bytedance/UI-TARS-desktop/commit/c190d0096)) [@ULIVZ](https://github.com/ULIVZ)
+
+### Chore
+
+* **ptk:** add `--no-verify` to release commits ([#1369](https://github.com/bytedance/UI-TARS-desktop/pull/1369)) ([e19a0f2](https://github.com/bytedance/UI-TARS-desktop/commit/e19a0f264)) [@ULIVZ](https://github.com/ULIVZ)
+* **ptk:** update release commit scope from agent-tars to tars-stack ([#1368](https://github.com/bytedance/UI-TARS-desktop/pull/1368)) ([25001c7](https://github.com/bytedance/UI-TARS-desktop/commit/25001c743)) [@ULIVZ](https://github.com/ULIVZ)
+* **all:** fix grammar typo ([#1367](https://github.com/bytedance/UI-TARS-desktop/pull/1367)) ([48e40ab](https://github.com/bytedance/UI-TARS-desktop/commit/48e40aba3)) [@ULIVZ](https://github.com/ULIVZ)
+* **o-agent:** update display texts ([#1351](https://github.com/bytedance/UI-TARS-desktop/pull/1351)) ([8c0f42a](https://github.com/bytedance/UI-TARS-desktop/commit/8c0f42a6c)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** remove codeblock action buttons ([#1344](https://github.com/bytedance/UI-TARS-desktop/pull/1344)) ([0f55ce9](https://github.com/bytedance/UI-TARS-desktop/commit/0f55ce9b6)) [@ULIVZ](https://github.com/ULIVZ)
 
 ## [0.3.0-beta.8](https://github.com/bytedance/UI-TARS-desktop/compare/@agent-tars@0.3.0-beta.5...@agent-tars@0.3.0-beta.8) (2025-09-03)
 
 ## [0.3.0-beta.7](https://github.com/bytedance/UI-TARS-desktop/compare/@agent-tars@0.3.0-beta.5...@agent-tars@0.3.0-beta.7) (2025-09-02)
 
+### Features
+
+* **browser-operator:** use agent-infra's Hotkey to execute hotkeys ([#1343](https://github.com/bytedance/UI-TARS-desktop/pull/1343)) ([0e758f5](https://github.com/bytedance/UI-TARS-desktop/commit/0e758f5b4)) [@ULIVZ](https://github.com/ULIVZ)
+* **o-gui-agent:** temporary solution for getting metadata when screenshot ([#1341](https://github.com/bytedance/UI-TARS-desktop/pull/1341)) ([a56a6c3](https://github.com/bytedance/UI-TARS-desktop/commit/a56a6c374)) [@ULIVZ](https://github.com/ULIVZ)
+* **o-agent:** enable `enableStreamingToolCallEvents` ([#1340](https://github.com/bytedance/UI-TARS-desktop/pull/1340)) ([97c937f](https://github.com/bytedance/UI-TARS-desktop/commit/97c937f2a)) [@ULIVZ](https://github.com/ULIVZ)
+* **o-gui-agent:** support navigate action for new model ([#1339](https://github.com/bytedance/UI-TARS-desktop/pull/1339)) ([3927337](https://github.com/bytedance/UI-TARS-desktop/commit/3927337e3)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** apply RTL only to file-related tools in tool blocks ([#1337](https://github.com/bytedance/UI-TARS-desktop/pull/1337)) ([19bf806](https://github.com/bytedance/UI-TARS-desktop/commit/19bf80607)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** trim leading newlines from thinking message content ([#1333](https://github.com/bytedance/UI-TARS-desktop/pull/1333)) ([1e7a553](https://github.com/bytedance/UI-TARS-desktop/commit/1e7a5534b)) [@ULIVZ](https://github.com/ULIVZ)
+* **omni-gui-agent:** adapt tarko's screenshot rendering protocol ([#1335](https://github.com/bytedance/UI-TARS-desktop/pull/1335)) ([cd84f2f](https://github.com/bytedance/UI-TARS-desktop/commit/cd84f2f0b)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** only show MessageFooter on final assistant response ([#1331](https://github.com/bytedance/UI-TARS-desktop/pull/1331)) ([da3196e](https://github.com/bytedance/UI-TARS-desktop/commit/da3196e98)) [@ULIVZ](https://github.com/ULIVZ)
+* **o-agent:** xml parser for agent model ([#1330](https://github.com/bytedance/UI-TARS-desktop/pull/1330)) ([80af8c7](https://github.com/bytedance/UI-TARS-desktop/commit/80af8c7ae)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** add math formula rendering support to markdown renderer ([#1329](https://github.com/bytedance/UI-TARS-desktop/pull/1329)) ([1239065](https://github.com/bytedance/UI-TARS-desktop/commit/123906556)) [@ULIVZ](https://github.com/ULIVZ)
+
+### Bug Fixes
+
+* **browser:** server declares logging capability but doesn't implement method logging/setLevel ([#1334](https://github.com/bytedance/UI-TARS-desktop/pull/1334)) ([6f537a3](https://github.com/bytedance/UI-TARS-desktop/commit/6f537a323)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** browser shell url bar takes full width without spacing ([#1327](https://github.com/bytedance/UI-TARS-desktop/pull/1327)) ([32f71a6](https://github.com/bytedance/UI-TARS-desktop/commit/32f71a6ef)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** unexpected markdown render in generic renderer dark mode ([#1324](https://github.com/bytedance/UI-TARS-desktop/pull/1324)) ([282e306](https://github.com/bytedance/UI-TARS-desktop/commit/282e30655)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** table dark mode styling ([#1323](https://github.com/bytedance/UI-TARS-desktop/pull/1323)) ([173a110](https://github.com/bytedance/UI-TARS-desktop/commit/173a110ea)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** move StrategySwitch after ScreenshotDisplay to prevent flicker ([#1321](https://github.com/bytedance/UI-TARS-desktop/pull/1321)) ([91b6053](https://github.com/bytedance/UI-TARS-desktop/commit/91b6053ac)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** model displayName regression issue ([#1315](https://github.com/bytedance/UI-TARS-desktop/pull/1315)) ([18f34fa](https://github.com/bytedance/UI-TARS-desktop/commit/18f34fa9a)) [@ULIVZ](https://github.com/ULIVZ)
+
 ## [0.3.0-beta.6](https://github.com/bytedance/UI-TARS-desktop/compare/@agent-tars@0.3.0-beta.5...@agent-tars@0.3.0-beta.6) (2025-08-21)
+
+### Features
+
+* **tarko:** show `edit_file` path in tool call block ([#1309](https://github.com/bytedance/UI-TARS-desktop/pull/1309)) ([28d58d3](https://github.com/bytedance/UI-TARS-desktop/commit/28d58d348)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** add url field to screenshot metadata and display in browser shell ([#1308](https://github.com/bytedance/UI-TARS-desktop/pull/1308)) ([4ca0fd9](https://github.com/bytedance/UI-TARS-desktop/commit/4ca0fd925)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** one-click copy raw tool data ([#1304](https://github.com/bytedance/UI-TARS-desktop/pull/1304)) ([df001c6](https://github.com/bytedance/UI-TARS-desktop/commit/df001c616)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko-web-ui:** narrow chat mode ([#1298](https://github.com/bytedance/UI-TARS-desktop/pull/1298)) ([f4510f9](https://github.com/bytedance/UI-TARS-desktop/commit/f4510f945)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** add gui agent screenshot render strategy config ([#1296](https://github.com/bytedance/UI-TARS-desktop/pull/1296)) ([3730cf6](https://github.com/bytedance/UI-TARS-desktop/commit/3730cf66a)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** switch gui agent to percentage coordinates ([#1292](https://github.com/bytedance/UI-TARS-desktop/pull/1292)) ([f56f6fc](https://github.com/bytedance/UI-TARS-desktop/commit/f56f6fcc6)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** improve abort button styling ([#1290](https://github.com/bytedance/UI-TARS-desktop/pull/1290)) ([68437e6](https://github.com/bytedance/UI-TARS-desktop/commit/68437e64f)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** adjust maxIterations default to 1000 ([#1289](https://github.com/bytedance/UI-TARS-desktop/pull/1289)) ([94e890b](https://github.com/bytedance/UI-TARS-desktop/commit/94e890b6c)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko-web-ui:** streaming thinking rendering support ([#1284](https://github.com/bytedance/UI-TARS-desktop/pull/1284)) ([ae83d3d](https://github.com/bytedance/UI-TARS-desktop/commit/ae83d3db8)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko-agent:** add messageId to thinking events for proper session correlation ([#1282](https://github.com/bytedance/UI-TARS-desktop/pull/1282)) ([1fcba4c](https://github.com/bytedance/UI-TARS-desktop/commit/1fcba4cb8)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** add codebase metadata to contextual references ([#1274](https://github.com/bytedance/UI-TARS-desktop/pull/1274)) ([6920d83](https://github.com/bytedance/UI-TARS-desktop/commit/6920d834e)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** adapt devicePixelRatio from metadata in web ui ([#1275](https://github.com/bytedance/UI-TARS-desktop/pull/1275)) ([a728915](https://github.com/bytedance/UI-TARS-desktop/commit/a72891590)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** add metadata field to EnvironmentInputEvent ([#1272](https://github.com/bytedance/UI-TARS-desktop/pull/1272)) ([97ad8aa](https://github.com/bytedance/UI-TARS-desktop/commit/97ad8aafb)) [@ULIVZ](https://github.com/ULIVZ)
+* **mcp-agent:** upgrade mcp-client to 1.2.20 and set 180s timeout ([#1271](https://github.com/bytedance/UI-TARS-desktop/pull/1271)) ([23d73a5](https://github.com/bytedance/UI-TARS-desktop/commit/23d73a560)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** support TTFT and TTLT metric ([#1232](https://github.com/bytedance/UI-TARS-desktop/pull/1232)) ([bfa2879](https://github.com/bytedance/UI-TARS-desktop/commit/bfa2879ef)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko-agent:** refine contextual selector ([#1134](https://github.com/bytedance/UI-TARS-desktop/pull/1134)) ([aee4bf8](https://github.com/bytedance/UI-TARS-desktop/commit/aee4bf88d)) [@ULIVZ](https://github.com/ULIVZ)
+* **o-agent:** add custom timeout for execute_bash tool; remove stop_sequences config ([#1256](https://github.com/bytedance/UI-TARS-desktop/pull/1256)) ([5728e0b](https://github.com/bytedance/UI-TARS-desktop/commit/5728e0b65)) [@ULIVZ](https://github.com/ULIVZ)
+
+### Bug Fixes
+
+* **tarko:** replace hardcoded agent name with dynamic config in TerminalOutput ([#1306](https://github.com/bytedance/UI-TARS-desktop/pull/1306)) ([f27942e](https://github.com/bytedance/UI-TARS-desktop/commit/f27942eed)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** handle open_computer action normalization ([#1305](https://github.com/bytedance/UI-TARS-desktop/pull/1305)) ([871ea58](https://github.com/bytedance/UI-TARS-desktop/commit/871ea5894)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** resolve infinite re-render in BrowserControlRenderer hooks ([#1303](https://github.com/bytedance/UI-TARS-desktop/pull/1303)) ([7278561](https://github.com/bytedance/UI-TARS-desktop/commit/72785617b)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** prevent unnecessary `environment_input` events without contextual references ([#1301](https://github.com/bytedance/UI-TARS-desktop/pull/1301)) ([e394343](https://github.com/bytedance/UI-TARS-desktop/commit/e39434399)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** disable share button during agent execution ([#1288](https://github.com/bytedance/UI-TARS-desktop/pull/1288)) ([ba4509b](https://github.com/bytedance/UI-TARS-desktop/commit/ba4509b0b)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko-cli:** `--thinking` does not work ([#1283](https://github.com/bytedance/UI-TARS-desktop/pull/1283)) ([03b1d21](https://github.com/bytedance/UI-TARS-desktop/commit/03b1d2196)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko-cli:** prevent console interceptor recursion in debug mode ([#1279](https://github.com/bytedance/UI-TARS-desktop/pull/1279)) ([7bcff07](https://github.com/bytedance/UI-TARS-desktop/commit/7bcff0746)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** improve script execution ui layout and styling ([#1268](https://github.com/bytedance/UI-TARS-desktop/pull/1268)) ([fc7a80d](https://github.com/bytedance/UI-TARS-desktop/commit/fc7a80d68)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** optimize EditFile title path display ([#1246](https://github.com/bytedance/UI-TARS-desktop/pull/1246)) ([83f8b85](https://github.com/bytedance/UI-TARS-desktop/commit/83f8b85df)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** enable line wrapping for command stdout/stderr ([#1249](https://github.com/bytedance/UI-TARS-desktop/pull/1249)) ([cda0324](https://github.com/bytedance/UI-TARS-desktop/commit/cda0324a9)) [@ULIVZ](https://github.com/ULIVZ)
+
+### Chore
+
+* **tarko:** improve gui agent screenshot ui layout and placeholder ([#1302](https://github.com/bytedance/UI-TARS-desktop/pull/1302)) ([e083c72](https://github.com/bytedance/UI-TARS-desktop/commit/e083c723d)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** replace @ui-tars/operator-browser with local @gui-agent/operator-browser ([#1278](https://github.com/bytedance/UI-TARS-desktop/pull/1278)) ([2c13c04](https://github.com/bytedance/UI-TARS-desktop/commit/2c13c0469)) [@ULIVZ](https://github.com/ULIVZ)
+* **mcp-client:** release 1.2.20 ([#1270](https://github.com/bytedance/UI-TARS-desktop/pull/1270)) ([5a7200d](https://github.com/bytedance/UI-TARS-desktop/commit/5a7200d42)) [@ULIVZ](https://github.com/ULIVZ)
+* **all:** unify naming case of webui config ([#1269](https://github.com/bytedance/UI-TARS-desktop/pull/1269)) ([55bb023](https://github.com/bytedance/UI-TARS-desktop/commit/55bb02309)) [@ULIVZ](https://github.com/ULIVZ)
 
 ## [0.3.0-beta.4](https://github.com/bytedance/UI-TARS-desktop/compare/@agent-tars@0.3.0-beta.1...@agent-tars@0.3.0-beta.4) (2025-08-21)
 

--- a/multimodal/CHANGELOG.md
+++ b/multimodal/CHANGELOG.md
@@ -6,12 +6,44 @@
 
 * **agent-tars:** strict-typed gui agent procotol ([#1295](https://github.com/bytedance/UI-TARS-desktop/pull/1295)) ([4aa9d78](https://github.com/bytedance/UI-TARS-desktop/commit/4aa9d7866)) [@ULIVZ](https://github.com/ULIVZ)
 * **agent-tars:** add static webui config to core ([#1266](https://github.com/bytedance/UI-TARS-desktop/pull/1266)) ([5ba0564](https://github.com/bytedance/UI-TARS-desktop/commit/5ba0564e5)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** limit welcome prompts to 3 with shuffle ([#1416](https://github.com/bytedance/UI-TARS-desktop/pull/1416)) ([c6d6791](https://github.com/bytedance/UI-TARS-desktop/commit/c6d679183)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** refine all empty state ([#1408](https://github.com/bytedance/UI-TARS-desktop/pull/1408)) ([18dc008](https://github.com/bytedance/UI-TARS-desktop/commit/18dc00803)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** add user message auto-scroll in normal mode ([#1412](https://github.com/bytedance/UI-TARS-desktop/pull/1412)) ([2c7f55d](https://github.com/bytedance/UI-TARS-desktop/commit/2c7f55dae)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** enhance slug generation with multilingual support ([#1410](https://github.com/bytedance/UI-TARS-desktop/pull/1410)) ([915c7c5](https://github.com/bytedance/UI-TARS-desktop/commit/915c7c576)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** auto-scroll for replay ([#1407](https://github.com/bytedance/UI-TARS-desktop/pull/1407)) ([da22a39](https://github.com/bytedance/UI-TARS-desktop/commit/da22a3985)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** improve ChatInput UX with conditional help text and home variant ([#1406](https://github.com/bytedance/UI-TARS-desktop/pull/1406)) ([8c38bfc](https://github.com/bytedance/UI-TARS-desktop/commit/8c38bfc17)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** refine thinking animation ([#1404](https://github.com/bytedance/UI-TARS-desktop/pull/1404)) ([bae4951](https://github.com/bytedance/UI-TARS-desktop/commit/bae4951db)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** refine scroll-to-bottom indicator ([#1402](https://github.com/bytedance/UI-TARS-desktop/pull/1402)) ([3a7d239](https://github.com/bytedance/UI-TARS-desktop/commit/3a7d23972)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** defaults background to white for html renderer ([#1397](https://github.com/bytedance/UI-TARS-desktop/pull/1397)) ([c583e7e](https://github.com/bytedance/UI-TARS-desktop/commit/c583e7eb3)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** refine LinkReaderRenderer ([#1393](https://github.com/bytedance/UI-TARS-desktop/pull/1393)) ([c9855426a](https://github.com/bytedance/UI-TARS-desktop/commit/c9855426a)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** auto-append `replay=1` to share URLs ([#1394](https://github.com/bytedance/UI-TARS-desktop/pull/1394)) ([6a8533248](https://github.com/bytedance/UI-TARS-desktop/commit/6a8533248)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** disable html rendering in markdown renderer ([#1391](https://github.com/bytedance/UI-TARS-desktop/pull/1391)) ([057a4669f](https://github.com/bytedance/UI-TARS-desktop/commit/057a4669f)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** refine behavior of `guiAgent.renderGUIAction` ([#1386](https://github.com/bytedance/UI-TARS-desktop/pull/1386)) ([94b4c32ad](https://github.com/bytedance/UI-TARS-desktop/commit/94b4c32ad)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** add multimodal clipboard paste support ([#1379](https://github.com/bytedance/UI-TARS-desktop/pull/1379)) ([2b40a7cbd](https://github.com/bytedance/UI-TARS-desktop/commit/2b40a7cbd)) [@ULIVZ](https://github.com/ULIVZ)
+* **o-agent:** temp hack for model thinking ([#1395](https://github.com/bytedance/UI-TARS-desktop/pull/1395)) ([605bf84d3](https://github.com/bytedance/UI-TARS-desktop/commit/605bf84d3)) [@ULIVZ](https://github.com/ULIVZ)
+* **o-agent:** system prompt update ([#1392](https://github.com/bytedance/UI-TARS-desktop/pull/1392)) ([b19f9ef4e](https://github.com/bytedance/UI-TARS-desktop/commit/b19f9ef4e)) [@ULIVZ](https://github.com/ULIVZ)
+* **o-agent:** update time and proxy instruction in sp ([#1384](https://github.com/bytedance/UI-TARS-desktop/pull/1384)) ([1906ec697](https://github.com/bytedance/UI-TARS-desktop/commit/1906ec697)) [@ULIVZ](https://github.com/ULIVZ)
+* **gui-agent:** delay 1s before screenshot on aio hybried operator ([#1388](https://github.com/bytedance/UI-TARS-desktop/pull/1388)) ([79e835ad2](https://github.com/bytedance/UI-TARS-desktop/commit/79e835ad2)) [@ULIVZ](https://github.com/ULIVZ)
+* **o-gui-agent:** support ChromeUI gui operation on AIO sandbox ([#1383](https://github.com/bytedance/UI-TARS-desktop/pull/1383)) ([a0343697b](https://github.com/bytedance/UI-TARS-desktop/commit/a0343697b)) [@ULIVZ](https://github.com/ULIVZ)
 
 ### Bug Fixes
 
 * **agent-server:** add safety check for agent.dispose in session cleanup ([#1291](https://github.com/bytedance/UI-TARS-desktop/pull/1291)) ([97ef7ad](https://github.com/bytedance/UI-TARS-desktop/commit/97ef7adb5)) [@ULIVZ](https://github.com/ULIVZ)
 * **agent-tars:** correct webui property name to webuiConfig ([#1267](https://github.com/bytedance/UI-TARS-desktop/pull/1267)) ([4a5f2fc](https://github.com/bytedance/UI-TARS-desktop/commit/4a5f2fc4f)) [@ULIVZ](https://github.com/ULIVZ)
 * **agent-tars:** move required deps from devDependencies to dependencies ([#1255](https://github.com/bytedance/UI-TARS-desktop/pull/1255)) ([24e6acf](https://github.com/bytedance/UI-TARS-desktop/commit/24e6acff5)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** prevent auto-scroll on refresh for historical user messages ([#1415](https://github.com/bytedance/UI-TARS-desktop/pull/1415)) ([62df7230a](https://github.com/bytedance/UI-TARS-desktop/commit/62df7230a)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** improve scroll-to-bottom indicator detection ([#1411](https://github.com/bytedance/UI-TARS-desktop/pull/1411)) ([556e3a051](https://github.com/bytedance/UI-TARS-desktop/commit/556e3a051)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** improve session UI state management ([#1409](https://github.com/bytedance/UI-TARS-desktop/pull/1409)) ([0391c1101](https://github.com/bytedance/UI-TARS-desktop/commit/0391c1101)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** scroll-to-bottom indicator session switching and edge cases ([#1405](https://github.com/bytedance/UI-TARS-desktop/pull/1405)) ([442dab890](https://github.com/bytedance/UI-TARS-desktop/commit/442dab890)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** improve markdown link parsing edge cases ([#1398](https://github.com/bytedance/UI-TARS-desktop/pull/1398)) ([24fdf3155](https://github.com/bytedance/UI-TARS-desktop/commit/24fdf3155)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** correct isProcessing state management during agent execution ([#1387](https://github.com/bytedance/UI-TARS-desktop/pull/1387)) ([9d0df702a](https://github.com/bytedance/UI-TARS-desktop/commit/9d0df702a)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** fix markdown link parsing with chinese text ([#1358](https://github.com/bytedance/UI-TARS-desktop/pull/1358)) ([73ca0ca7c](https://github.com/bytedance/UI-TARS-desktop/commit/73ca0ca7c)) [@ULIVZ](https://github.com/ULIVZ)
+
+### Chore
+
+* **o-agent:** update example prompts ([#1417](https://github.com/bytedance/UI-TARS-desktop/pull/1417)) ([3b28c9b27](https://github.com/bytedance/UI-TARS-desktop/commit/3b28c9b27)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** enhance code block spacing ([#1400](https://github.com/bytedance/UI-TARS-desktop/pull/1400)) ([17524599a](https://github.com/bytedance/UI-TARS-desktop/commit/17524599a)) [@ULIVZ](https://github.com/ULIVZ)
+* **o-agent:** disable gui agent screenshot switch and render ([#1385](https://github.com/bytedance/UI-TARS-desktop/pull/1385)) ([2a92348b2](https://github.com/bytedance/UI-TARS-desktop/commit/2a92348b2)) [@ULIVZ](https://github.com/ULIVZ)
 
 ## [0.3.0-beta.8](https://github.com/bytedance/UI-TARS-desktop/compare/@agent-tars@0.3.0-beta.5...@agent-tars@0.3.0-beta.8) (2025-09-04)
 

--- a/multimodal/CHANGELOG.md
+++ b/multimodal/CHANGELOG.md
@@ -79,8 +79,6 @@
 * **o-agent:** update display texts ([#1351](https://github.com/bytedance/UI-TARS-desktop/pull/1351)) ([8c0f42a](https://github.com/bytedance/UI-TARS-desktop/commit/8c0f42a6c)) [@ULIVZ](https://github.com/ULIVZ)
 * **tarko:** remove codeblock action buttons ([#1344](https://github.com/bytedance/UI-TARS-desktop/pull/1344)) ([0f55ce9](https://github.com/bytedance/UI-TARS-desktop/commit/0f55ce9b6)) [@ULIVZ](https://github.com/ULIVZ)
 
-## [0.3.0-beta.8](https://github.com/bytedance/UI-TARS-desktop/compare/@agent-tars@0.3.0-beta.5...@agent-tars@0.3.0-beta.8) (2025-09-03)
-
 ## [0.3.0-beta.7](https://github.com/bytedance/UI-TARS-desktop/compare/@agent-tars@0.3.0-beta.5...@agent-tars@0.3.0-beta.7) (2025-09-02)
 
 ### Features
@@ -146,6 +144,99 @@
 * **tarko:** replace @ui-tars/operator-browser with local @gui-agent/operator-browser ([#1278](https://github.com/bytedance/UI-TARS-desktop/pull/1278)) ([2c13c04](https://github.com/bytedance/UI-TARS-desktop/commit/2c13c0469)) [@ULIVZ](https://github.com/ULIVZ)
 * **mcp-client:** release 1.2.20 ([#1270](https://github.com/bytedance/UI-TARS-desktop/pull/1270)) ([5a7200d](https://github.com/bytedance/UI-TARS-desktop/commit/5a7200d42)) [@ULIVZ](https://github.com/ULIVZ)
 * **all:** unify naming case of webui config ([#1269](https://github.com/bytedance/UI-TARS-desktop/pull/1269)) ([55bb023](https://github.com/bytedance/UI-TARS-desktop/commit/55bb02309)) [@ULIVZ](https://github.com/ULIVZ)
+
+## [0.3.0-beta.5](https://github.com/bytedance/UI-TARS-desktop/compare/@agent-tars@0.3.0-beta.4...@agent-tars@0.3.0-beta.5) (2025-08-21)
+
+### Features
+
+* **omni-gui-agent:** optimize system prompt to use navigate instead of type ([#1230](https://github.com/bytedance/UI-TARS-desktop/pull/1230)) ([c5b4993](https://github.com/bytedance/UI-TARS-desktop/commit/c5b4993fa)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** support top_p configuration for the model ([#1247](https://github.com/bytedance/UI-TARS-desktop/pull/1247)) ([9ba651a](https://github.com/bytedance/UI-TARS-desktop/commit/9ba651a9f)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** improve workspace header icons and raw mode spacing ([90a7a8d](https://github.com/bytedance/UI-TARS-desktop/commit/90a7a8d78)) [@ULIVZ](https://github.com/ULIVZ)
+* **mcp-client:** add configurable timeout ([#1176](https://github.com/bytedance/UI-TARS-desktop/pull/1176)) ([858c8c7](https://github.com/bytedance/UI-TARS-desktop/commit/858c8c7f3)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** temporary support for `str_replace_editor` `view` command ([#1236](https://github.com/bytedance/UI-TARS-desktop/pull/1236)) ([dad2e3d](https://github.com/bytedance/UI-TARS-desktop/commit/dad2e3d06)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** refine `str_replace_editor` renderer ([#1200](https://github.com/bytedance/UI-TARS-desktop/pull/1200)) ([b19de17](https://github.com/bytedance/UI-TARS-desktop/commit/b19de178c)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** add support for new LinkReader ([#1226](https://github.com/bytedance/UI-TARS-desktop/pull/1226)) ([53e7c3e](https://github.com/bytedance/UI-TARS-desktop/commit/53e7c3eae)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** compatible with o-tars' tool call block ([#1224](https://github.com/bytedance/UI-TARS-desktop/pull/1224)) ([13e9e95](https://github.com/bytedance/UI-TARS-desktop/commit/13e9e952c)) [@ULIVZ](https://github.com/ULIVZ)
+* **o-tars:** using new icon ([#1223](https://github.com/bytedance/UI-TARS-desktop/pull/1223)) ([9ff2e27](https://github.com/bytedance/UI-TARS-desktop/commit/9ff2e27ac)) [@ULIVZ](https://github.com/ULIVZ)
+* **webui:** add configurable about modal links ([#1217](https://github.com/bytedance/UI-TARS-desktop/pull/1217)) ([ee7e7f8](https://github.com/bytedance/UI-TARS-desktop/commit/ee7e7f89f)) [@ULIVZ](https://github.com/ULIVZ)
+* **o-tars:** add code server entry ([#1218](https://github.com/bytedance/UI-TARS-desktop/pull/1218)) ([d67b8e6](https://github.com/bytedance/UI-TARS-desktop/commit/d67b8e6a1)) [@ULIVZ](https://github.com/ULIVZ)
+* **o-agent:** modify linkreader ([#1216](https://github.com/bytedance/UI-TARS-desktop/pull/1216)) ([e1189cd](https://github.com/bytedance/UI-TARS-desktop/commit/e1189cdee)) [@ULIVZ](https://github.com/ULIVZ)
+
+### Bug Fixes
+
+* **tarko:** update session title in correct metadata structure ([#1233](https://github.com/bytedance/UI-TARS-desktop/pull/1233)) ([94278e5](https://github.com/bytedance/UI-TARS-desktop/commit/94278e540)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** home page title is truncated ([#1222](https://github.com/bytedance/UI-TARS-desktop/pull/1222)) ([ff2d740](https://github.com/bytedance/UI-TARS-desktop/commit/ff2d740a7)) [@ULIVZ](https://github.com/ULIVZ)
+
+### Chore
+
+* **all:** standardize the written terminology of Omni-TARS ([#1235](https://github.com/bytedance/UI-TARS-desktop/pull/1235)) ([923785a](https://github.com/bytedance/UI-TARS-desktop/commit/923785ab3)) [@ULIVZ](https://github.com/ULIVZ)
+* **o-tars:** using sync mode for `execute_bash` ([#1228](https://github.com/bytedance/UI-TARS-desktop/pull/1228)) ([06fa5bf](https://github.com/bytedance/UI-TARS-desktop/commit/06fa5bf20)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** override strikethrough (del) to render as normal text ([#1219](https://github.com/bytedance/UI-TARS-desktop/pull/1219)) ([1b47f03](https://github.com/bytedance/UI-TARS-desktop/commit/1b47f038d)) [@ULIVZ](https://github.com/ULIVZ)
+* **omni-tars:** remove unused prompt ([#1221](https://github.com/bytedance/UI-TARS-desktop/pull/1221)) ([507ffc2](https://github.com/bytedance/UI-TARS-desktop/commit/507ffc222)) [@ULIVZ](https://github.com/ULIVZ)
+
+## [0.3.0-beta.3](https://github.com/bytedance/UI-TARS-desktop/compare/@agent-tars@0.3.0-beta.2...@agent-tars@0.3.0-beta.3) (2025-08-20)
+
+### Features
+
+* **tarko:** using backward-only screenshot association ([#1214](https://github.com/bytedance/UI-TARS-desktop/pull/1214)) ([387035e](https://github.com/bytedance/UI-TARS-desktop/commit/387035ed2)) [@ULIVZ](https://github.com/ULIVZ)
+* **o-agent:** modify env usage ([#1213](https://github.com/bytedance/UI-TARS-desktop/pull/1213)) ([b45f774](https://github.com/bytedance/UI-TARS-desktop/commit/b45f7744c)) [@ULIVZ](https://github.com/ULIVZ)
+* **omni-gui-agent:** disable streaming output of assistant message ([#1212](https://github.com/bytedance/UI-TARS-desktop/pull/1212)) ([01b9b67](https://github.com/bytedance/UI-TARS-desktop/commit/01b9b6721)) [@ULIVZ](https://github.com/ULIVZ)
+* **omni-gui-agent:** add navigate and navigate_back action space ([#1211](https://github.com/bytedance/UI-TARS-desktop/pull/1211)) ([89db4d1](https://github.com/bytedance/UI-TARS-desktop/commit/89db4d1aa)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** add built-in agents support ([#1208](https://github.com/bytedance/UI-TARS-desktop/pull/1208)) ([2ee2848](https://github.com/bytedance/UI-TARS-desktop/commit/2ee284855)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** add webUIConfig support to AgentConstructor ([#1207](https://github.com/bytedance/UI-TARS-desktop/pull/1207)) ([b968bb5](https://github.com/bytedance/UI-TARS-desktop/commit/b968bb5c0)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** add webui workspace panels support ([#1206](https://github.com/bytedance/UI-TARS-desktop/pull/1206)) ([04db315](https://github.com/bytedance/UI-TARS-desktop/commit/04db31505)) [@ULIVZ](https://github.com/ULIVZ)
+* **omni-gui-agent:** migrate from local browser to AIO sandbox browser ([#1205](https://github.com/bytedance/UI-TARS-desktop/pull/1205)) ([3f204bb](https://github.com/bytedance/UI-TARS-desktop/commit/3f204bb46)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** add intelligent auto-scroll to chat UI ([#1203](https://github.com/bytedance/UI-TARS-desktop/pull/1203)) ([85b6dd4](https://github.com/bytedance/UI-TARS-desktop/commit/85b6dd43b)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** decouple file renderers from GenericResultRenderer ([#1201](https://github.com/bytedance/UI-TARS-desktop/pull/1201)) ([9f58647](https://github.com/bytedance/UI-TARS-desktop/commit/9f586e479)) [@ULIVZ](https://github.com/ULIVZ)
+* **omni-agent:** enable gui in omni agent ([#1197](https://github.com/bytedance/UI-TARS-desktop/pull/1197)) ([b564062](https://github.com/bytedance/UI-TARS-desktop/commit/b56406202)) [@ULIVZ](https://github.com/ULIVZ)
+* **omni-gui-agent:** execute screenshot on demand on EachLoopEnd hook ([#1195](https://github.com/bytedance/UI-TARS-desktop/pull/1195)) ([e17643b](https://github.com/bytedance/UI-TARS-desktop/commit/e17643b12)) [@ULIVZ](https://github.com/ULIVZ)
+
+### Bug Fixes
+
+* **tarko:** allow workspace panel updates in replay mode ([#1202](https://github.com/bytedance/UI-TARS-desktop/pull/1202)) ([898914f](https://github.com/bytedance/UI-TARS-desktop/commit/898914f1a)) [@ULIVZ](https://github.com/ULIVZ)
+
+### Chore
+
+* **tarko:** fix which final environment is shown after non-screensh… ([#1209](https://github.com/bytedance/UI-TARS-desktop/pull/1209)) ([845cbd0](https://github.com/bytedance/UI-TARS-desktop/commit/845cbd0ce)) [@ULIVZ](https://github.com/ULIVZ)
+* **gui-agent:** fix the missing final screenshot ([#1190](https://github.com/bytedance/UI-TARS-desktop/pull/1190)) ([0ee8730](https://github.com/bytedance/UI-TARS-desktop/commit/0ee87301a)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** remove fallback when no screenshot is available ([34ad81f](https://github.com/bytedance/UI-TARS-desktop/commit/34ad81f9e)) [@ULIVZ](https://github.com/ULIVZ)
+* **omni-tars:** fix dev:agent launch issue ([b99db7b](https://github.com/bytedance/UI-TARS-desktop/commit/b99db7bc3)) [@ULIVZ](https://github.com/ULIVZ)
+
+## [0.3.0-beta.2](https://github.com/bytedance/UI-TARS-desktop/compare/@agent-tars@0.3.0-beta.1...@agent-tars@0.3.0-beta.2) (2025-08-19)
+
+### Features
+
+* **tarko:** fully compatible with `str_replace_editor` ([#1189](https://github.com/bytedance/UI-TARS-desktop/pull/1189)) ([7a4ff74](https://github.com/bytedance/UI-TARS-desktop/commit/7a4ff7482)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** initial support `model.displayName` ([#1163](https://github.com/bytedance/UI-TARS-desktop/pull/1163)) ([6239834](https://github.com/bytedance/UI-TARS-desktop/commit/62398348d)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** add workspace raw mode display ([#1167](https://github.com/bytedance/UI-TARS-desktop/pull/1167)) ([29826ae](https://github.com/bytedance/UI-TARS-desktop/commit/29826aec9)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** add loading states for session creation and switching ([#1168](https://github.com/bytedance/UI-TARS-desktop/pull/1168)) ([f551d4c](https://github.com/bytedance/UI-TARS-desktop/commit/f551d4ce8)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** improve JupyterCI tool rendering ui ([#1166](https://github.com/bytedance/UI-TARS-desktop/pull/1166)) ([4d43191](https://github.com/bytedance/UI-TARS-desktop/commit/4d4319118)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko-cli:** load env file baesd on the workspace ([#1170](https://github.com/bytedance/UI-TARS-desktop/pull/1170)) ([9482717](https://github.com/bytedance/UI-TARS-desktop/commit/9482717a7)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** refine run command semantics ([#1158](https://github.com/bytedance/UI-TARS-desktop/pull/1158)) ([73a79a9](https://github.com/bytedance/UI-TARS-desktop/commit/73a79a90b)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** add `.env` file support ([#1156](https://github.com/bytedance/UI-TARS-desktop/pull/1156)) ([2279ad9](https://github.com/bytedance/UI-TARS-desktop/commit/2279ad967)) [@ULIVZ](https://github.com/ULIVZ)
+* **mcp-client:** add tools and prompts filtering with comprehensive tests ([#1155](https://github.com/bytedance/UI-TARS-desktop/pull/1155)) ([896274f](https://github.com/bytedance/UI-TARS-desktop/commit/896274f24)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** add agent config viewer ([#1153](https://github.com/bytedance/UI-TARS-desktop/pull/1153)) ([971360b](https://github.com/bytedance/UI-TARS-desktop/commit/971360b20)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** add agent server exclusive mode support ([#1149](https://github.com/bytedance/UI-TARS-desktop/pull/1149)) ([acfae7c](https://github.com/bytedance/UI-TARS-desktop/commit/acfae7c42)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** add workspace config support for instructions.md ([#1145](https://github.com/bytedance/UI-TARS-desktop/pull/1145)) ([1357e48](https://github.com/bytedance/UI-TARS-desktop/commit/1357e48e4)) [@ULIVZ](https://github.com/ULIVZ)
+* **mcp:** increase default timeout from 10s to 60s ([#1139](https://github.com/bytedance/UI-TARS-desktop/pull/1139)) ([64095e5](https://github.com/bytedance/UI-TARS-desktop/commit/64095e564)) [@ULIVZ](https://github.com/ULIVZ)
+* **gui-agent:** support remote browser operator and update web-ui feature for o-tars gui agent ([#1136](https://github.com/bytedance/UI-TARS-desktop/pull/1136)) ([2249b98](https://github.com/bytedance/UI-TARS-desktop/commit/2249b9806)) [@ULIVZ](https://github.com/ULIVZ)
+* **o-agent:** migrate from omni-tars core to agent-infra sandbox ([#1137](https://github.com/bytedance/UI-TARS-desktop/pull/1137)) ([cda0a13](https://github.com/bytedance/UI-TARS-desktop/commit/cda0a13a6)) [@ULIVZ](https://github.com/ULIVZ)
+* **gui-agent:** construct operator on demand ([#1133](https://github.com/bytedance/UI-TARS-desktop/pull/1133)) ([b29c1d2](https://github.com/bytedance/UI-TARS-desktop/commit/b29c1d253)) [@ULIVZ](https://github.com/ULIVZ)
+* **o-agent:** improve configuration and performance optimization ([#1131](https://github.com/bytedance/UI-TARS-desktop/pull/1131)) ([61f2b8a](https://github.com/bytedance/UI-TARS-desktop/commit/61f2b8a09)) [@ULIVZ](https://github.com/ULIVZ)
+
+### Bug Fixes
+
+* **tarko:** replace hardcoded texts with configurable title ([#1174](https://github.com/bytedance/UI-TARS-desktop/pull/1174)) ([5bd7e26](https://github.com/bytedance/UI-TARS-desktop/commit/5bd7e2691)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** display "Unknown Agent" at initial rendering ([#1184](https://github.com/bytedance/UI-TARS-desktop/pull/1184)) ([6d3b0ca](https://github.com/bytedance/UI-TARS-desktop/commit/6d3b0ca47)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** persist agent name in session metadata ([#1175](https://github.com/bytedance/UI-TARS-desktop/pull/1175)) ([436da04](https://github.com/bytedance/UI-TARS-desktop/commit/436da040b)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** handle CLI parameter order for agent argument ([#1169](https://github.com/bytedance/UI-TARS-desktop/pull/1169)) ([2acb378](https://github.com/bytedance/UI-TARS-desktop/commit/2acb378f1)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** add rollback error handling in sqlite migration ([#1147](https://github.com/bytedance/UI-TARS-desktop/pull/1147)) ([9a49826](https://github.com/bytedance/UI-TARS-desktop/commit/9a49826e1)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** inline code dark mode text color ([#1143](https://github.com/bytedance/UI-TARS-desktop/pull/1143)) ([b37ec25](https://github.com/bytedance/UI-TARS-desktop/commit/b37ec2553)) [@ULIVZ](https://github.com/ULIVZ)
+
+### Chore
+
+* **docs:** correct workspace default path in English and Chinese guides ([#1124](https://github.com/bytedance/UI-TARS-desktop/pull/1124)) ([a437116](https://github.com/bytedance/UI-TARS-desktop/commit/a43711677)) [@ULIVZ](https://github.com/ULIVZ)
+* **mcp-browser:** _meta add screen coords & fix console in stdio mode ([#984](https://github.com/bytedance/UI-TARS-desktop/pull/984)) ([06243d4](https://github.com/bytedance/UI-TARS-desktop/commit/06243d44e)) [@ULIVZ](https://github.com/ULIVZ)
 
 ## [0.3.0-beta.4](https://github.com/bytedance/UI-TARS-desktop/compare/@agent-tars@0.3.0-beta.1...@agent-tars@0.3.0-beta.4) (2025-08-21)
 

--- a/multimodal/CHANGELOG.md
+++ b/multimodal/CHANGELOG.md
@@ -20,11 +20,11 @@
 * **tarko:** disable html rendering in markdown renderer ([#1391](https://github.com/bytedance/UI-TARS-desktop/pull/1391)) ([057a4669f](https://github.com/bytedance/UI-TARS-desktop/commit/057a4669f)) [@ULIVZ](https://github.com/ULIVZ)
 * **tarko:** refine behavior of `guiAgent.renderGUIAction` ([#1386](https://github.com/bytedance/UI-TARS-desktop/pull/1386)) ([94b4c32ad](https://github.com/bytedance/UI-TARS-desktop/commit/94b4c32ad)) [@ULIVZ](https://github.com/ULIVZ)
 * **tarko:** add multimodal clipboard paste support ([#1379](https://github.com/bytedance/UI-TARS-desktop/pull/1379)) ([2b40a7cbd](https://github.com/bytedance/UI-TARS-desktop/commit/2b40a7cbd)) [@ULIVZ](https://github.com/ULIVZ)
-* **o-agent:** temp hack for model thinking ([#1395](https://github.com/bytedance/UI-TARS-desktop/pull/1395)) ([605bf84d3](https://github.com/bytedance/UI-TARS-desktop/commit/605bf84d3)) [@ULIVZ](https://github.com/ULIVZ)
-* **o-agent:** system prompt update ([#1392](https://github.com/bytedance/UI-TARS-desktop/pull/1392)) ([b19f9ef4e](https://github.com/bytedance/UI-TARS-desktop/commit/b19f9ef4e)) [@ULIVZ](https://github.com/ULIVZ)
-* **o-agent:** update time and proxy instruction in sp ([#1384](https://github.com/bytedance/UI-TARS-desktop/pull/1384)) ([1906ec697](https://github.com/bytedance/UI-TARS-desktop/commit/1906ec697)) [@ULIVZ](https://github.com/ULIVZ)
-* **gui-agent:** delay 1s before screenshot on aio hybried operator ([#1388](https://github.com/bytedance/UI-TARS-desktop/pull/1388)) ([79e835ad2](https://github.com/bytedance/UI-TARS-desktop/commit/79e835ad2)) [@ULIVZ](https://github.com/ULIVZ)
-* **o-gui-agent:** support ChromeUI gui operation on AIO sandbox ([#1383](https://github.com/bytedance/UI-TARS-desktop/pull/1383)) ([a0343697b](https://github.com/bytedance/UI-TARS-desktop/commit/a0343697b)) [@ULIVZ](https://github.com/ULIVZ)
+* **o-agent:** temp hack for model thinking ([#1395](https://github.com/bytedance/UI-TARS-desktop/pull/1395)) ([605bf84d3](https://github.com/bytedance/UI-TARS-desktop/commit/605bf84d3)) [@小健](https://github.com/小健)
+* **o-agent:** system prompt update ([#1392](https://github.com/bytedance/UI-TARS-desktop/pull/1392)) ([b19f9ef4e](https://github.com/bytedance/UI-TARS-desktop/commit/b19f9ef4e)) [@小健](https://github.com/小健)
+* **o-agent:** update time and proxy instruction in sp ([#1384](https://github.com/bytedance/UI-TARS-desktop/pull/1384)) ([1906ec697](https://github.com/bytedance/UI-TARS-desktop/commit/1906ec697)) [@小健](https://github.com/小健)
+* **gui-agent:** delay 1s before screenshot on aio hybried operator ([#1388](https://github.com/bytedance/UI-TARS-desktop/pull/1388)) ([79e835ad2](https://github.com/bytedance/UI-TARS-desktop/commit/79e835ad2)) [@heh](https://github.com/heh)
+* **o-gui-agent:** support ChromeUI gui operation on AIO sandbox ([#1383](https://github.com/bytedance/UI-TARS-desktop/pull/1383)) ([a0343697b](https://github.com/bytedance/UI-TARS-desktop/commit/a0343697b)) [@heh](https://github.com/heh)
 
 ### Bug Fixes
 
@@ -149,8 +149,8 @@
 
 ### Features
 
-* **omni-gui-agent:** optimize system prompt to use navigate instead of type ([#1230](https://github.com/bytedance/UI-TARS-desktop/pull/1230)) ([c5b4993](https://github.com/bytedance/UI-TARS-desktop/commit/c5b4993fa)) [@ULIVZ](https://github.com/ULIVZ)
-* **tarko:** support top_p configuration for the model ([#1247](https://github.com/bytedance/UI-TARS-desktop/pull/1247)) ([9ba651a](https://github.com/bytedance/UI-TARS-desktop/commit/9ba651a9f)) [@ULIVZ](https://github.com/ULIVZ)
+* **omni-gui-agent:** optimize system prompt to use navigate instead of type ([#1230](https://github.com/bytedance/UI-TARS-desktop/pull/1230)) ([c5b4993](https://github.com/bytedance/UI-TARS-desktop/commit/c5b4993fa)) [@heh](https://github.com/heh)
+* **tarko:** support top_p configuration for the model ([#1247](https://github.com/bytedance/UI-TARS-desktop/pull/1247)) ([9ba651a](https://github.com/bytedance/UI-TARS-desktop/commit/9ba651a9f)) [@小健](https://github.com/小健)
 * **tarko:** improve workspace header icons and raw mode spacing ([90a7a8d](https://github.com/bytedance/UI-TARS-desktop/commit/90a7a8d78)) [@ULIVZ](https://github.com/ULIVZ)
 * **mcp-client:** add configurable timeout ([#1176](https://github.com/bytedance/UI-TARS-desktop/pull/1176)) ([858c8c7](https://github.com/bytedance/UI-TARS-desktop/commit/858c8c7f3)) [@ULIVZ](https://github.com/ULIVZ)
 * **tarko:** temporary support for `str_replace_editor` `view` command ([#1236](https://github.com/bytedance/UI-TARS-desktop/pull/1236)) ([dad2e3d](https://github.com/bytedance/UI-TARS-desktop/commit/dad2e3d06)) [@ULIVZ](https://github.com/ULIVZ)
@@ -160,7 +160,7 @@
 * **o-tars:** using new icon ([#1223](https://github.com/bytedance/UI-TARS-desktop/pull/1223)) ([9ff2e27](https://github.com/bytedance/UI-TARS-desktop/commit/9ff2e27ac)) [@ULIVZ](https://github.com/ULIVZ)
 * **webui:** add configurable about modal links ([#1217](https://github.com/bytedance/UI-TARS-desktop/pull/1217)) ([ee7e7f8](https://github.com/bytedance/UI-TARS-desktop/commit/ee7e7f89f)) [@ULIVZ](https://github.com/ULIVZ)
 * **o-tars:** add code server entry ([#1218](https://github.com/bytedance/UI-TARS-desktop/pull/1218)) ([d67b8e6](https://github.com/bytedance/UI-TARS-desktop/commit/d67b8e6a1)) [@ULIVZ](https://github.com/ULIVZ)
-* **o-agent:** modify linkreader ([#1216](https://github.com/bytedance/UI-TARS-desktop/pull/1216)) ([e1189cd](https://github.com/bytedance/UI-TARS-desktop/commit/e1189cdee)) [@ULIVZ](https://github.com/ULIVZ)
+* **o-agent:** modify linkreader ([#1216](https://github.com/bytedance/UI-TARS-desktop/pull/1216)) ([e1189cd](https://github.com/bytedance/UI-TARS-desktop/commit/e1189cdee)) [@小健](https://github.com/小健)
 
 ### Bug Fixes
 
@@ -173,70 +173,6 @@
 * **o-tars:** using sync mode for `execute_bash` ([#1228](https://github.com/bytedance/UI-TARS-desktop/pull/1228)) ([06fa5bf](https://github.com/bytedance/UI-TARS-desktop/commit/06fa5bf20)) [@ULIVZ](https://github.com/ULIVZ)
 * **tarko:** override strikethrough (del) to render as normal text ([#1219](https://github.com/bytedance/UI-TARS-desktop/pull/1219)) ([1b47f03](https://github.com/bytedance/UI-TARS-desktop/commit/1b47f038d)) [@ULIVZ](https://github.com/ULIVZ)
 * **omni-tars:** remove unused prompt ([#1221](https://github.com/bytedance/UI-TARS-desktop/pull/1221)) ([507ffc2](https://github.com/bytedance/UI-TARS-desktop/commit/507ffc222)) [@ULIVZ](https://github.com/ULIVZ)
-
-## [0.3.0-beta.3](https://github.com/bytedance/UI-TARS-desktop/compare/@agent-tars@0.3.0-beta.2...@agent-tars@0.3.0-beta.3) (2025-08-20)
-
-### Features
-
-* **tarko:** using backward-only screenshot association ([#1214](https://github.com/bytedance/UI-TARS-desktop/pull/1214)) ([387035e](https://github.com/bytedance/UI-TARS-desktop/commit/387035ed2)) [@ULIVZ](https://github.com/ULIVZ)
-* **o-agent:** modify env usage ([#1213](https://github.com/bytedance/UI-TARS-desktop/pull/1213)) ([b45f774](https://github.com/bytedance/UI-TARS-desktop/commit/b45f7744c)) [@ULIVZ](https://github.com/ULIVZ)
-* **omni-gui-agent:** disable streaming output of assistant message ([#1212](https://github.com/bytedance/UI-TARS-desktop/pull/1212)) ([01b9b67](https://github.com/bytedance/UI-TARS-desktop/commit/01b9b6721)) [@ULIVZ](https://github.com/ULIVZ)
-* **omni-gui-agent:** add navigate and navigate_back action space ([#1211](https://github.com/bytedance/UI-TARS-desktop/pull/1211)) ([89db4d1](https://github.com/bytedance/UI-TARS-desktop/commit/89db4d1aa)) [@ULIVZ](https://github.com/ULIVZ)
-* **tarko:** add built-in agents support ([#1208](https://github.com/bytedance/UI-TARS-desktop/pull/1208)) ([2ee2848](https://github.com/bytedance/UI-TARS-desktop/commit/2ee284855)) [@ULIVZ](https://github.com/ULIVZ)
-* **tarko:** add webUIConfig support to AgentConstructor ([#1207](https://github.com/bytedance/UI-TARS-desktop/pull/1207)) ([b968bb5](https://github.com/bytedance/UI-TARS-desktop/commit/b968bb5c0)) [@ULIVZ](https://github.com/ULIVZ)
-* **tarko:** add webui workspace panels support ([#1206](https://github.com/bytedance/UI-TARS-desktop/pull/1206)) ([04db315](https://github.com/bytedance/UI-TARS-desktop/commit/04db31505)) [@ULIVZ](https://github.com/ULIVZ)
-* **omni-gui-agent:** migrate from local browser to AIO sandbox browser ([#1205](https://github.com/bytedance/UI-TARS-desktop/pull/1205)) ([3f204bb](https://github.com/bytedance/UI-TARS-desktop/commit/3f204bb46)) [@ULIVZ](https://github.com/ULIVZ)
-* **tarko:** add intelligent auto-scroll to chat UI ([#1203](https://github.com/bytedance/UI-TARS-desktop/pull/1203)) ([85b6dd4](https://github.com/bytedance/UI-TARS-desktop/commit/85b6dd43b)) [@ULIVZ](https://github.com/ULIVZ)
-* **tarko:** decouple file renderers from GenericResultRenderer ([#1201](https://github.com/bytedance/UI-TARS-desktop/pull/1201)) ([9f58647](https://github.com/bytedance/UI-TARS-desktop/commit/9f586e479)) [@ULIVZ](https://github.com/ULIVZ)
-* **omni-agent:** enable gui in omni agent ([#1197](https://github.com/bytedance/UI-TARS-desktop/pull/1197)) ([b564062](https://github.com/bytedance/UI-TARS-desktop/commit/b56406202)) [@ULIVZ](https://github.com/ULIVZ)
-* **omni-gui-agent:** execute screenshot on demand on EachLoopEnd hook ([#1195](https://github.com/bytedance/UI-TARS-desktop/pull/1195)) ([e17643b](https://github.com/bytedance/UI-TARS-desktop/commit/e17643b12)) [@ULIVZ](https://github.com/ULIVZ)
-
-### Bug Fixes
-
-* **tarko:** allow workspace panel updates in replay mode ([#1202](https://github.com/bytedance/UI-TARS-desktop/pull/1202)) ([898914f](https://github.com/bytedance/UI-TARS-desktop/commit/898914f1a)) [@ULIVZ](https://github.com/ULIVZ)
-
-### Chore
-
-* **tarko:** fix which final environment is shown after non-screensh… ([#1209](https://github.com/bytedance/UI-TARS-desktop/pull/1209)) ([845cbd0](https://github.com/bytedance/UI-TARS-desktop/commit/845cbd0ce)) [@ULIVZ](https://github.com/ULIVZ)
-* **gui-agent:** fix the missing final screenshot ([#1190](https://github.com/bytedance/UI-TARS-desktop/pull/1190)) ([0ee8730](https://github.com/bytedance/UI-TARS-desktop/commit/0ee87301a)) [@ULIVZ](https://github.com/ULIVZ)
-* **tarko:** remove fallback when no screenshot is available ([34ad81f](https://github.com/bytedance/UI-TARS-desktop/commit/34ad81f9e)) [@ULIVZ](https://github.com/ULIVZ)
-* **omni-tars:** fix dev:agent launch issue ([b99db7b](https://github.com/bytedance/UI-TARS-desktop/commit/b99db7bc3)) [@ULIVZ](https://github.com/ULIVZ)
-
-## [0.3.0-beta.2](https://github.com/bytedance/UI-TARS-desktop/compare/@agent-tars@0.3.0-beta.1...@agent-tars@0.3.0-beta.2) (2025-08-19)
-
-### Features
-
-* **tarko:** fully compatible with `str_replace_editor` ([#1189](https://github.com/bytedance/UI-TARS-desktop/pull/1189)) ([7a4ff74](https://github.com/bytedance/UI-TARS-desktop/commit/7a4ff7482)) [@ULIVZ](https://github.com/ULIVZ)
-* **tarko:** initial support `model.displayName` ([#1163](https://github.com/bytedance/UI-TARS-desktop/pull/1163)) ([6239834](https://github.com/bytedance/UI-TARS-desktop/commit/62398348d)) [@ULIVZ](https://github.com/ULIVZ)
-* **tarko:** add workspace raw mode display ([#1167](https://github.com/bytedance/UI-TARS-desktop/pull/1167)) ([29826ae](https://github.com/bytedance/UI-TARS-desktop/commit/29826aec9)) [@ULIVZ](https://github.com/ULIVZ)
-* **tarko:** add loading states for session creation and switching ([#1168](https://github.com/bytedance/UI-TARS-desktop/pull/1168)) ([f551d4c](https://github.com/bytedance/UI-TARS-desktop/commit/f551d4ce8)) [@ULIVZ](https://github.com/ULIVZ)
-* **tarko:** improve JupyterCI tool rendering ui ([#1166](https://github.com/bytedance/UI-TARS-desktop/pull/1166)) ([4d43191](https://github.com/bytedance/UI-TARS-desktop/commit/4d4319118)) [@ULIVZ](https://github.com/ULIVZ)
-* **tarko-cli:** load env file baesd on the workspace ([#1170](https://github.com/bytedance/UI-TARS-desktop/pull/1170)) ([9482717](https://github.com/bytedance/UI-TARS-desktop/commit/9482717a7)) [@ULIVZ](https://github.com/ULIVZ)
-* **tarko:** refine run command semantics ([#1158](https://github.com/bytedance/UI-TARS-desktop/pull/1158)) ([73a79a9](https://github.com/bytedance/UI-TARS-desktop/commit/73a79a90b)) [@ULIVZ](https://github.com/ULIVZ)
-* **tarko:** add `.env` file support ([#1156](https://github.com/bytedance/UI-TARS-desktop/pull/1156)) ([2279ad9](https://github.com/bytedance/UI-TARS-desktop/commit/2279ad967)) [@ULIVZ](https://github.com/ULIVZ)
-* **mcp-client:** add tools and prompts filtering with comprehensive tests ([#1155](https://github.com/bytedance/UI-TARS-desktop/pull/1155)) ([896274f](https://github.com/bytedance/UI-TARS-desktop/commit/896274f24)) [@ULIVZ](https://github.com/ULIVZ)
-* **tarko:** add agent config viewer ([#1153](https://github.com/bytedance/UI-TARS-desktop/pull/1153)) ([971360b](https://github.com/bytedance/UI-TARS-desktop/commit/971360b20)) [@ULIVZ](https://github.com/ULIVZ)
-* **tarko:** add agent server exclusive mode support ([#1149](https://github.com/bytedance/UI-TARS-desktop/pull/1149)) ([acfae7c](https://github.com/bytedance/UI-TARS-desktop/commit/acfae7c42)) [@ULIVZ](https://github.com/ULIVZ)
-* **tarko:** add workspace config support for instructions.md ([#1145](https://github.com/bytedance/UI-TARS-desktop/pull/1145)) ([1357e48](https://github.com/bytedance/UI-TARS-desktop/commit/1357e48e4)) [@ULIVZ](https://github.com/ULIVZ)
-* **mcp:** increase default timeout from 10s to 60s ([#1139](https://github.com/bytedance/UI-TARS-desktop/pull/1139)) ([64095e5](https://github.com/bytedance/UI-TARS-desktop/commit/64095e564)) [@ULIVZ](https://github.com/ULIVZ)
-* **gui-agent:** support remote browser operator and update web-ui feature for o-tars gui agent ([#1136](https://github.com/bytedance/UI-TARS-desktop/pull/1136)) ([2249b98](https://github.com/bytedance/UI-TARS-desktop/commit/2249b9806)) [@ULIVZ](https://github.com/ULIVZ)
-* **o-agent:** migrate from omni-tars core to agent-infra sandbox ([#1137](https://github.com/bytedance/UI-TARS-desktop/pull/1137)) ([cda0a13](https://github.com/bytedance/UI-TARS-desktop/commit/cda0a13a6)) [@ULIVZ](https://github.com/ULIVZ)
-* **gui-agent:** construct operator on demand ([#1133](https://github.com/bytedance/UI-TARS-desktop/pull/1133)) ([b29c1d2](https://github.com/bytedance/UI-TARS-desktop/commit/b29c1d253)) [@ULIVZ](https://github.com/ULIVZ)
-* **o-agent:** improve configuration and performance optimization ([#1131](https://github.com/bytedance/UI-TARS-desktop/pull/1131)) ([61f2b8a](https://github.com/bytedance/UI-TARS-desktop/commit/61f2b8a09)) [@ULIVZ](https://github.com/ULIVZ)
-
-### Bug Fixes
-
-* **tarko:** replace hardcoded texts with configurable title ([#1174](https://github.com/bytedance/UI-TARS-desktop/pull/1174)) ([5bd7e26](https://github.com/bytedance/UI-TARS-desktop/commit/5bd7e2691)) [@ULIVZ](https://github.com/ULIVZ)
-* **tarko:** display "Unknown Agent" at initial rendering ([#1184](https://github.com/bytedance/UI-TARS-desktop/pull/1184)) ([6d3b0ca](https://github.com/bytedance/UI-TARS-desktop/commit/6d3b0ca47)) [@ULIVZ](https://github.com/ULIVZ)
-* **tarko:** persist agent name in session metadata ([#1175](https://github.com/bytedance/UI-TARS-desktop/pull/1175)) ([436da04](https://github.com/bytedance/UI-TARS-desktop/commit/436da040b)) [@ULIVZ](https://github.com/ULIVZ)
-* **tarko:** handle CLI parameter order for agent argument ([#1169](https://github.com/bytedance/UI-TARS-desktop/pull/1169)) ([2acb378](https://github.com/bytedance/UI-TARS-desktop/commit/2acb378f1)) [@ULIVZ](https://github.com/ULIVZ)
-* **tarko:** add rollback error handling in sqlite migration ([#1147](https://github.com/bytedance/UI-TARS-desktop/pull/1147)) ([9a49826](https://github.com/bytedance/UI-TARS-desktop/commit/9a49826e1)) [@ULIVZ](https://github.com/ULIVZ)
-* **tarko:** inline code dark mode text color ([#1143](https://github.com/bytedance/UI-TARS-desktop/pull/1143)) ([b37ec25](https://github.com/bytedance/UI-TARS-desktop/commit/b37ec2553)) [@ULIVZ](https://github.com/ULIVZ)
-
-### Chore
-
-* **docs:** correct workspace default path in English and Chinese guides ([#1124](https://github.com/bytedance/UI-TARS-desktop/pull/1124)) ([a437116](https://github.com/bytedance/UI-TARS-desktop/commit/a43711677)) [@ULIVZ](https://github.com/ULIVZ)
-* **mcp-browser:** _meta add screen coords & fix console in stdio mode ([#984](https://github.com/bytedance/UI-TARS-desktop/pull/984)) ([06243d4](https://github.com/bytedance/UI-TARS-desktop/commit/06243d44e)) [@ULIVZ](https://github.com/ULIVZ)
 
 ## [0.3.0-beta.4](https://github.com/bytedance/UI-TARS-desktop/compare/@agent-tars@0.3.0-beta.1...@agent-tars@0.3.0-beta.4) (2025-08-21)
 
@@ -257,6 +193,70 @@
 * **agent-tars:** `directory_tree` causes context overflow (close: #969) (close: [#969](https://github.com/bytedance/UI-TARS-desktop/issues/969)) ([#1055](https://github.com/bytedance/UI-TARS-desktop/pull/1055)) ([9220b25](https://github.com/bytedance/UI-TARS-desktop/commit/9220b255)) [@ULIVZ](https://github.com/ULIVZ)
 * **agent-tars-cli:** sqlite should consider backward compatibility ([#1029](https://github.com/bytedance/UI-TARS-desktop/pull/1029)) ([62f5e05](https://github.com/bytedance/UI-TARS-desktop/commit/62f5e05f)) [@ULIVZ](https://github.com/ULIVZ)
 * **agent-tars-web-ui:** replay does not work ([#981](https://github.com/bytedance/UI-TARS-desktop/pull/981)) ([c39deb9](https://github.com/bytedance/UI-TARS-desktop/commit/c39deb9c)) [@ULIVZ](https://github.com/ULIVZ)
+
+## [0.3.0-beta.3](https://github.com/bytedance/UI-TARS-desktop/compare/@agent-tars@0.3.0-beta.2...@agent-tars@0.3.0-beta.3) (2025-08-20)
+
+### Features
+
+* **tarko:** using backward-only screenshot association ([#1214](https://github.com/bytedance/UI-TARS-desktop/pull/1214)) ([387035e](https://github.com/bytedance/UI-TARS-desktop/commit/387035ed2)) [@ULIVZ](https://github.com/ULIVZ)
+* **o-agent:** modify env usage ([#1213](https://github.com/bytedance/UI-TARS-desktop/pull/1213)) ([b45f774](https://github.com/bytedance/UI-TARS-desktop/commit/b45f7744c)) [@小健](https://github.com/小健)
+* **omni-gui-agent:** disable streaming output of assistant message ([#1212](https://github.com/bytedance/UI-TARS-desktop/pull/1212)) ([01b9b67](https://github.com/bytedance/UI-TARS-desktop/commit/01b9b6721)) [@heh](https://github.com/heh)
+* **omni-gui-agent:** add navigate and navigate_back action space ([#1211](https://github.com/bytedance/UI-TARS-desktop/pull/1211)) ([89db4d1](https://github.com/bytedance/UI-TARS-desktop/commit/89db4d1aa)) [@heh](https://github.com/heh)
+* **tarko:** add built-in agents support ([#1208](https://github.com/bytedance/UI-TARS-desktop/pull/1208)) ([2ee2848](https://github.com/bytedance/UI-TARS-desktop/commit/2ee284855)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** add webUIConfig support to AgentConstructor ([#1207](https://github.com/bytedance/UI-TARS-desktop/pull/1207)) ([b968bb5](https://github.com/bytedance/UI-TARS-desktop/commit/b968bb5c0)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** add webui workspace panels support ([#1206](https://github.com/bytedance/UI-TARS-desktop/pull/1206)) ([04db315](https://github.com/bytedance/UI-TARS-desktop/commit/04db31505)) [@ULIVZ](https://github.com/ULIVZ)
+* **omni-gui-agent:** migrate from local browser to AIO sandbox browser ([#1205](https://github.com/bytedance/UI-TARS-desktop/pull/1205)) ([3f204bb](https://github.com/bytedance/UI-TARS-desktop/commit/3f204bb46)) [@heh](https://github.com/heh)
+* **tarko:** add intelligent auto-scroll to chat UI ([#1203](https://github.com/bytedance/UI-TARS-desktop/pull/1203)) ([85b6dd4](https://github.com/bytedance/UI-TARS-desktop/commit/85b6dd43b)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** decouple file renderers from GenericResultRenderer ([#1201](https://github.com/bytedance/UI-TARS-desktop/pull/1201)) ([9f58647](https://github.com/bytedance/UI-TARS-desktop/commit/9f586e479)) [@ULIVZ](https://github.com/ULIVZ)
+* **omni-agent:** enable gui in omni agent ([#1197](https://github.com/bytedance/UI-TARS-desktop/pull/1197)) ([b564062](https://github.com/bytedance/UI-TARS-desktop/commit/b56406202)) [@heh](https://github.com/heh)
+* **omni-gui-agent:** execute screenshot on demand on EachLoopEnd hook ([#1195](https://github.com/bytedance/UI-TARS-desktop/pull/1195)) ([e17643b](https://github.com/bytedance/UI-TARS-desktop/commit/e17643b12)) [@heh](https://github.com/heh)
+
+### Bug Fixes
+
+* **tarko:** allow workspace panel updates in replay mode ([#1202](https://github.com/bytedance/UI-TARS-desktop/pull/1202)) ([898914f](https://github.com/bytedance/UI-TARS-desktop/commit/898914f1a)) [@ULIVZ](https://github.com/ULIVZ)
+
+### Chore
+
+* **tarko:** fix which final environment is shown after non-screensh… ([#1209](https://github.com/bytedance/UI-TARS-desktop/pull/1209)) ([845cbd0](https://github.com/bytedance/UI-TARS-desktop/commit/845cbd0ce)) [@heh](https://github.com/heh)
+* **gui-agent:** fix the missing final screenshot ([#1190](https://github.com/bytedance/UI-TARS-desktop/pull/1190)) ([0ee8730](https://github.com/bytedance/UI-TARS-desktop/commit/0ee87301a)) [@heh](https://github.com/heh)
+* **tarko:** remove fallback when no screenshot is available ([34ad81f](https://github.com/bytedance/UI-TARS-desktop/commit/34ad81f9e)) [@chenhaoli](https://github.com/chenhaoli)
+* **omni-tars:** fix dev:agent launch issue ([b99db7b](https://github.com/bytedance/UI-TARS-desktop/commit/b99db7bc3)) [@chenhaoli](https://github.com/chenhaoli)
+
+## [0.3.0-beta.2](https://github.com/bytedance/UI-TARS-desktop/compare/@agent-tars@0.3.0-beta.1...@agent-tars@0.3.0-beta.2) (2025-08-19)
+
+### Features
+
+* **tarko:** fully compatible with `str_replace_editor` ([#1189](https://github.com/bytedance/UI-TARS-desktop/pull/1189)) ([7a4ff74](https://github.com/bytedance/UI-TARS-desktop/commit/7a4ff7482)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** initial support `model.displayName` ([#1163](https://github.com/bytedance/UI-TARS-desktop/pull/1163)) ([6239834](https://github.com/bytedance/UI-TARS-desktop/commit/62398348d)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** add workspace raw mode display ([#1167](https://github.com/bytedance/UI-TARS-desktop/pull/1167)) ([29826ae](https://github.com/bytedance/UI-TARS-desktop/commit/29826aec9)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** add loading states for session creation and switching ([#1168](https://github.com/bytedance/UI-TARS-desktop/pull/1168)) ([f551d4c](https://github.com/bytedance/UI-TARS-desktop/commit/f551d4ce8)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** improve JupyterCI tool rendering ui ([#1166](https://github.com/bytedance/UI-TARS-desktop/pull/1166)) ([4d43191](https://github.com/bytedance/UI-TARS-desktop/commit/4d4319118)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko-cli:** load env file baesd on the workspace ([#1170](https://github.com/bytedance/UI-TARS-desktop/pull/1170)) ([9482717](https://github.com/bytedance/UI-TARS-desktop/commit/9482717a7)) [@小健](https://github.com/小健)
+* **tarko:** refine run command semantics ([#1158](https://github.com/bytedance/UI-TARS-desktop/pull/1158)) ([73a79a9](https://github.com/bytedance/UI-TARS-desktop/commit/73a79a90b)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** add `.env` file support ([#1156](https://github.com/bytedance/UI-TARS-desktop/pull/1156)) ([2279ad9](https://github.com/bytedance/UI-TARS-desktop/commit/2279ad967)) [@小健](https://github.com/小健)
+* **mcp-client:** add tools and prompts filtering with comprehensive tests ([#1155](https://github.com/bytedance/UI-TARS-desktop/pull/1155)) ([896274f](https://github.com/bytedance/UI-TARS-desktop/commit/896274f24)) [@Charles](https://github.com/Charles)
+* **tarko:** add agent config viewer ([#1153](https://github.com/bytedance/UI-TARS-desktop/pull/1153)) ([971360b](https://github.com/bytedance/UI-TARS-desktop/commit/971360b20)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** add agent server exclusive mode support ([#1149](https://github.com/bytedance/UI-TARS-desktop/pull/1149)) ([acfae7c](https://github.com/bytedance/UI-TARS-desktop/commit/acfae7c42)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** add workspace config support for instructions.md ([#1145](https://github.com/bytedance/UI-TARS-desktop/pull/1145)) ([1357e48](https://github.com/bytedance/UI-TARS-desktop/commit/1357e48e4)) [@ULIVZ](https://github.com/ULIVZ)
+* **mcp:** increase default timeout from 10s to 60s ([#1139](https://github.com/bytedance/UI-TARS-desktop/pull/1139)) ([64095e5](https://github.com/bytedance/UI-TARS-desktop/commit/64095e564)) [@ULIVZ](https://github.com/ULIVZ)
+* **gui-agent:** support remote browser operator and update web-ui feature for o-tars gui agent ([#1136](https://github.com/bytedance/UI-TARS-desktop/pull/1136)) ([2249b98](https://github.com/bytedance/UI-TARS-desktop/commit/2249b9806)) [@heh](https://github.com/heh)
+* **o-agent:** migrate from omni-tars core to agent-infra sandbox ([#1137](https://github.com/bytedance/UI-TARS-desktop/pull/1137)) ([cda0a13](https://github.com/bytedance/UI-TARS-desktop/commit/cda0a13a6)) [@小健](https://github.com/小健)
+* **gui-agent:** construct operator on demand ([#1133](https://github.com/bytedance/UI-TARS-desktop/pull/1133)) ([b29c1d2](https://github.com/bytedance/UI-TARS-desktop/commit/b29c1d253)) [@heh](https://github.com/heh)
+* **o-agent:** improve configuration and performance optimization ([#1131](https://github.com/bytedance/UI-TARS-desktop/pull/1131)) ([61f2b8a](https://github.com/bytedance/UI-TARS-desktop/commit/61f2b8a09)) [@小健](https://github.com/小健)
+
+### Bug Fixes
+
+* **tarko:** replace hardcoded texts with configurable title ([#1174](https://github.com/bytedance/UI-TARS-desktop/pull/1174)) ([5bd7e26](https://github.com/bytedance/UI-TARS-desktop/commit/5bd7e2691)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** display "Unknown Agent" at initial rendering ([#1184](https://github.com/bytedance/UI-TARS-desktop/pull/1184)) ([6d3b0ca](https://github.com/bytedance/UI-TARS-desktop/commit/6d3b0ca47)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** persist agent name in session metadata ([#1175](https://github.com/bytedance/UI-TARS-desktop/pull/1175)) ([436da04](https://github.com/bytedance/UI-TARS-desktop/commit/436da040b)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** handle CLI parameter order for agent argument ([#1169](https://github.com/bytedance/UI-TARS-desktop/pull/1169)) ([2acb378](https://github.com/bytedance/UI-TARS-desktop/commit/2acb378f1)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** add rollback error handling in sqlite migration ([#1147](https://github.com/bytedance/UI-TARS-desktop/pull/1147)) ([9a49826](https://github.com/bytedance/UI-TARS-desktop/commit/9a49826e1)) [@ULIVZ](https://github.com/ULIVZ)
+* **tarko:** inline code dark mode text color ([#1143](https://github.com/bytedance/UI-TARS-desktop/pull/1143)) ([b37ec25](https://github.com/bytedance/UI-TARS-desktop/commit/b37ec2553)) [@ULIVZ](https://github.com/ULIVZ)
+
+### Chore
+
+* **docs:** correct workspace default path in English and Chinese guides ([#1124](https://github.com/bytedance/UI-TARS-desktop/pull/1124)) ([a437116](https://github.com/bytedance/UI-TARS-desktop/commit/a43711677)) [@Jacob](https://github.com/Jacob)
+* **mcp-browser:** _meta add screen coords & fix console in stdio mode ([#984](https://github.com/bytedance/UI-TARS-desktop/pull/984)) ([06243d4](https://github.com/bytedance/UI-TARS-desktop/commit/06243d44e)) [@Charles](https://github.com/Charles)
 
 ## [0.3.0-beta.1](https://github.com/bytedance/UI-TARS-desktop/compare/@agent-tars@0.3.0-beta.0...@agent-tars@0.3.0-beta.1) (2025-07-17)
 

--- a/multimodal/tarko/pnpm-toolkit/src/cli.ts
+++ b/multimodal/tarko/pnpm-toolkit/src/cli.ts
@@ -101,7 +101,7 @@ export function bootstrapCli() {
     .option('--apiKey, --api-key <apiKey>', 'Custom API key for LLM')
     .option('--baseURL, --base-url <baseURL>', 'Custom base URL for LLM')
     .option('--filter-scopes <scopes>', 'Comma-separated list of scopes to include in changelog', {
-      default: 'tars,agent,tarko',
+      default: 'tars,agent,tarko,browser,infra,mcp,all',
     })
     .option(
       '--filter-types <types>',
@@ -167,7 +167,7 @@ export function bootstrapCli() {
     .option('--apiKey, --api-key <apiKey>', 'Custom API key for LLM')
     .option('--baseURL, --base-url <baseURL>', 'Custom base URL for LLM')
     .option('--filter-scopes <scopes>', 'Comma-separated list of scopes to include in changelog', {
-      default: 'tars,agent,tarko',
+      default: 'tars,agent,tarko,browser,infra,mcp,all',
     })
     .option(
       '--filter-types <types>',

--- a/multimodal/tarko/pnpm-toolkit/src/cli.ts
+++ b/multimodal/tarko/pnpm-toolkit/src/cli.ts
@@ -101,7 +101,7 @@ export function bootstrapCli() {
     .option('--apiKey, --api-key <apiKey>', 'Custom API key for LLM')
     .option('--baseURL, --base-url <baseURL>', 'Custom base URL for LLM')
     .option('--filter-scopes <scopes>', 'Comma-separated list of scopes to include in changelog', {
-      default: 'agent',
+      default: 'tars,agent,tarko',
     })
     .option(
       '--filter-types <types>',
@@ -167,7 +167,7 @@ export function bootstrapCli() {
     .option('--apiKey, --api-key <apiKey>', 'Custom API key for LLM')
     .option('--baseURL, --base-url <baseURL>', 'Custom base URL for LLM')
     .option('--filter-scopes <scopes>', 'Comma-separated list of scopes to include in changelog', {
-      default: 'agent',
+      default: 'tars,agent,tarko',
     })
     .option(
       '--filter-types <types>',


### PR DESCRIPTION
## Summary

Fixed the CHANGELOG.md issue where many release notes were missing from version 0.3.0 onwards due to incorrect `--filter-scopes` configuration.

## Checklist

- [x] Added or updated necessary tests (Optional).
- [x] Updated documentation to align with changes (Optional).
- [x] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [ ] My change does not involve the above items.