### PR TITLE
refactor(tarko): rename `SessionItemInfo` to `SessionInfo`

### DIFF
--- a/multimodal/tarko/agent-server/src/api/controllers/oneshot.ts
+++ b/multimodal/tarko/agent-server/src/api/controllers/oneshot.ts
@@ -6,7 +6,7 @@
 import { Request, Response } from 'express';
 import { ChatCompletionContentPart } from '@tarko/interface';
 import { nanoid } from 'nanoid';
-import { SessionItemInfo } from '../../storage';
+import { SessionInfo } from '../../storage';
 import { AgentSession } from '../../core';
 import { createErrorResponse } from '../../utils/error-handler';
 
@@ -60,11 +60,11 @@ export async function createAndQuery(req: Request, res: Response) {
 
     // Store session metadata if storage is available
     if (server.storageProvider) {
-      const metadataContent: SessionItemInfo['metadata'] = { version: 1 };
+      const metadataContent: SessionInfo['metadata'] = { version: 1 };
       if (sessionName) metadataContent.name = sessionName;
       if (sessionTags) metadataContent.tags = sessionTags;
 
-      const metadata: SessionItemInfo = {
+      const metadata: SessionInfo = {
         id: sessionId,
         createdAt: Date.now(),
         updatedAt: Date.now(),
@@ -126,11 +126,11 @@ export async function createAndStreamingQuery(req: Request, res: Response) {
 
     // Store session metadata if storage is available
     if (server.storageProvider) {
-      const metadataContent: SessionItemInfo['metadata'] = { version: 1 };
+      const metadataContent: SessionInfo['metadata'] = { version: 1 };
       if (sessionName) metadataContent.name = sessionName;
       if (sessionTags) metadataContent.tags = sessionTags;
 
-      const metadata: SessionItemInfo = {
+      const metadata: SessionInfo = {
         id: sessionId,
         createdAt: Date.now(),
         updatedAt: Date.now(),

--- a/multimodal/tarko/agent-server/src/api/controllers/system.ts
+++ b/multimodal/tarko/agent-server/src/api/controllers/system.ts
@@ -85,15 +85,15 @@ export async function updateSessionModel(req: Request, res: Response) {
     // Update session model configuration
     if (server.storageProvider) {
       // Get current session metadata
-      const currentSessionItemInfo = await server.storageProvider.getSessionItemInfo(sessionId);
-      if (!currentSessionItemInfo) {
+      const currentSessionInfo = await server.storageProvider.getSessionInfo(sessionId);
+      if (!currentSessionInfo) {
         return res.status(404).json({ error: 'Session not found' });
       }
 
       // Update metadata with new model config
-      const updatedSessionItemInfo = await server.storageProvider.updateSessionItemInfo(sessionId, {
+      const updatedSessionInfo = await server.storageProvider.updateSessionInfo(sessionId, {
         metadata: {
-          ...currentSessionItemInfo.metadata,
+          ...currentSessionInfo.metadata,
           modelConfig: {
             provider,
             modelId,
@@ -109,7 +109,7 @@ export async function updateSessionModel(req: Request, res: Response) {
 
         try {
           // Recreate agent with new model configuration
-          await activeSession.updateModelConfig(updatedSessionItemInfo);
+          await activeSession.updateModelConfig(updatedSessionInfo);
           console.log(`Session ${sessionId} agent recreated with new model config`);
         } catch (error) {
           console.error(`Failed to update agent model config for session ${sessionId}:`, error);
@@ -119,7 +119,7 @@ export async function updateSessionModel(req: Request, res: Response) {
 
       res.status(200).json({
         success: true,
-        sessionItemInfo: updatedSessionItemInfo,
+        sessionInfo: updatedSessionInfo,
       });
     } else {
       res.status(400).json({ error: 'Storage not configured' });

--- a/multimodal/tarko/agent-server/src/api/middleware/session-restore.ts
+++ b/multimodal/tarko/agent-server/src/api/middleware/session-restore.ts
@@ -31,7 +31,7 @@ export async function sessionRestoreMiddleware(
 
     // If the session is not in memory but the storage is available, try to restore the session from storage
     if (!session && server.storageProvider) {
-      const metadata = await server.storageProvider.getSessionItemInfo(sessionId);
+      const metadata = await server.storageProvider.getSessionInfo(sessionId);
       if (metadata) {
         try {
           // Recover sessions from storage using a custom AGIO provider

--- a/multimodal/tarko/agent-server/src/core/AgentSession.ts
+++ b/multimodal/tarko/agent-server/src/core/AgentSession.ts
@@ -69,23 +69,23 @@ export class AgentSession {
   eventBridge: EventStreamBridge;
   private unsubscribe: (() => void) | null = null;
   private agioProvider?: AgioEvent.AgioProvider;
-  private sessionItemInfo?: import('../storage').SessionItemInfo;
+  private sessionInfo?: import('../storage').SessionInfo;
 
   constructor(
     private server: AgentServer,
     sessionId: string,
     agioProviderImpl?: AgioProviderConstructor,
-    sessionItemInfo?: import('../storage').SessionItemInfo,
+    sessionInfo?: import('../storage').SessionInfo,
   ) {
     this.id = sessionId;
     this.eventBridge = new EventStreamBridge();
-    this.sessionItemInfo = sessionItemInfo;
+    this.sessionInfo = sessionInfo;
 
     // Get agent options from server
     const agentOptions = { ...server.appConfig };
 
     // Create agent instance using the server's session-aware factory method
-    const agent = server.createAgentWithSessionModel(sessionItemInfo);
+    const agent = server.createAgentWithSessionModel(sessionInfo);
 
     // Initialize agent snapshot if enabled
     if (agentOptions.snapshot?.enable) {
@@ -233,10 +233,10 @@ export class AgentSession {
       // Run agent to process the query
 
       // Add model configuration if available in session metadata
-      if (this.sessionItemInfo?.metadata?.modelConfig) {
-        runOptions.provider = this.sessionItemInfo.metadata.modelConfig
+      if (this.sessionInfo?.metadata?.modelConfig) {
+        runOptions.provider = this.sessionInfo.metadata.modelConfig
           .provider as ModelProviderName;
-        runOptions.model = this.sessionItemInfo.metadata.modelConfig.modelId;
+        runOptions.model = this.sessionInfo.metadata.modelConfig.modelId;
         console.log(
           `🎯 [AgentSession] Using session model: ${runOptions.provider}:${runOptions.model}`,
         );
@@ -324,10 +324,10 @@ export class AgentSession {
       };
 
       // Add model configuration if available in session metadata
-      if (this.sessionItemInfo?.metadata?.modelConfig) {
-        runOptions.provider = this.sessionItemInfo.metadata.modelConfig
+      if (this.sessionInfo?.metadata?.modelConfig) {
+        runOptions.provider = this.sessionInfo.metadata.modelConfig
           .provider as ModelProviderName;
-        runOptions.model = this.sessionItemInfo.metadata.modelConfig.modelId;
+        runOptions.model = this.sessionInfo.metadata.modelConfig.modelId;
         console.log(
           `🎯 [AgentSession] Using session model for streaming: ${runOptions.provider}:${runOptions.model}`,
         );
@@ -421,20 +421,20 @@ export class AgentSession {
   /**
    * Store the updated model configuration for this session
    * The model will be used in subsequent queries via Agent.run() parameters
-   * @param sessionItemInfo Updated session metadata with new model config
+   * @param sessionInfo Updated session metadata with new model config
    */
-  async updateModelConfig(sessionItemInfo: import('../storage').SessionItemInfo): Promise<void> {
+  async updateModelConfig(sessionInfo: import('../storage').SessionInfo): Promise<void> {
     console.log(
-      `🔄 [AgentSession] Storing model config for session ${this.id}: ${sessionItemInfo.metadata?.modelConfig?.provider}:${sessionItemInfo.metadata?.modelConfig?.modelId}`,
+      `🔄 [AgentSession] Storing model config for session ${this.id}: ${sessionInfo.metadata?.modelConfig?.provider}:${sessionInfo.metadata?.modelConfig?.modelId}`,
     );
 
     // Store the session metadata for use in future queries
-    this.sessionItemInfo = sessionItemInfo;
+    this.sessionInfo = sessionInfo;
 
     // Emit model updated event to client
     this.eventBridge.emit('model_updated', {
       sessionId: this.id,
-      modelConfig: sessionItemInfo.metadata?.modelConfig,
+      modelConfig: sessionInfo.metadata?.modelConfig,
     });
 
     console.log(`✅ [AgentSession] Model config stored for session ${this.id}`);

--- a/multimodal/tarko/agent-server/src/server.ts
+++ b/multimodal/tarko/agent-server/src/server.ts
@@ -223,17 +223,17 @@ export class AgentServer<T extends AgentAppConfig = AgentAppConfig> {
   /**
    * Create Agent with session-specific model configuration
    */
-  createAgentWithSessionModel(sessionItemInfo?: import('./storage').SessionItemInfo): IAgent {
+  createAgentWithSessionModel(sessionInfo?: import('./storage').SessionInfo): IAgent {
     let modelConfig = this.getDefaultModelConfig();
 
     // If session has specific model config and it's still valid, use session config
-    if (sessionItemInfo?.metadata?.modelConfig) {
-      const { provider, modelId } = sessionItemInfo.metadata.modelConfig;
+    if (sessionInfo?.metadata?.modelConfig) {
+      const { provider, modelId } = sessionInfo.metadata.modelConfig;
       if (this.isModelConfigValid(provider, modelId)) {
         modelConfig = { provider, modelId };
       } else {
         console.warn(
-          `Session ${sessionItemInfo.id} model config is invalid, falling back to default`,
+          `Session ${sessionInfo.id} model config is invalid, falling back to default`,
         );
       }
     }

--- a/multimodal/tarko/agent-server/src/services/ShareService.ts
+++ b/multimodal/tarko/agent-server/src/services/ShareService.ts
@@ -421,7 +421,7 @@ export class ShareService {
     }
 
     return ShareUtils.uploadShareHtml(html, sessionId, this.appConfig.share?.provider as string, {
-      sessionItemInfo,
+      sessionInfo,
       slug: normalizedSlug,
       query: originalQuery,
     });

--- a/multimodal/tarko/agent-server/src/services/ShareService.ts
+++ b/multimodal/tarko/agent-server/src/services/ShareService.ts
@@ -5,7 +5,7 @@
 
 import crypto from 'crypto';
 import { AgentEventStream, isAgentWebUIImplementationType } from '@tarko/interface';
-import { SessionItemInfo, StorageProvider } from '../storage';
+import { SessionInfo, StorageProvider } from '../storage';
 import { ShareUtils } from '../utils/share';
 import { SlugGenerator } from '../utils/slug-generator';
 import fs from 'fs';
@@ -58,7 +58,7 @@ export class ShareService {
       }
 
       // Get session metadata
-      const metadata = await this.storageProvider.getSessionItemInfo(sessionId);
+      const metadata = await this.storageProvider.getSessionInfo(sessionId);
       if (!metadata) {
         throw new Error('Session not found');
       }
@@ -346,7 +346,7 @@ export class ShareService {
 
   private generateShareHtml(
     events: AgentEventStream.Event[],
-    metadata: SessionItemInfo,
+    metadata: SessionInfo,
     versionInfo?: AgentServerVersionInfo,
   ): string {
     if (isAgentWebUIImplementationType(this.appConfig.webui!, 'static')) {
@@ -376,7 +376,7 @@ export class ShareService {
   private async uploadShareHtml(
     html: string,
     sessionId: string,
-    sessionItemInfo: SessionItemInfo,
+    sessionInfo: SessionInfo,
     agent?: IAgent,
   ): Promise<string> {
     if (!this.appConfig.share?.provider) {

--- a/multimodal/tarko/agent-server/src/storage/DatabaseStorageProvider.ts
+++ b/multimodal/tarko/agent-server/src/storage/DatabaseStorageProvider.ts
@@ -4,7 +4,7 @@
  */
 
 import { AgentEventStream, AgentStorageImplementation } from '@tarko/interface';
-import { StorageProvider, SessionItemInfo } from './types';
+import { StorageProvider, SessionInfo } from './types';
 
 /**
  * Abstract database storage provider
@@ -19,13 +19,13 @@ export abstract class DatabaseStorageProvider implements StorageProvider {
   }
 
   abstract initialize(): Promise<void>;
-  abstract createSession(metadata: SessionItemInfo): Promise<SessionItemInfo>;
-  abstract updateSessionItemInfo(
+  abstract createSession(metadata: SessionInfo): Promise<SessionInfo>;
+  abstract updateSessionInfo(
     sessionId: string,
-    sessionItemInfo: Partial<Omit<SessionItemInfo, 'id'>>,
-  ): Promise<SessionItemInfo>;
-  abstract getSessionItemInfo(sessionId: string): Promise<SessionItemInfo | null>;
-  abstract getAllSessions(): Promise<SessionItemInfo[]>;
+    sessionInfo: Partial<Omit<SessionInfo, 'id'>>,
+  ): Promise<SessionInfo>;
+  abstract getSessionInfo(sessionId: string): Promise<SessionInfo | null>;
+  abstract getAllSessions(): Promise<SessionInfo[]>;
   abstract deleteSession(sessionId: string): Promise<boolean>;
   abstract saveEvent(sessionId: string, event: AgentEventStream.Event): Promise<void>;
   abstract getSessionEvents(sessionId: string): Promise<AgentEventStream.Event[]>;

--- a/multimodal/tarko/agent-server/src/storage/FileStorageProvider.ts
+++ b/multimodal/tarko/agent-server/src/storage/FileStorageProvider.ts
@@ -13,13 +13,13 @@ import {
   getGlobalStorageDirectory,
   TARKO_CONSTANTS,
 } from '@tarko/interface';
-import { StorageProvider, SessionItemInfo } from './types';
+import { StorageProvider, SessionInfo } from './types';
 
 /**
  * Data structure for lowdb
  */
 interface DbSchema {
-  sessions: Record<string, SessionItemInfo>;
+  sessions: Record<string, SessionInfo>;
   events: Record<string, AgentEventStream.Event[]>;
 }
 
@@ -64,26 +64,26 @@ export class FileStorageProvider implements StorageProvider {
     }
   }
 
-  async createSession(sessionItemInfo: SessionItemInfo): Promise<SessionItemInfo> {
+  async createSession(sessionInfo: SessionInfo): Promise<SessionInfo> {
     await this.ensureInitialized();
 
     const sessionData = {
-      ...sessionItemInfo,
-      createdAt: sessionItemInfo.createdAt || Date.now(),
-      updatedAt: sessionItemInfo.updatedAt || Date.now(),
+      ...sessionInfo,
+      createdAt: sessionInfo.createdAt || Date.now(),
+      updatedAt: sessionInfo.updatedAt || Date.now(),
     };
 
-    this.db.data.sessions[sessionItemInfo.id] = sessionData;
-    this.db.data.events[sessionItemInfo.id] = [];
+    this.db.data.sessions[sessionInfo.id] = sessionData;
+    this.db.data.events[sessionInfo.id] = [];
 
     await this.db.write();
     return sessionData;
   }
 
-  async updateSessionItemInfo(
+  async updateSessionInfo(
     sessionId: string,
-    sessionItemInfo: Partial<Omit<SessionItemInfo, 'id'>>,
-  ): Promise<SessionItemInfo> {
+    sessionInfo: Partial<Omit<SessionInfo, 'id'>>,
+  ): Promise<SessionInfo> {
     await this.ensureInitialized();
 
     const session = this.db.data.sessions[sessionId];
@@ -93,7 +93,7 @@ export class FileStorageProvider implements StorageProvider {
 
     const updatedSession = {
       ...session,
-      ...sessionItemInfo,
+      ...sessionInfo,
       updatedAt: Date.now(),
     };
 
@@ -103,12 +103,12 @@ export class FileStorageProvider implements StorageProvider {
     return updatedSession;
   }
 
-  async getSessionItemInfo(sessionId: string): Promise<SessionItemInfo | null> {
+  async getSessionInfo(sessionId: string): Promise<SessionInfo | null> {
     await this.ensureInitialized();
     return this.db.data.sessions[sessionId] || null;
   }
 
-  async getAllSessions(): Promise<SessionItemInfo[]> {
+  async getAllSessions(): Promise<SessionInfo[]> {
     await this.ensureInitialized();
     return Object.values(this.db.data.sessions);
   }

--- a/multimodal/tarko/agent-server/src/storage/MemoryStorageProvider.ts
+++ b/multimodal/tarko/agent-server/src/storage/MemoryStorageProvider.ts
@@ -4,7 +4,7 @@
  */
 
 import { AgentEventStream } from '@tarko/interface';
-import { StorageProvider, SessionItemInfo } from './types';
+import { StorageProvider, SessionInfo } from './types';
 
 /**
  * In-memory storage provider
@@ -13,14 +13,14 @@ import { StorageProvider, SessionItemInfo } from './types';
  * Note: Data will be lost when the server restarts
  */
 export class MemoryStorageProvider implements StorageProvider {
-  private sessions: Map<string, SessionItemInfo> = new Map();
+  private sessions: Map<string, SessionInfo> = new Map();
   private events: Map<string, AgentEventStream.Event[]> = new Map();
 
   async initialize(): Promise<void> {
     // No initialization needed for memory storage
   }
 
-  async createSession(metadata: SessionItemInfo): Promise<SessionItemInfo> {
+  async createSession(metadata: SessionInfo): Promise<SessionInfo> {
     this.sessions.set(metadata.id, {
       ...metadata,
       createdAt: metadata.createdAt || Date.now(),
@@ -30,10 +30,10 @@ export class MemoryStorageProvider implements StorageProvider {
     return this.sessions.get(metadata.id)!;
   }
 
-  async updateSessionItemInfo(
+  async updateSessionInfo(
     sessionId: string,
-    metadata: Partial<Omit<SessionItemInfo, 'id'>>,
-  ): Promise<SessionItemInfo> {
+    metadata: Partial<Omit<SessionInfo, 'id'>>,
+  ): Promise<SessionInfo> {
     const session = this.sessions.get(sessionId);
     if (!session) {
       throw new Error(`Session not found: ${sessionId}`);
@@ -49,11 +49,11 @@ export class MemoryStorageProvider implements StorageProvider {
     return updatedSession;
   }
 
-  async getSessionItemInfo(sessionId: string): Promise<SessionItemInfo | null> {
+  async getSessionInfo(sessionId: string): Promise<SessionInfo | null> {
     return this.sessions.get(sessionId) || null;
   }
 
-  async getAllSessions(): Promise<SessionItemInfo[]> {
+  async getAllSessions(): Promise<SessionInfo[]> {
     return Array.from(this.sessions.values());
   }
 
@@ -73,7 +73,7 @@ export class MemoryStorageProvider implements StorageProvider {
     this.events.set(sessionId, sessionEvents);
 
     // Update the session's updatedAt timestamp
-    await this.updateSessionItemInfo(sessionId, { updatedAt: Date.now() });
+    await this.updateSessionInfo(sessionId, { updatedAt: Date.now() });
   }
 
   async getSessionEvents(sessionId: string): Promise<AgentEventStream.Event[]> {

--- a/multimodal/tarko/agent-server/src/storage/SQLiteStorageProvider.ts
+++ b/multimodal/tarko/agent-server/src/storage/SQLiteStorageProvider.ts
@@ -12,7 +12,7 @@ import {
   SqliteAgentStorageImplementation,
   TARKO_CONSTANTS,
 } from '@tarko/interface';
-import { StorageProvider, SessionItemInfo, LegacySessionItemInfo } from './types';
+import { StorageProvider, SessionInfo, LegacySessionItemInfo } from './types';
 
 // Define row types for better type safety
 interface SessionRow {
@@ -257,7 +257,7 @@ export class SQLiteStorageProvider implements StorageProvider {
 
       for (const row of legacyRows) {
         // Convert legacy data to JSON metadata format
-        const metadata: SessionItemInfo['metadata'] = { version: 1 };
+        const metadata: SessionInfo['metadata'] = { version: 1 };
 
         if (row.name) metadata.name = row.name;
         if (row.tags) {
@@ -329,7 +329,7 @@ export class SQLiteStorageProvider implements StorageProvider {
         `);
 
         for (const row of legacyRows) {
-          const metadata: SessionItemInfo['metadata'] = { version: 1 };
+          const metadata: SessionInfo['metadata'] = { version: 1 };
           if (row.name) metadata.name = row.name;
           if (row.tags) {
             try {
@@ -375,7 +375,7 @@ export class SQLiteStorageProvider implements StorageProvider {
     }
   }
 
-  async createSession(metadata: SessionItemInfo): Promise<SessionItemInfo> {
+  async createSession(metadata: SessionInfo): Promise<SessionInfo> {
     await this.ensureInitialized();
 
     const sessionData = {
@@ -440,21 +440,21 @@ export class SQLiteStorageProvider implements StorageProvider {
     }
   }
 
-  async updateSessionItemInfo(
+  async updateSessionInfo(
     sessionId: string,
-    sessionItemInfo: Partial<Omit<SessionItemInfo, 'id'>>,
-  ): Promise<SessionItemInfo> {
+    sessionInfo: Partial<Omit<SessionInfo, 'id'>>,
+  ): Promise<SessionInfo> {
     await this.ensureInitialized();
 
     // First, get the current session data
-    const session = await this.getSessionItemInfo(sessionId);
+    const session = await this.getSessionInfo(sessionId);
     if (!session) {
       throw new Error(`Session not found: ${sessionId}`);
     }
 
     const updatedSession = {
       ...session,
-      ...sessionItemInfo,
+      ...sessionInfo,
       updatedAt: Date.now(),
     };
 
@@ -462,14 +462,14 @@ export class SQLiteStorageProvider implements StorageProvider {
       const params: Array<string | number | null> = [];
       const setClauses: string[] = [];
 
-      if (sessionItemInfo.workspace !== undefined) {
+      if (sessionInfo.workspace !== undefined) {
         setClauses.push('workspace = ?');
-        params.push(sessionItemInfo.workspace);
+        params.push(sessionInfo.workspace);
       }
 
-      if (sessionItemInfo.metadata !== undefined) {
+      if (sessionInfo.metadata !== undefined) {
         setClauses.push('metadata = ?');
-        params.push(sessionItemInfo.metadata ? JSON.stringify(sessionItemInfo.metadata) : null);
+        params.push(sessionInfo.metadata ? JSON.stringify(sessionInfo.metadata) : null);
       }
 
       // Always update the timestamp
@@ -502,7 +502,7 @@ export class SQLiteStorageProvider implements StorageProvider {
     }
   }
 
-  async getSessionItemInfo(sessionId: string): Promise<SessionItemInfo | null> {
+  async getSessionInfo(sessionId: string): Promise<SessionInfo | null> {
     await this.ensureInitialized();
 
     try {
@@ -547,7 +547,7 @@ export class SQLiteStorageProvider implements StorageProvider {
     }
   }
 
-  async getAllSessions(): Promise<SessionItemInfo[]> {
+  async getAllSessions(): Promise<SessionInfo[]> {
     await this.ensureInitialized();
 
     try {

--- a/multimodal/tarko/agent-server/src/storage/compatibility.ts
+++ b/multimodal/tarko/agent-server/src/storage/compatibility.ts
@@ -3,14 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { SessionItemInfo, LegacySessionItemInfo } from './types';
+import { SessionInfo, LegacySessionItemInfo } from './types';
 
 /**
- * Convert legacy SessionItemInfo to new JSON schema format
+ * Convert legacy SessionInfo to new JSON schema format
  * Provides backward compatibility during the transition period
  */
-export function migrateLegacyToJsonSchema(legacy: LegacySessionItemInfo): SessionItemInfo {
-  const metadata: SessionItemInfo['metadata'] = { version: 1 };
+export function migrateLegacyToJsonSchema(legacy: LegacySessionItemInfo): SessionInfo {
+  const metadata: SessionInfo['metadata'] = { version: 1 };
 
   if (legacy.name) metadata.name = legacy.name;
   if (legacy.tags) metadata.tags = legacy.tags;
@@ -29,7 +29,7 @@ export function migrateLegacyToJsonSchema(legacy: LegacySessionItemInfo): Sessio
  * Extract legacy fields from JSON schema for backward compatibility
  * This allows existing code to continue working during transition
  */
-export function extractLegacyFields(session: SessionItemInfo): LegacySessionItemInfo {
+export function extractLegacyFields(session: SessionInfo): LegacySessionItemInfo {
   return {
     id: session.id,
     createdAt: session.createdAt,
@@ -56,9 +56,9 @@ export function createJsonSchemaSession(
       configuredAt: number;
     };
   },
-): SessionItemInfo {
+): SessionInfo {
   const now = Date.now();
-  const metadata: SessionItemInfo['metadata'] = { version: 1 };
+  const metadata: SessionInfo['metadata'] = { version: 1 };
 
   if (options?.name) metadata.name = options.name;
   if (options?.tags) metadata.tags = options.tags;

--- a/multimodal/tarko/agent-server/src/storage/types.ts
+++ b/multimodal/tarko/agent-server/src/storage/types.ts
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { AgentEventStream, SessionItemInfo } from '@tarko/interface';
+import { AgentEventStream, SessionInfo } from '@tarko/interface';
 
-export type { SessionItemInfo, LegacySessionItemInfo } from '@tarko/interface';
+export type { SessionInfo, LegacySessionItemInfo } from '@tarko/interface';
 
 /**
  * Abstract storage provider interface
@@ -26,28 +26,28 @@ export interface StorageProvider {
    * Create a new session with metadata
    * @param metadata Session metadata
    */
-  createSession(metadata: SessionItemInfo): Promise<SessionItemInfo>;
+  createSession(metadata: SessionInfo): Promise<SessionInfo>;
 
   /**
    * Update session metadata
    * @param sessionId Session ID
-   * @param sessionItemInfo Partial session item info data to update
+   * @param sessionInfo Partial session info data to update
    */
-  updateSessionItemInfo(
+  updateSessionInfo(
     sessionId: string,
-    sessionItemInfo: Partial<Omit<SessionItemInfo, 'id'>>,
-  ): Promise<SessionItemInfo>;
+    sessionInfo: Partial<Omit<SessionInfo, 'id'>>,
+  ): Promise<SessionInfo>;
 
   /**
    * Get session metadata
    * @param sessionId Session ID
    */
-  getSessionItemInfo(sessionId: string): Promise<SessionItemInfo | null>;
+  getSessionInfo(sessionId: string): Promise<SessionInfo | null>;
 
   /**
    * Get all sessions metadata
    */
-  getAllSessions(): Promise<SessionItemInfo[]>;
+  getAllSessions(): Promise<SessionInfo[]>;
 
   /**
    * Delete a session and all its events

--- a/multimodal/tarko/agent-server/src/utils/share.ts
+++ b/multimodal/tarko/agent-server/src/utils/share.ts
@@ -7,7 +7,7 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import { AgentEventStream, AgentServerVersionInfo } from '@tarko/interface';
-import { SessionItemInfo } from '../storage';
+import { SessionInfo } from '../storage';
 
 /**
  * ShareUtils - Utility functions for sharing session data
@@ -29,7 +29,7 @@ export class ShareUtils {
    */
   static generateShareHtml(
     events: AgentEventStream.Event[],
-    metadata: SessionItemInfo,
+    metadata: SessionInfo,
     staticPath: string,
     serverInfo?: AgentServerVersionInfo,
     webUIConfig?: Record<string, any>,
@@ -130,7 +130,7 @@ export class ShareUtils {
       /**
        * Session metadata containing additional session information
        */
-      sessionItemInfo?: SessionItemInfo;
+      sessionInfo?: SessionInfo;
 
       /**
        * Normalized slug for semantic URLs, derived from user query
@@ -182,15 +182,15 @@ export class ShareUtils {
         }
 
         // Add session metadata fields
-        if (options.sessionItemInfo) {
-          const sessionName = options.sessionItemInfo.metadata?.name || '';
+        if (options.sessionInfo) {
+          const sessionName = options.sessionInfo.metadata?.name || '';
           formData.append('name', sessionName);
           // Add tags if available
           if (
-            options.sessionItemInfo.metadata?.tags &&
-            options.sessionItemInfo.metadata.tags.length > 0
+            options.sessionInfo.metadata?.tags &&
+            options.sessionInfo.metadata.tags.length > 0
           ) {
-            const tagsJson = JSON.stringify(options.sessionItemInfo.metadata.tags);
+            const tagsJson = JSON.stringify(options.sessionInfo.metadata.tags);
             formData.append('tags', tagsJson);
           }
         }

--- a/multimodal/tarko/agent-server/tests/SQLiteStorageProvider.test.ts
+++ b/multimodal/tarko/agent-server/tests/SQLiteStorageProvider.test.ts
@@ -10,7 +10,7 @@ import os from 'os';
 import { DatabaseSync } from 'node:sqlite';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { SQLiteStorageProvider } from '../src/storage/SQLiteStorageProvider';
-import { SessionItemInfo } from '../src/types';
+import { SessionInfo } from '../src/types';
 import { AgentEventStream } from '@tarko/interface';
 
 // Mock the interface module
@@ -72,7 +72,7 @@ describe('SQLiteStorageProvider - Complete Migration Testing', () => {
     });
 
     it('should create and retrieve sessions', async () => {
-      const sessionData: SessionItemInfo = {
+      const sessionData: SessionInfo = {
         id: 'test-session-1',
         workspace: '/test/workspace',
         createdAt: Date.now(),
@@ -89,7 +89,7 @@ describe('SQLiteStorageProvider - Complete Migration Testing', () => {
       expect(created.workspace).toBe(sessionData.workspace);
       expect(created.metadata).toEqual(sessionData.metadata);
 
-      const retrieved = await provider.getSessionItemInfo('test-session-1');
+      const retrieved = await provider.getSessionInfo('test-session-1');
       expect(retrieved).not.toBeNull();
       expect(retrieved!.id).toBe(sessionData.id);
       expect(retrieved!.workspace).toBe(sessionData.workspace);
@@ -97,7 +97,7 @@ describe('SQLiteStorageProvider - Complete Migration Testing', () => {
     });
 
     it('should update session metadata', async () => {
-      const sessionData: SessionItemInfo = {
+      const sessionData: SessionInfo = {
         id: 'test-session-update',
         workspace: '/test/workspace',
         createdAt: Date.now(),
@@ -110,7 +110,7 @@ describe('SQLiteStorageProvider - Complete Migration Testing', () => {
       // Wait a bit to ensure timestamp difference
       await new Promise((resolve) => setTimeout(resolve, 10));
 
-      const updated = await provider.updateSessionItemInfo('test-session-update', {
+      const updated = await provider.updateSessionInfo('test-session-update', {
         workspace: '/updated/workspace',
         metadata: { name: 'Updated Name', tags: ['updated'] },
       });
@@ -122,7 +122,7 @@ describe('SQLiteStorageProvider - Complete Migration Testing', () => {
     });
 
     it('should handle session deletion with events', async () => {
-      const sessionData: SessionItemInfo = {
+      const sessionData: SessionInfo = {
         id: 'test-session-delete',
         workspace: '/test/workspace',
         createdAt: Date.now(),
@@ -141,7 +141,7 @@ describe('SQLiteStorageProvider - Complete Migration Testing', () => {
       await provider.saveEvent('test-session-delete', event);
 
       // Verify session and events exist
-      const session = await provider.getSessionItemInfo('test-session-delete');
+      const session = await provider.getSessionInfo('test-session-delete');
       expect(session).not.toBeNull();
 
       const events = await provider.getSessionEvents('test-session-delete');
@@ -152,7 +152,7 @@ describe('SQLiteStorageProvider - Complete Migration Testing', () => {
       expect(deleted).toBe(true);
 
       // Verify session and events are gone
-      const deletedSession = await provider.getSessionItemInfo('test-session-delete');
+      const deletedSession = await provider.getSessionInfo('test-session-delete');
       expect(deletedSession).toBeNull();
 
       const deletedEvents = await provider.getSessionEvents('test-session-delete');
@@ -231,7 +231,7 @@ describe('SQLiteStorageProvider - Complete Migration Testing', () => {
       await provider.initialize();
 
       // Verify migration worked
-      const session = await provider.getSessionItemInfo('legacy-session');
+      const session = await provider.getSessionInfo('legacy-session');
       expect(session).not.toBeNull();
       expect(session!.workspace).toBe('/legacy/workspace');
       expect(session!.metadata!.name).toBe('Legacy Session');
@@ -280,7 +280,7 @@ describe('SQLiteStorageProvider - Complete Migration Testing', () => {
       await provider.initialize();
 
       // Verify session migrated
-      const session = await provider.getSessionItemInfo('legacy-with-events');
+      const session = await provider.getSessionInfo('legacy-with-events');
       expect(session).not.toBeNull();
       expect(session!.workspace).toBe('/legacy/workspace');
 
@@ -350,7 +350,7 @@ describe('SQLiteStorageProvider - Complete Migration Testing', () => {
 
       await provider.initialize();
 
-      const session = await provider.getSessionItemInfo('mixed-session');
+      const session = await provider.getSessionInfo('mixed-session');
       expect(session).not.toBeNull();
       // The migration logic doesn't update existing workspace columns that are empty
       // It only adds workspace column when it doesn't exist
@@ -433,7 +433,7 @@ describe('SQLiteStorageProvider - Complete Migration Testing', () => {
       await provider.initialize();
 
       // Test that the SQL quote fixes work
-      const sessionData: SessionItemInfo = {
+      const sessionData: SessionInfo = {
         id: 'quote-test',
         workspace: '/test/workspace',
         createdAt: Date.now(),
@@ -461,7 +461,7 @@ describe('SQLiteStorageProvider - Complete Migration Testing', () => {
       await provider.initialize();
 
       // The dynamic insert logic should handle missing workspace/metadata columns
-      const sessionData: SessionItemInfo = {
+      const sessionData: SessionInfo = {
         id: 'dynamic-test',
         workspace: '/test/workspace',
         createdAt: Date.now(),
@@ -520,10 +520,10 @@ describe('SQLiteStorageProvider - Complete Migration Testing', () => {
     });
 
     it('should handle session not found errors', async () => {
-      await expect(provider.getSessionItemInfo('non-existent')).resolves.toBeNull();
+      await expect(provider.getSessionInfo('non-existent')).resolves.toBeNull();
 
       await expect(
-        provider.updateSessionItemInfo('non-existent', { workspace: '/new' }),
+        provider.updateSessionInfo('non-existent', { workspace: '/new' }),
       ).rejects.toThrow('Session not found: non-existent');
 
       await expect(provider.deleteSession('non-existent')).resolves.toBe(false);

--- a/multimodal/tarko/agent-ui/src/common/hooks/useSession.ts
+++ b/multimodal/tarko/agent-ui/src/common/hooks/useSession.ts
@@ -62,7 +62,7 @@ export function useSession() {
   const loadSessions = useSetAtom(loadSessionsAction);
   const createSession = useSetAtom(createSessionAction);
   const setActiveSession = useSetAtom(setActiveSessionAction);
-  const updateSessionItemInfo = useSetAtom(updateSessionAction);
+  const updateSessionInfo = useSetAtom(updateSessionAction);
   const deleteSession = useSetAtom(deleteSessionAction);
   const sendMessage = useSetAtom(sendMessageAction);
   const abortQuery = useSetAtom(abortQueryAction);
@@ -158,7 +158,7 @@ export function useSession() {
       loadSessions,
       createSession,
       setActiveSession,
-      updateSessionItemInfo,
+      updateSessionInfo,
       deleteSession,
 
       // Message operations
@@ -193,7 +193,7 @@ export function useSession() {
       loadSessions,
       createSession,
       setActiveSession,
-      updateSessionItemInfo,
+      updateSessionInfo,
       deleteSession,
       sendMessage,
       abortQuery,

--- a/multimodal/tarko/agent-ui/src/common/services/apiService.ts
+++ b/multimodal/tarko/agent-ui/src/common/services/apiService.ts
@@ -1,7 +1,7 @@
 import { API_BASE_URL, API_ENDPOINTS } from '@/common/constants';
 import {
   AgentEventStream,
-  SessionItemInfo,
+  SessionInfo,
   SanitizedAgentOptions,
   WorkspaceInfo,
 } from '@/common/types';
@@ -74,7 +74,7 @@ class ApiService {
   /**
    * Create a new session
    */
-  async createSession(): Promise<SessionItemInfo> {
+  async createSession(): Promise<SessionInfo> {
     try {
       const response = await fetch(`${API_BASE_URL}${API_ENDPOINTS.CREATE_SESSION}`, {
         method: 'POST',
@@ -86,7 +86,7 @@ class ApiService {
       }
 
       const { sessionId, session } = await response.json();
-      return session as SessionItemInfo;
+      return session as SessionInfo;
     } catch (error) {
       console.error('Error creating session:', error);
       throw error;
@@ -96,7 +96,7 @@ class ApiService {
   /**
    * Get all sessions
    */
-  async getSessions(): Promise<SessionItemInfo[]> {
+  async getSessions(): Promise<SessionInfo[]> {
     try {
       const response = await fetch(`${API_BASE_URL}${API_ENDPOINTS.SESSIONS}`, {
         method: 'GET',
@@ -118,7 +118,7 @@ class ApiService {
   /**
    * Get details for a specific session
    */
-  async getSessionDetails(sessionId: string): Promise<SessionItemInfo> {
+  async getSessionDetails(sessionId: string): Promise<SessionInfo> {
     try {
       const response = await fetch(
         `${API_BASE_URL}${API_ENDPOINTS.SESSION_DETAILS}?sessionId=${sessionId}`,
@@ -197,10 +197,10 @@ class ApiService {
   /**
    * Update session metadata
    */
-  async updateSessionItemInfo(
+  async updateSessionInfo(
     sessionId: string,
-    updates: Partial<SessionItemInfo>,
-  ): Promise<SessionItemInfo> {
+    updates: Partial<SessionInfo>,
+  ): Promise<SessionInfo> {
     try {
       const response = await fetch(`${API_BASE_URL}${API_ENDPOINTS.UPDATE_SESSION}`, {
         method: 'POST',

--- a/multimodal/tarko/agent-ui/src/common/state/actions/eventProcessors/handlers/AgentRunHandler.ts
+++ b/multimodal/tarko/agent-ui/src/common/state/actions/eventProcessors/handlers/AgentRunHandler.ts
@@ -2,7 +2,7 @@ import { sessionAgentStatusAtom, sessionMetadataAtom } from '@/common/state/atom
 import { AgentEventStream } from '@/common/types';
 import { EventHandler, EventHandlerContext } from '../types';
 import { apiService } from '@/common/services/apiService';
-import { SessionItemInfo } from '@tarko/interface';
+import { SessionInfo } from '@tarko/interface';
 import { createModelConfigFromEvent, createAgentInfoFromEvent } from '@/common/utils/metadataUtils';
 import { shouldUpdateProcessingState } from '../utils/panelContentUpdater';
 
@@ -19,7 +19,7 @@ export class AgentRunStartHandler implements EventHandler<AgentEventStream.Agent
     const { set } = context;
 
     // Update session metadata with model and agent info from event
-    const metadataUpdates: Partial<NonNullable<SessionItemInfo['metadata']>> = {};
+    const metadataUpdates: Partial<NonNullable<SessionInfo['metadata']>> = {};
     const modelConfig = createModelConfigFromEvent(event);
     if (modelConfig) {
       metadataUpdates.modelConfig = modelConfig;
@@ -38,7 +38,7 @@ export class AgentRunStartHandler implements EventHandler<AgentEventStream.Agent
 
       // Persist to server
       try {
-        await apiService.updateSessionItemInfo(sessionId, {
+        await apiService.updateSessionInfo(sessionId, {
           metadata: metadataUpdates,
         });
       } catch (error) {

--- a/multimodal/tarko/agent-ui/src/common/state/actions/sessionActions.ts
+++ b/multimodal/tarko/agent-ui/src/common/state/actions/sessionActions.ts
@@ -6,7 +6,7 @@ import { messagesAtom } from '../atoms/message';
 import { toolResultsAtom, toolCallResultMap } from '../atoms/tool';
 import { sessionAgentStatusAtom, sessionPanelContentAtom, sessionMetadataAtom } from '../atoms/ui';
 import { processEventAction } from './eventProcessors';
-import { Message, SessionItemInfo } from '@/common/types';
+import { Message, SessionInfo } from '@/common/types';
 import { connectionStatusAtom } from '../atoms/ui';
 import { replayStateAtom } from '../atoms/replay';
 import { sessionFilesAtom, FileItem } from '../atoms/files';
@@ -254,11 +254,11 @@ export const setActiveSessionAction = atom(null, async (get, set, sessionId: str
 
 export const updateSessionAction = atom(
   null,
-  async (get, set, params: { sessionId: string; updates: Partial<SessionItemInfo> }) => {
+  async (get, set, params: { sessionId: string; updates: Partial<SessionInfo> }) => {
     const { sessionId, updates } = params;
 
     try {
-      const updatedSession = await apiService.updateSessionItemInfo(sessionId, updates);
+      const updatedSession = await apiService.updateSessionInfo(sessionId, updates);
 
       set(sessionsAtom, (prev) =>
         prev.map((session) =>
@@ -389,7 +389,7 @@ export const sendMessageAction = atom(
           }
         }
 
-        await apiService.updateSessionItemInfo(activeSessionId, { metadata: { name: summary } });
+        await apiService.updateSessionInfo(activeSessionId, { metadata: { name: summary } });
 
         set(sessionsAtom, (prev) =>
           prev.map((session) =>

--- a/multimodal/tarko/agent-ui/src/common/state/atoms/session.ts
+++ b/multimodal/tarko/agent-ui/src/common/state/atoms/session.ts
@@ -1,10 +1,10 @@
 import { atom } from 'jotai';
-import { SessionItemInfo } from '@/common/types';
+import { SessionInfo } from '@/common/types';
 
 /**
  * Atom for storing all sessions
  */
-export const sessionsAtom = atom<SessionItemInfo[]>([]);
+export const sessionsAtom = atom<SessionInfo[]>([]);
 
 /**
  * Atom for the currently active session ID

--- a/multimodal/tarko/agent-ui/src/common/state/atoms/ui.ts
+++ b/multimodal/tarko/agent-ui/src/common/state/atoms/ui.ts
@@ -1,5 +1,5 @@
 import { atom } from 'jotai';
-import { AgentProcessingPhase, AgentStatusInfo, SessionItemInfo, LayoutMode } from '@tarko/interface';
+import { AgentProcessingPhase, AgentStatusInfo, SessionInfo, LayoutMode } from '@tarko/interface';
 import { getDefaultLayoutMode } from '@/config/web-ui-config';
 import {
   ConnectionStatus,
@@ -45,10 +45,10 @@ export const connectionStatusAtom = atom<ConnectionStatus>({
 });
 
 /**
- * Session metadata atom using server-side SessionItemInfo metadata type
+ * Session metadata atom using server-side SessionInfo metadata type
  * This eliminates type duplication and ensures consistency with persistence layer
  */
-export const sessionMetadataAtom = atom<SessionItemInfo['metadata']>({});
+export const sessionMetadataAtom = atom<SessionInfo['metadata']>({});
 
 /**
  * Atom for agent options (sanitized configuration)

--- a/multimodal/tarko/agent-ui/src/common/types/env.d.ts
+++ b/multimodal/tarko/agent-ui/src/common/types/env.d.ts
@@ -5,7 +5,7 @@ import type { AgentServerVersionInfo, AgentWebUIImplementation } from '@agent-ta
  * Session metadata interface
  * Forked from server, we need move to interface later.
  */
-export interface SessionItemInfo {
+export interface SessionInfo {
   id: string;
   createdAt: number;
   updatedAt: number;
@@ -22,7 +22,7 @@ declare global {
     AGENT_BASE_URL?: string;
     AGENT_WEB_UI_CONFIG?: AgentWebUIImplementation;
     AGENT_REPLAY_MODE?: boolean;
-    AGENT_SESSION_DATA?: SessionItemInfo;
+    AGENT_SESSION_DATA?: SessionInfo;
     AGENT_EVENT_STREAM?: AgentEventStream.Event[];
     AGENT_VERSION_INFO?: AgentServerVersionInfo;
   }

--- a/multimodal/tarko/agent-ui/src/common/types/index.ts
+++ b/multimodal/tarko/agent-ui/src/common/types/index.ts
@@ -4,10 +4,10 @@ import {
   ChatCompletionContentPart,
   ChatCompletionMessageToolCall,
 } from '@tarko/agent-interface';
-import { SanitizedAgentOptions, WorkspaceInfo, SessionItemInfo } from '@tarko/interface';
+import { SanitizedAgentOptions, WorkspaceInfo, SessionInfo } from '@tarko/interface';
 
 export { AgentEventStream };
-export type { SanitizedAgentOptions, WorkspaceInfo, SessionItemInfo };
+export type { SanitizedAgentOptions, WorkspaceInfo, SessionInfo };
 
 export type { ChatCompletionContentPart, ChatCompletionMessageToolCall };
 

--- a/multimodal/tarko/agent-ui/src/common/utils/modelUtils.ts
+++ b/multimodal/tarko/agent-ui/src/common/utils/modelUtils.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { SessionItemInfo } from '@tarko/interface';
+import { SessionInfo } from '@tarko/interface';
 
 /**
  * Get the display name for a model configuration.
@@ -13,7 +13,7 @@ import { SessionItemInfo } from '@tarko/interface';
  * @returns The display name or model ID
  */
 export function getModelDisplayName(
-  modelConfig?: SessionItemInfo['metadata']['modelConfig'],
+  modelConfig?: SessionInfo['metadata']['modelConfig'],
 ): string {
   if (!modelConfig?.modelId) {
     return '';
@@ -30,7 +30,7 @@ export function getModelDisplayName(
  * @returns The display name or model ID
  */
 export function getModelDisplayNameFromSession(
-  sessionMetadata?: SessionItemInfo['metadata'],
+  sessionMetadata?: SessionInfo['metadata'],
 ): string {
   return getModelDisplayName(sessionMetadata?.modelConfig);
 }

--- a/multimodal/tarko/agent-ui/src/standalone/navbar/AboutModal.tsx
+++ b/multimodal/tarko/agent-ui/src/standalone/navbar/AboutModal.tsx
@@ -4,14 +4,14 @@ import { motion } from 'framer-motion';
 import { FiX, FiExternalLink, FiGithub, FiGlobe, FiCpu, FiCopy, FiCheck } from 'react-icons/fi';
 import { FaBrain } from 'react-icons/fa';
 import { apiService } from '@/common/services/apiService';
-import { AgentServerVersionInfo, SessionItemInfo } from '@agent-tars/interface';
+import { AgentServerVersionInfo, SessionInfo } from '@agent-tars/interface';
 import { getWebUIConfig, getLogoUrl, getAgentTitle } from '@/config/web-ui-config';
 import { getModelDisplayName } from '@/common/utils/modelUtils';
 
 interface AboutModalProps {
   isOpen: boolean;
   onClose: () => void;
-  sessionMetadata?: SessionItemInfo['metadata'];
+  sessionMetadata?: SessionInfo['metadata'];
 }
 
 export const AboutModal: React.FC<AboutModalProps> = ({ isOpen, onClose, sessionMetadata }) => {

--- a/multimodal/tarko/agent-ui/src/standalone/sidebar/ChatSession.tsx
+++ b/multimodal/tarko/agent-ui/src/standalone/sidebar/ChatSession.tsx
@@ -19,7 +19,7 @@ export const ChatSession: React.FC<ChatSessionProps> = ({ isCollapsed }) => {
     sessions,
     activeSessionId,
     setActiveSession,
-    updateSessionItemInfo,
+    updateSessionInfo,
     deleteSession,
     loadSessions,
     connectionStatus,
@@ -205,13 +205,13 @@ export const ChatSession: React.FC<ChatSessionProps> = ({ isCollapsed }) => {
   const handleSaveEdit = useCallback(
     async (sessionId: string) => {
       try {
-        await updateSessionItemInfo({ sessionId, updates: { metadata: { name: editedName } } });
+        await updateSessionInfo({ sessionId, updates: { metadata: { name: editedName } } });
         setEditingSessionId(null);
       } catch (error) {
         console.error('Failed to update session name:', error);
       }
     },
-    [updateSessionItemInfo, editedName],
+    [updateSessionInfo, editedName],
   );
 
   const handleDeleteSession = useCallback(async (sessionId: string, e: React.MouseEvent) => {

--- a/multimodal/tarko/agent-ui/src/standalone/sidebar/SessionItem.tsx
+++ b/multimodal/tarko/agent-ui/src/standalone/sidebar/SessionItem.tsx
@@ -2,12 +2,12 @@ import React, { useCallback } from 'react';
 import { motion } from 'framer-motion';
 import { FiMessageSquare, FiEdit2, FiTrash2, FiTag, FiClock, FiLoader } from 'react-icons/fi';
 import { formatTimestamp } from '@/common/utils/formatters';
-import { SessionItemInfo } from '@/common/types';
+import { SessionInfo } from '@/common/types';
 import classNames from 'classnames';
 import { HighlightText } from './HighlightText';
 
 interface SessionItemProps {
-  session: SessionItemInfo;
+  session: SessionInfo;
   isActive: boolean;
   isLoading: boolean;
   isConnected: boolean;

--- a/multimodal/tarko/interface/src/server.ts
+++ b/multimodal/tarko/interface/src/server.ts
@@ -161,9 +161,9 @@ export interface SessionItemMetadata {
 }
 
 /**
- * Session item interface
+ * Session interface
  */
-export interface SessionItemInfo {
+export interface SessionInfo {
   id: string;
   createdAt: number;
   updatedAt: number;
@@ -173,7 +173,7 @@ export interface SessionItemInfo {
 
 /**
  * Legacy interface for backward compatibility during transition
- * @deprecated Use SessionItemInfo.metadata instead
+ * @deprecated Use SessionInfo.metadata instead
  */
 export interface LegacySessionItemInfo {
   id: string;


### PR DESCRIPTION
## Summary

To make Agent UI Builder's API design **_cleaner_** at https://github.com/bytedance/UI-TARS-desktop/pull/1436, we renamed "SessionItemInfo" to "SessionInfo" throughout the multimodal directory to improve naming consistency. We also updated the comment to clarify that "SessionMetadata" is just a field of "SessionInfo".

## Checklist

- [ ] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [x] My change does not involve the above items.