### PR TITLE
fix(tarko): prevent duplicate session loading in SessionRouter

### DIFF
--- a/multimodal/tarko/agent-web-ui/src/standalone/app/Router/SessionRouter.tsx
+++ b/multimodal/tarko/agent-web-ui/src/standalone/app/Router/SessionRouter.tsx
@@ -52,13 +52,22 @@ export const SessionRouter: React.FC<SessionRouterProps> = ({ children }) => {
     // 3. We're connected
     // 4. It's not already the active session (prevent duplicate calls)
     if (sessionId && sessionExists && connectionStatus.connected && activeSessionId !== sessionId) {
-      console.log(`SessionRouter: Loading session ${sessionId} from URL (current active: ${activeSessionId})`);
+      console.log(
+        `SessionRouter: Loading session ${sessionId} from URL (current active: ${activeSessionId})`,
+      );
 
       setActiveSession(sessionId).catch((error) => {
         console.error(`Failed to load session ${sessionId}:`, error);
       });
     }
-  }, [sessionId, sessionExists, connectionStatus.connected, activeSessionId, setActiveSession, isReplayMode]);
+  }, [
+    sessionId,
+    sessionExists,
+    connectionStatus.connected,
+    activeSessionId,
+    setActiveSession,
+    isReplayMode,
+  ]);
 
   // In replay mode, always show content regardless of session existence
   if (isReplayMode) {

--- a/multimodal/tarko/agent-web-ui/src/standalone/app/Router/SessionRouter.tsx
+++ b/multimodal/tarko/agent-web-ui/src/standalone/app/Router/SessionRouter.tsx
@@ -50,14 +50,15 @@ export const SessionRouter: React.FC<SessionRouterProps> = ({ children }) => {
     // 1. We have a session ID from URL
     // 2. It exists in our sessions list
     // 3. We're connected
-    if (sessionId && sessionExists && connectionStatus.connected) {
-      console.log(`SessionRouter: Loading session ${sessionId} from URL`);
+    // 4. It's not already the active session (prevent duplicate calls)
+    if (sessionId && sessionExists && connectionStatus.connected && activeSessionId !== sessionId) {
+      console.log(`SessionRouter: Loading session ${sessionId} from URL (current active: ${activeSessionId})`);
 
       setActiveSession(sessionId).catch((error) => {
         console.error(`Failed to load session ${sessionId}:`, error);
       });
     }
-  }, [sessionId, sessionExists, connectionStatus.connected, setActiveSession, isReplayMode]);
+  }, [sessionId, sessionExists, connectionStatus.connected, activeSessionId, setActiveSession, isReplayMode]);
 
   // In replay mode, always show content regardless of session existence
   if (isReplayMode) {


### PR DESCRIPTION
## Summary

Fixes duplicate user message rendering when entering existing conversations from homepage by preventing duplicate session loading calls in `SessionRouter`.

**Root Cause:** The `SessionRouter` `useEffect` was missing `activeSessionId` in its dependency array, causing it to call `setActiveSession` even when the session was already active. This led to duplicate event processing and message rendering.

**Solution:** Added `activeSessionId !== sessionId` check to prevent calling `setActiveSession` when the session is already active, eliminating the race condition that caused duplicate user messages.

## Checklist

- [x] My change does not involve the above items.