### PR TITLE
fix(tarko): external `@tarko/agent-ui-builder` in agent-cli build

### DIFF
--- a/multimodal/tarko/agent-cli/rslib.config.ts
+++ b/multimodal/tarko/agent-cli/rslib.config.ts
@@ -46,7 +46,7 @@ export default defineConfig({
         peerDependencies: true,
       },
       output: {
-        externals: ['@agent-tars/core', '@tarko/agent-server', '@tarko/shared-utils'],
+        externals: ['@agent-tars/core', '@tarko/agent-server', '@tarko/shared-utils', '@tarko/agent-ui-builder'],
       },
     },
   ],


### PR DESCRIPTION
## Summary

Externalize `@tarko/agent-ui-builder` in `agent-cli` build configuration to prevent bundling issues with static path resolution.

## Checklist

- [ ] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [x] My change does not involve the above items.