### PR TITLE
feat(tarko): add `guiAgent.renderBrowserShell` option

### DIFF
--- a/multimodal/omni-tars/omni-agent/src/index.ts
+++ b/multimodal/omni-tars/omni-agent/src/index.ts
@@ -67,6 +67,7 @@ export default class OmniTARSAgent extends ComposableAgent {
       defaultScreenshotRenderStrategy: 'afterAction',
       enableScreenshotRenderStrategySwitch: true,
       renderGUIAction: true,
+      renderBrowserShell: false,
     },
     layout: {
       enableLayoutSwitchButton: true,

--- a/multimodal/tarko/agent-web-ui/src/config/web-ui-config.ts
+++ b/multimodal/tarko/agent-web-ui/src/config/web-ui-config.ts
@@ -50,6 +50,7 @@ export function getGUIAgentConfig() {
       defaultScreenshotRenderStrategy: 'afterAction',
       enableScreenshotRenderStrategySwitch: false,
       renderGUIAction: true,
+      renderBrowserShell: true,
     }
   );
 }

--- a/multimodal/tarko/agent-web-ui/src/standalone/workspace/renderers/BrowserControlRenderer.tsx
+++ b/multimodal/tarko/agent-web-ui/src/standalone/workspace/renderers/BrowserControlRenderer.tsx
@@ -78,6 +78,7 @@ export const BrowserControlRenderer: React.FC<BrowserControlRendererProps> = ({
         previousMousePosition={previousMousePosition}
         action={action}
         showCoordinates={guiAgentConfig.renderGUIAction}
+        renderBrowserShell={guiAgentConfig.renderBrowserShell}
       />
 
       {/* Strategy Switch Controls */}

--- a/multimodal/tarko/agent-web-ui/src/standalone/workspace/renderers/browser-control/ScreenshotDisplay.tsx
+++ b/multimodal/tarko/agent-web-ui/src/standalone/workspace/renderers/browser-control/ScreenshotDisplay.tsx
@@ -54,15 +54,21 @@ export const ScreenshotDisplay: React.FC<ScreenshotDisplayProps> = ({
   };
 
   // Render placeholder when no image available
-  const renderPlaceholder = () => (
-    <div className="flex items-center justify-center bg-gray-50 dark:bg-gray-900 min-h-[400px]">
-      <div className="text-center">
-        <div className="text-gray-400 dark:text-gray-500 text-sm">
-          GUI Agent Environment Not Started
+  const renderPlaceholder = () => {
+    const placeholderClassName = renderBrowserShell
+      ? 'flex items-center justify-center bg-gray-50 dark:bg-gray-900 min-h-[400px]'
+      : 'flex items-center justify-center bg-gray-50 dark:bg-gray-900 min-h-[400px] rounded-xl';
+
+    return (
+      <div className={placeholderClassName}>
+        <div className="text-center">
+          <div className="text-gray-400 dark:text-gray-500 text-sm">
+            GUI Agent Environment Not Started
+          </div>
         </div>
       </div>
-    </div>
-  );
+    );
+  };
 
   const renderImageContent = (
     image: string | null,
@@ -71,9 +77,13 @@ export const ScreenshotDisplay: React.FC<ScreenshotDisplayProps> = ({
     referenceImage?: string | null,
   ) => {
     if (image) {
+      const imageClassName = renderBrowserShell
+        ? 'w-full h-auto object-contain'
+        : 'w-full h-auto object-contain rounded-xl';
+
       return (
         <div className="relative">
-          <img ref={imageRef} src={image} alt={alt} className="w-full h-auto object-contain" />
+          <img ref={imageRef} src={image} alt={alt} className={imageClassName} />
           {showCursor && mousePosition && (
             <MouseCursor
               position={mousePosition}
@@ -87,10 +97,17 @@ export const ScreenshotDisplay: React.FC<ScreenshotDisplayProps> = ({
 
     // Show placeholder with consistent sizing using reference image
     if (referenceImage) {
+      const imageClassName = renderBrowserShell
+        ? 'w-full h-auto object-contain invisible'
+        : 'w-full h-auto object-contain invisible rounded-xl';
+      const overlayClassName = renderBrowserShell
+        ? 'absolute inset-0 flex items-center justify-center bg-gray-50 dark:bg-gray-900'
+        : 'absolute inset-0 flex items-center justify-center bg-gray-50 dark:bg-gray-900 rounded-xl';
+
       return (
         <div className="relative">
-          <img src={referenceImage} alt={alt} className="w-full h-auto object-contain invisible" />
-          <div className="absolute inset-0 flex items-center justify-center bg-gray-50 dark:bg-gray-900">
+          <img src={referenceImage} alt={alt} className={imageClassName} />
+          <div className={overlayClassName}>
             <div className="text-center">
               <div className="text-gray-400 dark:text-gray-500 text-sm">
                 GUI Agent Environment Not Started

--- a/multimodal/tarko/agent-web-ui/src/standalone/workspace/renderers/browser-control/ScreenshotDisplay.tsx
+++ b/multimodal/tarko/agent-web-ui/src/standalone/workspace/renderers/browser-control/ScreenshotDisplay.tsx
@@ -16,6 +16,7 @@ interface ScreenshotDisplayProps {
   previousMousePosition?: { x: number; y: number } | null;
   action?: string;
   showCoordinates?: boolean;
+  renderBrowserShell?: boolean;
 }
 
 export const ScreenshotDisplay: React.FC<ScreenshotDisplayProps> = ({
@@ -30,6 +31,7 @@ export const ScreenshotDisplay: React.FC<ScreenshotDisplayProps> = ({
   previousMousePosition,
   action,
   showCoordinates = true,
+  renderBrowserShell = true,
 }) => {
   const imageRef = useRef<HTMLImageElement>(null);
 
@@ -38,6 +40,17 @@ export const ScreenshotDisplay: React.FC<ScreenshotDisplayProps> = ({
 
     // Only show cursor on before action images or single images in beforeAction strategy
     return imageType === 'before' || (imageType === 'single' && strategy === 'beforeAction');
+  };
+
+  const wrapWithBrowserShell = (content: React.ReactNode, url?: string, className?: string) => {
+    if (renderBrowserShell) {
+      return (
+        <BrowserShell url={url} className={className}>
+          {content}
+        </BrowserShell>
+      );
+    }
+    return content;
   };
 
   // Render placeholder when no image available
@@ -102,14 +115,15 @@ export const ScreenshotDisplay: React.FC<ScreenshotDisplayProps> = ({
                 Before Action
               </span>
             </div>
-            <BrowserShell url={beforeActionImageUrl || undefined}>
-              {renderImageContent(
+            {wrapWithBrowserShell(
+              renderImageContent(
                 beforeActionImage,
                 'Browser Screenshot - Before Action',
                 shouldShowMouseCursor('before'),
                 afterActionImage,
-              )}
-            </BrowserShell>
+              ),
+              beforeActionImageUrl || undefined,
+            )}
           </div>
           <div>
             <div className="flex items-center justify-center mb-2">
@@ -117,14 +131,15 @@ export const ScreenshotDisplay: React.FC<ScreenshotDisplayProps> = ({
                 After Action
               </span>
             </div>
-            <BrowserShell url={afterActionImageUrl || undefined}>
-              {renderImageContent(
+            {wrapWithBrowserShell(
+              renderImageContent(
                 afterActionImage,
                 'Browser Screenshot - After Action',
                 shouldShowMouseCursor('after'),
                 beforeActionImage,
-              )}
-            </BrowserShell>
+              ),
+              afterActionImageUrl || undefined,
+            )}
           </div>
         </div>
       </div>
@@ -132,9 +147,9 @@ export const ScreenshotDisplay: React.FC<ScreenshotDisplayProps> = ({
   }
 
   // Show single screenshot
-  return (
-    <BrowserShell className="mb-4" url={relatedImageUrl || undefined}>
-      {renderImageContent(relatedImage, 'Browser Screenshot', shouldShowMouseCursor('single'))}
-    </BrowserShell>
+  return wrapWithBrowserShell(
+    renderImageContent(relatedImage, 'Browser Screenshot', shouldShowMouseCursor('single')),
+    relatedImageUrl || undefined,
+    'mb-4',
   );
 };

--- a/multimodal/tarko/interface/src/web-ui-implementation.ts
+++ b/multimodal/tarko/interface/src/web-ui-implementation.ts
@@ -72,7 +72,7 @@ export interface TarkoWebUIGUIAgentConfig {
    *
    * @defaultValue 'afterAction'
    */
-  defaultScreenshotRenderStrategy: 'both' | 'beforeAction' | 'afterAction';
+  defaultScreenshotRenderStrategy?: 'both' | 'beforeAction' | 'afterAction';
   /**
    * Whether to enable runtime screenshot rendering strategy switch
    *
@@ -81,7 +81,7 @@ export interface TarkoWebUIGUIAgentConfig {
    *
    * @defaultValue false
    */
-  enableScreenshotRenderStrategySwitch: boolean;
+  enableScreenshotRenderStrategySwitch?: boolean;
   /**
    * Whether to enable GUI Agent action rendering
    *
@@ -91,7 +91,7 @@ export interface TarkoWebUIGUIAgentConfig {
    *
    * @defaultValue true
    */
-  renderGUIAction: boolean;
+  renderGUIAction?: boolean;
   /**
    * Whether to render browser shell around screenshots
    *
@@ -100,7 +100,7 @@ export interface TarkoWebUIGUIAgentConfig {
    *
    * @defaultValue true
    */
-  renderBrowserShell: boolean;
+  renderBrowserShell?: boolean;
 }
 
 /**
@@ -192,10 +192,10 @@ export type AgentWebUIImplementation =
  */
 export type AgentWebUIImplementationByType<T extends AgentWebUIImplementationType> =
   T extends 'static'
-    ? StaticAgentWebUIImplementation
-    : T extends 'remote'
-      ? RemoteAgentWebUIImplementation
-      : never;
+  ? StaticAgentWebUIImplementation
+  : T extends 'remote'
+  ? RemoteAgentWebUIImplementation
+  : never;
 
 /**
  * Type guard to check if implementation is of specific type

--- a/multimodal/tarko/interface/src/web-ui-implementation.ts
+++ b/multimodal/tarko/interface/src/web-ui-implementation.ts
@@ -92,6 +92,15 @@ export interface TarkoWebUIGUIAgentConfig {
    * @defaultValue true
    */
   renderGUIAction: boolean;
+  /**
+   * Whether to render browser shell around screenshots
+   *
+   * - `true`: Display screenshots wrapped in browser shell UI
+   * - `false`: Display screenshots directly without browser shell, suitable for screenshots that already contain browser chrome or computer use scenarios
+   *
+   * @defaultValue true
+   */
+  renderBrowserShell: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

By default, a browser shell appears when a GUIAgent screenshot is rendered, which is suitable for most browser usage scenarios:

<img width="4400" height="2616" alt="image" src="https://github.com/user-attachments/assets/f771f952-7219-4c03-b3f4-4486119dae71" />

However, in Computer Use or Full-Screen-based Browser Use, rendering the Browser Shell will cause it to overlap with the Navigation Bar in the screenshot. Starting with 0.3.0-beta.11, Tarko supports `guiAgent.renderBrowserShell`. Options to control:

**Default Behavior**

<img width="4400" height="2618" alt="image" src="https://github.com/user-attachments/assets/c6240a42-9a9b-4e38-bb0f-9281bb1cfeac" />


**`guiAgent.renderBrowserShell: false`**

<img width="4400" height="2618" alt="image" src="https://github.com/user-attachments/assets/c6240a42-9a9b-4e38-bb0f-9281bb1cfeac" />



## Checklist

- [ ] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [x] My change does not involve the above items.