### PR TITLE
fix(tarko): improve markdown inline code wrapping

### DIFF
--- a/multimodal/tarko/agent-ui/src/sdk/markdown-renderer/components/CodeBlock.tsx
+++ b/multimodal/tarko/agent-ui/src/sdk/markdown-renderer/components/CodeBlock.tsx
@@ -11,7 +11,7 @@ export const CodeBlock: React.FC<CodeBlockProps> = ({ inline, className, childre
 
   if (inline || !match) {
     return (
-      <code className="font-mono text-[#525252] bg-[#1b1f230d] dark:bg-[#333e4ecc] dark:text-gray-200 px-1 py-0.5 mx-0.5 whitespace-nowrap rounded-md">
+      <code className="font-mono text-[#525252] bg-[#1b1f230d] dark:bg-[#333e4ecc] dark:text-gray-200 px-1 py-0.5 mx-0.5 rounded-md">
         {children}
       </code>
     );

--- a/multimodal/tarko/agent-ui/src/sdk/markdown-renderer/markdown.css
+++ b/multimodal/tarko/agent-ui/src/sdk/markdown-renderer/markdown.css
@@ -19,7 +19,7 @@
 }
 
 .markdown-content code {
-  word-break: break-all;
+  word-break: break-word;
   overflow-wrap: break-word;
 }
 


### PR DESCRIPTION
## Summary

Fixed `inline code` overflow issue in Markdown Renderer by removing `whitespace-nowrap` and changing `word-break` from `break-all` to `break-word` for better text wrapping.

## Checklist  

- [ ] Added or updated necessary tests (Optional).  
- [ ] Updated documentation to align with changes (Optional).  
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).  
- [x] My change does not involve the above items.