### PR TITLE
feat(tarko): add navbar logo display options

### DIFF
--- a/multimodal/tarko/agent-ui/src/standalone/app/App.tsx
+++ b/multimodal/tarko/agent-ui/src/standalone/app/App.tsx
@@ -48,7 +48,6 @@ export const App: React.FC = () => {
 
   // Special handling for replay mode - bypass normal routing
   if (isReplayMode) {
-    debugger;
     console.log('[ReplayMode] Rendering replay layout directly');
     return <Layout isReplayMode={true} />;
   }

--- a/multimodal/tarko/agent-ui/src/standalone/navbar/Navbar.tsx
+++ b/multimodal/tarko/agent-ui/src/standalone/navbar/Navbar.tsx
@@ -87,9 +87,6 @@ export const Navbar: React.FC = () => {
     }
   }, []);
 
-  debugger;
-  debugger;
-
   // Toggle dark mode
   const toggleDarkMode = useCallback(() => {
     const newMode = !isDarkMode;


### PR DESCRIPTION
## Summary

Adds three navbar logo display options via URL query parameter `?logo=`:

- `logo`: Shows agent logo (default behavior)
- `traffic-lights`: Shows macOS-style traffic lights
- `space`: Shows empty space (54px width) for wrapped scenarios with existing traffic lights

Replaces the previous binary `agent-tars`/default logic with more flexible options.

## Checklist

- [ ] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [x] My change does not involve the above items.