### PR TITLE
feat(mcp-servers): support mcp offical registry

### DIFF
--- a/.changeset/olive-mangos-leave.md
+++ b/.changeset/olive-mangos-leave.md
@@ -1,9 +1,0 @@
----
-'@agent-infra/mcp-server-filesystem': patch
-'@agent-infra/mcp-server-commands': patch
-'@agent-infra/mcp-server-browser': patch
-'@agent-infra/mcp-server-search': patch
-'create-new-mcp': patch
----
-
-feat(mcp-servers): support mcp offical registry

--- a/.changeset/olive-mangos-leave.md
+++ b/.changeset/olive-mangos-leave.md
@@ -1,0 +1,9 @@
+---
+'@agent-infra/mcp-server-filesystem': patch
+'@agent-infra/mcp-server-commands': patch
+'@agent-infra/mcp-server-browser': patch
+'@agent-infra/mcp-server-search': patch
+'create-new-mcp': patch
+---
+
+feat(mcp-servers): support mcp offical registry

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ coverage/
 scripts/merge-yml/*.yml
 .claude/
 .tarko
+.mcp*_token

--- a/packages/agent-infra/create-new-mcp/CHANGELOG.md
+++ b/packages/agent-infra/create-new-mcp/CHANGELOG.md
@@ -1,5 +1,11 @@
 # create-new-mcp
 
+## 1.1.3
+
+### Patch Changes
+
+- 910105e: feat(mcp-servers): support mcp offical registry
+
 ## 1.1.2
 
 ### Patch Changes

--- a/packages/agent-infra/create-new-mcp/package.json
+++ b/packages/agent-infra/create-new-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "create-new-mcp",
   "type": "module",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Create MCP server template",
   "license": "MIT",
   "bugs": "https://github.com/bytedance/UI-TARS-desktop/issues",

--- a/packages/agent-infra/create-new-mcp/template-default/package.json
+++ b/packages/agent-infra/create-new-mcp/template-default/package.json
@@ -17,8 +17,7 @@
     "mcp-server-{{name}}": "./dist/index.cjs"
   },
   "files": [
-    "dist",
-    "server.json"
+    "dist"
   ],
   "scripts": {
     "clean": "shx rm -rf build",

--- a/packages/agent-infra/create-new-mcp/template-default/package.json
+++ b/packages/agent-infra/create-new-mcp/template-default/package.json
@@ -1,6 +1,7 @@
 {
   "name": "mcp-server-{{name}}",
   "version": "1.0.0",
+  "mcpName": "io.github.username/mcp-server-{{name}}",
   "description": "An MCP server for {{name}}",
   "type": "module",
   "main": "./dist/server.cjs",
@@ -16,7 +17,8 @@
     "mcp-server-{{name}}": "./dist/index.cjs"
   },
   "files": [
-    "dist"
+    "dist",
+    "server.json"
   ],
   "scripts": {
     "clean": "shx rm -rf build",

--- a/packages/agent-infra/create-new-mcp/template-default/server.json
+++ b/packages/agent-infra/create-new-mcp/template-default/server.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
+  "name": "io.github.username/mcp-server-{{name}}",
+  "description": "MCP server for browser use access",
+  "status": "active",
+  "repository": {
+    "url": "https://github.com/username/mcp-server-{{name}}",
+    "source": "github"
+  },
+  "version": "1.0.0",
+  "packages": [
+    {
+      "registry_type": "npm",
+      "registry_base_url": "https://registry.npmjs.org",
+      "identifier": "mcp-server-{{name}}",
+      "version": "latest",
+      "transport": {
+        "type": "stdio"
+      },
+      "package_arguments": [],
+      "environment_variables": []
+    },
+    {
+      "registry_type": "npm",
+      "registry_base_url": "https://registry.npmjs.org",
+      "identifier": "mcp-server-{{name}}",
+      "version": "latest",
+      "runtime_hint": "npx",
+      "transport": {
+        "type": "sse",
+        "url": "http://127.0.0.1:{port}/sse"
+      },
+      "runtime_arguments": [],
+      "package_arguments": [
+        {
+          "type": "named",
+          "name": "port",
+          "description": "Server port number",
+          "format": "number",
+          "is_required": true,
+          "default": "8089"
+        }
+      ],
+      "environment_variables": []
+    },
+    {
+      "registry_type": "npm",
+      "registry_base_url": "https://registry.npmjs.org",
+      "identifier": "mcp-server-{{name}}",
+      "version": "latest",
+      "runtime_hint": "npx",
+      "transport": {
+        "type": "streamable-http",
+        "url": "http://127.0.0.1:{port}/mcp"
+      },
+      "runtime_arguments": [],
+      "package_arguments": [
+        {
+          "type": "named",
+          "name": "port",
+          "description": "Server port number",
+          "format": "number",
+          "is_required": true,
+          "default": "8089"
+        }
+      ],
+      "environment_variables": []
+    }
+  ]
+}

--- a/packages/agent-infra/mcp-client/CHANGELOG.md
+++ b/packages/agent-infra/mcp-client/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @agent-infra/mcp-client
 
+## 1.2.23
+
+### Patch Changes
+
+- @agent-infra/mcp-shared@1.2.23
+
 ## 1.2.22
 
 ### Patch Changes

--- a/packages/agent-infra/mcp-client/CHANGELOG.md
+++ b/packages/agent-infra/mcp-client/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @agent-infra/mcp-client
 
+## 1.2.22
+
+### Patch Changes
+
+- @agent-infra/mcp-shared@1.2.22
+
 ## 1.2.21
 
 ### Patch Changes

--- a/packages/agent-infra/mcp-client/package.json
+++ b/packages/agent-infra/mcp-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-infra/mcp-client",
-  "version": "1.2.22",
+  "version": "1.2.23",
   "description": "An MCP Client to run servers for Electron apps, support same-process approaching",
   "types": "./dist/index.d.ts",
   "main": "./dist/index.js",

--- a/packages/agent-infra/mcp-client/package.json
+++ b/packages/agent-infra/mcp-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-infra/mcp-client",
-  "version": "1.2.21",
+  "version": "1.2.22",
   "description": "An MCP Client to run servers for Electron apps, support same-process approaching",
   "types": "./dist/index.d.ts",
   "main": "./dist/index.js",

--- a/packages/agent-infra/mcp-servers/browser/CHANGELOG.md
+++ b/packages/agent-infra/mcp-servers/browser/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @agent-infra/mcp-server-browser
 
+## 1.2.23
+
+### Patch Changes
+
+- chore: rename mcpName
+
 ## 1.2.22
 
 ### Patch Changes

--- a/packages/agent-infra/mcp-servers/browser/CHANGELOG.md
+++ b/packages/agent-infra/mcp-servers/browser/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @agent-infra/mcp-server-browser
 
+## 1.2.22
+
+### Patch Changes
+
+- 910105e: feat(mcp-servers): support mcp offical registry
+
 ## 1.2.21
 
 ### Patch Changes

--- a/packages/agent-infra/mcp-servers/browser/package.json
+++ b/packages/agent-infra/mcp-servers/browser/package.json
@@ -33,8 +33,7 @@
     }
   },
   "files": [
-    "dist",
-    "server.json"
+    "dist"
   ],
   "scripts": {
     "build": "shx rm -rf dist && rslib build && shx chmod +x dist/*.{js,cjs}",

--- a/packages/agent-infra/mcp-servers/browser/package.json
+++ b/packages/agent-infra/mcp-servers/browser/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@agent-infra/mcp-server-browser",
   "version": "1.2.21",
+  "mcpName": "io.github.agent-infra/mcp-server-browser",
   "description": "MCP server for browser use access",
   "license": "MIT",
   "homepage": "https://github.com/bytedance/UI-TARS-desktop",
   "bugs": "https://github.com/bytedance/UI-TARS-desktop/issues",
-  "mcpName": "io.github.agent-infra/mcp-server-browser",
   "type": "module",
   "repository": {
     "type": "git",

--- a/packages/agent-infra/mcp-servers/browser/package.json
+++ b/packages/agent-infra/mcp-servers/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-infra/mcp-server-browser",
-  "version": "1.2.22",
+  "version": "1.2.23",
   "mcpName": "io.github.bytedance/mcp-server-browser",
   "description": "MCP server for browser use access",
   "license": "MIT",

--- a/packages/agent-infra/mcp-servers/browser/package.json
+++ b/packages/agent-infra/mcp-servers/browser/package.json
@@ -33,7 +33,8 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "server.json"
   ],
   "scripts": {
     "build": "shx rm -rf dist && rslib build && shx chmod +x dist/*.{js,cjs}",

--- a/packages/agent-infra/mcp-servers/browser/package.json
+++ b/packages/agent-infra/mcp-servers/browser/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agent-infra/mcp-server-browser",
   "version": "1.2.22",
-  "mcpName": "io.github.agent-infra/mcp-server-browser",
+  "mcpName": "io.github.bytedance/mcp-server-browser",
   "description": "MCP server for browser use access",
   "license": "MIT",
   "homepage": "https://github.com/bytedance/UI-TARS-desktop",

--- a/packages/agent-infra/mcp-servers/browser/package.json
+++ b/packages/agent-infra/mcp-servers/browser/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "homepage": "https://github.com/bytedance/UI-TARS-desktop",
   "bugs": "https://github.com/bytedance/UI-TARS-desktop/issues",
+  "mcpName": "io.github.agent-infra/mcp-server-browser",
   "type": "module",
   "repository": {
     "type": "git",

--- a/packages/agent-infra/mcp-servers/browser/package.json
+++ b/packages/agent-infra/mcp-servers/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-infra/mcp-server-browser",
-  "version": "1.2.21",
+  "version": "1.2.22",
   "mcpName": "io.github.agent-infra/mcp-server-browser",
   "description": "MCP server for browser use access",
   "license": "MIT",

--- a/packages/agent-infra/mcp-servers/browser/server.json
+++ b/packages/agent-infra/mcp-servers/browser/server.json
@@ -1,0 +1,263 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
+  "name": "io.github.agent-infra/mcp-server-browser",
+  "description": "MCP server for browser use access",
+  "status": "active",
+  "repository": {
+    "url": "https://github.com/bytedance/UI-TARS-desktop",
+    "source": "github"
+  },
+  "version": "1.0.0",
+  "packages": [
+    {
+      "registry_type": "npm",
+      "registry_base_url": "https://registry.npmjs.org",
+      "identifier": "@agent-infra/mcp-server-browser",
+      "version": "latest",
+      "transport": {
+        "type": "stdio"
+      },
+      "package_arguments": [
+        {
+          "type": "named",
+          "name": "browser",
+          "description": "browser or chrome channel to use, possible values: chrome, edge, firefox.",
+          "format": "string",
+          "is_required": false
+        },
+        {
+          "type": "named",
+          "name": "cdp-endpoint",
+          "description": "Chrome DevTools Protocol endpoint URL",
+          "format": "string",
+          "is_required": false
+        },
+        {
+          "type": "named",
+          "name": "ws-endpoint",
+          "description": "WebSocket endpoint to connect to, for example",
+          "format": "string",
+          "is_required": false
+        },
+        {
+          "type": "named",
+          "name": "executable-path",
+          "description": "Path to the browser executable",
+          "format": "string",
+          "is_required": false
+        },
+        {
+          "type": "named",
+          "name": "output-dir",
+          "description": "Path to the output directory",
+          "format": "string",
+          "is_required": false
+        },
+        {
+          "type": "named",
+          "name": "proxy-bypass",
+          "description": "Comma-separated list of patterns to bypass the proxy",
+          "format": "string",
+          "is_required": false
+        },
+        {
+          "type": "named",
+          "name": "proxy-server",
+          "description": "Proxy server address",
+          "format": "string",
+          "is_required": false
+        },
+        {
+          "type": "named",
+          "name": "vision",
+          "description": "Run server that uses screenshots (Aria snapshots are used by default)",
+          "format": "boolean",
+          "is_required": false
+        }
+      ],
+      "environment_variables": [
+        {
+          "description": "DISPLAY environment variable for browser rendering",
+          "is_required": false,
+          "format": "string",
+          "is_secret": false,
+          "name": "DISPLAY"
+        }
+      ]
+    },
+    {
+      "registry_type": "npm",
+      "registry_base_url": "https://registry.npmjs.org",
+      "identifier": "@agent-infra/mcp-server-browser",
+      "version": "latest",
+      "runtime_hint": "npx",
+      "transport": {
+        "type": "sse",
+        "url": "http://127.0.0.1:{port}/sse"
+      },
+      "runtime_arguments": [],
+      "package_arguments": [
+        {
+          "type": "named",
+          "name": "port",
+          "description": "Server port number",
+          "format": "number",
+          "is_required": true,
+          "default": "8089"
+        },
+        {
+          "type": "named",
+          "name": "browser",
+          "description": "browser or chrome channel to use, possible values: chrome, edge, firefox.",
+          "format": "string",
+          "is_required": false
+        },
+        {
+          "type": "named",
+          "name": "cdp-endpoint",
+          "description": "Chrome DevTools Protocol endpoint URL",
+          "format": "string",
+          "is_required": false
+        },
+        {
+          "type": "named",
+          "name": "ws-endpoint",
+          "description": "WebSocket endpoint to connect to, for example",
+          "format": "string",
+          "is_required": false
+        },
+        {
+          "type": "named",
+          "name": "executable-path",
+          "description": "Path to the browser executable",
+          "format": "string",
+          "is_required": false
+        },
+        {
+          "type": "named",
+          "name": "output-dir",
+          "description": "Path to the output directory",
+          "format": "string",
+          "is_required": false
+        },
+        {
+          "type": "named",
+          "name": "proxy-bypass",
+          "description": "Comma-separated list of patterns to bypass the proxy",
+          "format": "string",
+          "is_required": false
+        },
+        {
+          "type": "named",
+          "name": "proxy-server",
+          "description": "Proxy server address",
+          "format": "string",
+          "is_required": false
+        },
+        {
+          "type": "named",
+          "name": "vision",
+          "description": "Run server that uses screenshots (Aria snapshots are used by default)",
+          "format": "boolean",
+          "is_required": false
+        }
+      ],
+      "environment_variables": [
+        {
+          "description": "DISPLAY environment variable for browser rendering",
+          "is_required": false,
+          "format": "string",
+          "is_secret": false,
+          "name": "DISPLAY"
+        }
+      ]
+    },
+    {
+      "registry_type": "npm",
+      "registry_base_url": "https://registry.npmjs.org",
+      "identifier": "@agent-infra/mcp-server-browser",
+      "version": "latest",
+      "runtime_hint": "npx",
+      "transport": {
+        "type": "streamable-http",
+        "url": "http://127.0.0.1:{port}/mcp"
+      },
+      "runtime_arguments": [],
+      "package_arguments": [
+        {
+          "type": "named",
+          "name": "port",
+          "description": "Server port number",
+          "format": "number",
+          "is_required": true,
+          "default": "8089"
+        },
+        {
+          "type": "named",
+          "name": "browser",
+          "description": "browser or chrome channel to use, possible values: chrome, edge, firefox.",
+          "format": "string",
+          "is_required": false
+        },
+        {
+          "type": "named",
+          "name": "cdp-endpoint",
+          "description": "Chrome DevTools Protocol endpoint URL",
+          "format": "string",
+          "is_required": false
+        },
+        {
+          "type": "named",
+          "name": "ws-endpoint",
+          "description": "WebSocket endpoint to connect to, for example",
+          "format": "string",
+          "is_required": false
+        },
+        {
+          "type": "named",
+          "name": "executable-path",
+          "description": "Path to the browser executable",
+          "format": "string",
+          "is_required": false
+        },
+        {
+          "type": "named",
+          "name": "output-dir",
+          "description": "Path to the output directory",
+          "format": "string",
+          "is_required": false
+        },
+        {
+          "type": "named",
+          "name": "proxy-bypass",
+          "description": "Comma-separated list of patterns to bypass the proxy",
+          "format": "string",
+          "is_required": false
+        },
+        {
+          "type": "named",
+          "name": "proxy-server",
+          "description": "Proxy server address",
+          "format": "string",
+          "is_required": false
+        },
+        {
+          "type": "named",
+          "name": "vision",
+          "description": "Run server that uses screenshots (Aria snapshots are used by default)",
+          "format": "boolean",
+          "is_required": false
+        }
+      ],
+      "environment_variables": [
+        {
+          "description": "DISPLAY environment variable for browser rendering",
+          "is_required": false,
+          "format": "string",
+          "is_secret": false,
+          "name": "DISPLAY"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/agent-infra/mcp-servers/browser/server.json
+++ b/packages/agent-infra/mcp-servers/browser/server.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
-  "name": "io.github.agent-infra/mcp-server-browser",
+  "name": "io.github.bytedance/mcp-server-browser",
   "description": "MCP server for browser use access",
   "status": "active",
   "repository": {

--- a/packages/agent-infra/mcp-servers/browser/server.json
+++ b/packages/agent-infra/mcp-servers/browser/server.json
@@ -5,7 +5,8 @@
   "status": "active",
   "repository": {
     "url": "https://github.com/bytedance/UI-TARS-desktop",
-    "source": "github"
+    "source": "github",
+    "subfolder": "packages/agent-infra/mcp-servers/browser"
   },
   "version": "1.0.0",
   "packages": [

--- a/packages/agent-infra/mcp-servers/commands/CHANGELOG.md
+++ b/packages/agent-infra/mcp-servers/commands/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## 0.4.0 2024-12-10 - add logging
 
+## 1.2.23
+
+### Patch Changes
+
+- chore: rename mcpName
+
 ## 1.2.22
 
 ### Patch Changes

--- a/packages/agent-infra/mcp-servers/commands/CHANGELOG.md
+++ b/packages/agent-infra/mcp-servers/commands/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## 0.4.0 2024-12-10 - add logging
 
+## 1.2.22
+
+### Patch Changes
+
+- 910105e: feat(mcp-servers): support mcp offical registry
+
 ## 1.2.21
 
 ### Patch Changes

--- a/packages/agent-infra/mcp-servers/commands/package.json
+++ b/packages/agent-infra/mcp-servers/commands/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@agent-infra/mcp-server-commands",
   "version": "1.2.21",
+  "mcpName": "io.github.agent-infra/mcp-server-commands",
   "description": "An MCP server to run arbitrary commands",
   "type": "module",
   "main": "./dist/server.cjs",

--- a/packages/agent-infra/mcp-servers/commands/package.json
+++ b/packages/agent-infra/mcp-servers/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-infra/mcp-server-commands",
-  "version": "1.2.22",
+  "version": "1.2.23",
   "mcpName": "io.github.bytedance/mcp-server-commands",
   "description": "An MCP server to run arbitrary commands",
   "type": "module",

--- a/packages/agent-infra/mcp-servers/commands/package.json
+++ b/packages/agent-infra/mcp-servers/commands/package.json
@@ -24,7 +24,8 @@
     "directory": "packages/agent-infra/mcp-servers/commands"
   },
   "files": [
-    "dist"
+    "dist",
+    "server.json"
   ],
   "scripts": {
     "clean": "shx rm -rf build",

--- a/packages/agent-infra/mcp-servers/commands/package.json
+++ b/packages/agent-infra/mcp-servers/commands/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agent-infra/mcp-server-commands",
   "version": "1.2.22",
-  "mcpName": "io.github.agent-infra/mcp-server-commands",
+  "mcpName": "io.github.bytedance/mcp-server-commands",
   "description": "An MCP server to run arbitrary commands",
   "type": "module",
   "main": "./dist/server.cjs",

--- a/packages/agent-infra/mcp-servers/commands/package.json
+++ b/packages/agent-infra/mcp-servers/commands/package.json
@@ -24,8 +24,7 @@
     "directory": "packages/agent-infra/mcp-servers/commands"
   },
   "files": [
-    "dist",
-    "server.json"
+    "dist"
   ],
   "scripts": {
     "clean": "shx rm -rf build",

--- a/packages/agent-infra/mcp-servers/commands/package.json
+++ b/packages/agent-infra/mcp-servers/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-infra/mcp-server-commands",
-  "version": "1.2.21",
+  "version": "1.2.22",
   "mcpName": "io.github.agent-infra/mcp-server-commands",
   "description": "An MCP server to run arbitrary commands",
   "type": "module",

--- a/packages/agent-infra/mcp-servers/commands/server.json
+++ b/packages/agent-infra/mcp-servers/commands/server.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
-  "name": "io.github.agent-infra/mcp-server-commands",
+  "name": "io.github.bytedance/mcp-server-commands",
   "description": "An MCP server to run arbitrary commands",
   "status": "active",
   "repository": {

--- a/packages/agent-infra/mcp-servers/commands/server.json
+++ b/packages/agent-infra/mcp-servers/commands/server.json
@@ -5,7 +5,8 @@
   "status": "active",
   "repository": {
     "url": "https://github.com/bytedance/UI-TARS-desktop",
-    "source": "github"
+    "source": "github",
+    "subfolder": "packages/agent-infra/mcp-servers/commands"
   },
   "version": "1.0.0",
   "packages": [

--- a/packages/agent-infra/mcp-servers/commands/server.json
+++ b/packages/agent-infra/mcp-servers/commands/server.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
+  "name": "io.github.agent-infra/mcp-server-commands",
+  "description": "An MCP server to run arbitrary commands",
+  "status": "active",
+  "repository": {
+    "url": "https://github.com/bytedance/UI-TARS-desktop",
+    "source": "github"
+  },
+  "version": "1.0.0",
+  "packages": [
+    {
+      "registry_type": "npm",
+      "registry_base_url": "https://registry.npmjs.org",
+      "identifier": "@agent-infra/mcp-server-commands",
+      "version": "latest",
+      "transport": {
+        "type": "stdio"
+      },
+      "package_arguments": [
+        {
+          "type": "named",
+          "name": "cwd",
+          "description": "current working directory",
+          "format": "string",
+          "is_required": false
+        }
+      ],
+      "environment_variables": []
+    },
+    {
+      "registry_type": "npm",
+      "registry_base_url": "https://registry.npmjs.org",
+      "identifier": "@agent-infra/mcp-server-commands",
+      "version": "latest",
+      "runtime_hint": "npx",
+      "transport": {
+        "type": "sse",
+        "url": "http://127.0.0.1:{port}/sse"
+      },
+      "runtime_arguments": [],
+      "package_arguments": [
+        {
+          "type": "named",
+          "name": "cwd",
+          "description": "current working directory",
+          "format": "string",
+          "is_required": false
+        },
+        {
+          "type": "named",
+          "name": "port",
+          "description": "Server port number",
+          "format": "number",
+          "is_required": true,
+          "default": "8089"
+        }
+      ],
+      "environment_variables": []
+    },
+    {
+      "registry_type": "npm",
+      "registry_base_url": "https://registry.npmjs.org",
+      "identifier": "@agent-infra/mcp-server-commands",
+      "version": "latest",
+      "runtime_hint": "npx",
+      "transport": {
+        "type": "streamable-http",
+        "url": "http://127.0.0.1:{port}/mcp"
+      },
+      "runtime_arguments": [
+        {
+          "type": "named",
+          "name": "cwd",
+          "description": "current working directory",
+          "format": "string",
+          "is_required": false
+        }
+      ],
+      "package_arguments": [
+        {
+          "type": "named",
+          "name": "port",
+          "description": "Server port number",
+          "format": "number",
+          "is_required": true,
+          "default": "8089"
+        }
+      ],
+      "environment_variables": []
+    }
+  ]
+}

--- a/packages/agent-infra/mcp-servers/filesystem/CHANGELOG.md
+++ b/packages/agent-infra/mcp-servers/filesystem/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @agent-infra/mcp-server-filesystem
 
+## 1.2.23
+
+### Patch Changes
+
+- chore: rename mcpName
+
 ## 1.2.22
 
 ### Patch Changes

--- a/packages/agent-infra/mcp-servers/filesystem/CHANGELOG.md
+++ b/packages/agent-infra/mcp-servers/filesystem/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @agent-infra/mcp-server-filesystem
 
+## 1.2.22
+
+### Patch Changes
+
+- 910105e: feat(mcp-servers): support mcp offical registry
+
 ## 1.2.21
 
 ### Patch Changes

--- a/packages/agent-infra/mcp-servers/filesystem/package.json
+++ b/packages/agent-infra/mcp-servers/filesystem/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agent-infra/mcp-server-filesystem",
   "version": "1.2.22",
-  "mcpName": "io.github.agent-infra/mcp-server-filesystem",
+  "mcpName": "io.github.bytedance/mcp-server-filesystem",
   "description": "MCP server for filesystem access",
   "license": "MIT",
   "type": "module",

--- a/packages/agent-infra/mcp-servers/filesystem/package.json
+++ b/packages/agent-infra/mcp-servers/filesystem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-infra/mcp-server-filesystem",
-  "version": "1.2.21",
+  "version": "1.2.22",
   "mcpName": "io.github.agent-infra/mcp-server-filesystem",
   "description": "MCP server for filesystem access",
   "license": "MIT",

--- a/packages/agent-infra/mcp-servers/filesystem/package.json
+++ b/packages/agent-infra/mcp-servers/filesystem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-infra/mcp-server-filesystem",
-  "version": "1.2.22",
+  "version": "1.2.23",
   "mcpName": "io.github.bytedance/mcp-server-filesystem",
   "description": "MCP server for filesystem access",
   "license": "MIT",

--- a/packages/agent-infra/mcp-servers/filesystem/package.json
+++ b/packages/agent-infra/mcp-servers/filesystem/package.json
@@ -25,8 +25,7 @@
     "mcp-server-filesystem": "dist/index.cjs"
   },
   "files": [
-    "dist",
-    "server.json"
+    "dist"
   ],
   "scripts": {
     "build": "shx rm -rf dist && rslib build && shx chmod +x dist/*.js",

--- a/packages/agent-infra/mcp-servers/filesystem/package.json
+++ b/packages/agent-infra/mcp-servers/filesystem/package.json
@@ -25,7 +25,8 @@
     "mcp-server-filesystem": "dist/index.cjs"
   },
   "files": [
-    "dist"
+    "dist",
+    "server.json"
   ],
   "scripts": {
     "build": "shx rm -rf dist && rslib build && shx chmod +x dist/*.js",

--- a/packages/agent-infra/mcp-servers/filesystem/package.json
+++ b/packages/agent-infra/mcp-servers/filesystem/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@agent-infra/mcp-server-filesystem",
   "version": "1.2.21",
+  "mcpName": "io.github.agent-infra/mcp-server-filesystem",
   "description": "MCP server for filesystem access",
   "license": "MIT",
   "type": "module",

--- a/packages/agent-infra/mcp-servers/filesystem/server.json
+++ b/packages/agent-infra/mcp-servers/filesystem/server.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
-  "name": "io.github.agent-infra/mcp-server-filesystem",
+  "name": "io.github.bytedance/mcp-server-filesystem",
   "description": "MCP server for filesystem access",
   "status": "active",
   "repository": {

--- a/packages/agent-infra/mcp-servers/filesystem/server.json
+++ b/packages/agent-infra/mcp-servers/filesystem/server.json
@@ -5,7 +5,8 @@
   "status": "active",
   "repository": {
     "url": "https://github.com/bytedance/UI-TARS-desktop",
-    "source": "github"
+    "source": "github",
+    "subfolder": "packages/agent-infra/mcp-servers/filesystem"
   },
   "version": "1.0.0",
   "packages": [

--- a/packages/agent-infra/mcp-servers/filesystem/server.json
+++ b/packages/agent-infra/mcp-servers/filesystem/server.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
+  "name": "io.github.agent-infra/mcp-server-filesystem",
+  "description": "MCP server for filesystem access",
+  "status": "active",
+  "repository": {
+    "url": "https://github.com/bytedance/UI-TARS-desktop",
+    "source": "github"
+  },
+  "version": "1.0.0",
+  "packages": [
+    {
+      "registry_type": "npm",
+      "registry_base_url": "https://registry.npmjs.org",
+      "identifier": "@agent-infra/mcp-server-filesystem",
+      "version": "latest",
+      "transport": {
+        "type": "stdio"
+      },
+      "package_arguments": [
+        {
+          "type": "named",
+          "name": "allowed-directories",
+          "description": "Comma-separated list of allowed directories for file operations",
+          "format": "string",
+          "is_required": true
+        }
+      ]
+    },
+    {
+      "registry_type": "npm",
+      "registry_base_url": "https://registry.npmjs.org",
+      "identifier": "@agent-infra/mcp-server-filesystem",
+      "version": "latest",
+      "runtime_hint": "npx",
+      "transport": {
+        "type": "sse",
+        "url": "http://127.0.0.1:{port}/sse"
+      },
+      "runtime_arguments": [],
+      "package_arguments": [
+        {
+          "type": "named",
+          "name": "allowed-directories",
+          "description": "Comma-separated list of allowed directories for file operations",
+          "format": "string",
+          "is_required": true
+        },
+        {
+          "type": "named",
+          "name": "port",
+          "description": "Server port number",
+          "format": "number",
+          "is_required": true,
+          "default": "8089"
+        }
+      ],
+      "environment_variables": []
+    },
+    {
+      "registry_type": "npm",
+      "registry_base_url": "https://registry.npmjs.org",
+      "identifier": "@agent-infra/mcp-server-filesystem",
+      "version": "latest",
+      "runtime_hint": "npx",
+      "transport": {
+        "type": "streamable-http",
+        "url": "http://127.0.0.1:{port}/mcp"
+      },
+      "runtime_arguments": [],
+      "package_arguments": [
+        {
+          "type": "named",
+          "name": "allowed-directories",
+          "description": "Comma-separated list of allowed directories for file operations",
+          "format": "string",
+          "is_required": true
+        },
+        {
+          "type": "named",
+          "name": "port",
+          "description": "Server port number",
+          "format": "number",
+          "is_required": true,
+          "default": "8089"
+        }
+      ],
+      "environment_variables": []
+    }
+  ]
+}

--- a/packages/agent-infra/mcp-servers/search/CHANGELOG.md
+++ b/packages/agent-infra/mcp-servers/search/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @agent-infra/mcp-server-search
 
+## 1.2.22
+
+### Patch Changes
+
+- 910105e: feat(mcp-servers): support mcp offical registry
+
 ## 1.2.21
 
 ### Patch Changes

--- a/packages/agent-infra/mcp-servers/search/CHANGELOG.md
+++ b/packages/agent-infra/mcp-servers/search/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @agent-infra/mcp-server-search
 
+## 1.2.23
+
+### Patch Changes
+
+- chore: rename mcpName
+
 ## 1.2.22
 
 ### Patch Changes

--- a/packages/agent-infra/mcp-servers/search/package.json
+++ b/packages/agent-infra/mcp-servers/search/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agent-infra/mcp-server-search",
   "version": "1.2.22",
-  "mcpName": "io.github.agent-infra/mcp-server-search",
+  "mcpName": "io.github.bytedance/mcp-server-search",
   "description": "MCP server for web search operations",
   "type": "module",
   "main": "./dist/server.cjs",

--- a/packages/agent-infra/mcp-servers/search/package.json
+++ b/packages/agent-infra/mcp-servers/search/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@agent-infra/mcp-server-search",
   "version": "1.2.21",
+  "mcpName": "io.github.agent-infra/mcp-server-search",
   "description": "MCP server for web search operations",
   "type": "module",
   "main": "./dist/server.cjs",

--- a/packages/agent-infra/mcp-servers/search/package.json
+++ b/packages/agent-infra/mcp-servers/search/package.json
@@ -17,7 +17,8 @@
     "mcp-server-search": "./dist/index.cjs"
   },
   "files": [
-    "dist"
+    "dist",
+    "server.json"
   ],
   "scripts": {
     "clean": "shx rm -rf dist",

--- a/packages/agent-infra/mcp-servers/search/package.json
+++ b/packages/agent-infra/mcp-servers/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-infra/mcp-server-search",
-  "version": "1.2.21",
+  "version": "1.2.22",
   "mcpName": "io.github.agent-infra/mcp-server-search",
   "description": "MCP server for web search operations",
   "type": "module",

--- a/packages/agent-infra/mcp-servers/search/package.json
+++ b/packages/agent-infra/mcp-servers/search/package.json
@@ -17,8 +17,7 @@
     "mcp-server-search": "./dist/index.cjs"
   },
   "files": [
-    "dist",
-    "server.json"
+    "dist"
   ],
   "scripts": {
     "clean": "shx rm -rf dist",

--- a/packages/agent-infra/mcp-servers/search/package.json
+++ b/packages/agent-infra/mcp-servers/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-infra/mcp-server-search",
-  "version": "1.2.22",
+  "version": "1.2.23",
   "mcpName": "io.github.bytedance/mcp-server-search",
   "description": "MCP server for web search operations",
   "type": "module",

--- a/packages/agent-infra/mcp-servers/search/server.json
+++ b/packages/agent-infra/mcp-servers/search/server.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
-  "name": "io.github.agent-infra/mcp-server-search",
+  "name": "io.github.bytedance/mcp-server-search",
   "description": "MCP server for web search operations",
   "status": "active",
   "repository": {

--- a/packages/agent-infra/mcp-servers/search/server.json
+++ b/packages/agent-infra/mcp-servers/search/server.json
@@ -5,7 +5,8 @@
   "status": "active",
   "repository": {
     "url": "https://github.com/bytedance/UI-TARS-desktop",
-    "source": "github"
+    "source": "github",
+    "subfolder": "packages/agent-infra/mcp-servers/search"
   },
   "version": "1.0.0",
   "packages": [

--- a/packages/agent-infra/mcp-servers/search/server.json
+++ b/packages/agent-infra/mcp-servers/search/server.json
@@ -1,0 +1,136 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
+  "name": "io.github.agent-infra/mcp-server-search",
+  "description": "MCP server for web search operations",
+  "status": "active",
+  "repository": {
+    "url": "https://github.com/bytedance/UI-TARS-desktop",
+    "source": "github"
+  },
+  "version": "1.0.0",
+  "packages": [
+    {
+      "registry_type": "npm",
+      "registry_base_url": "https://registry.npmjs.org",
+      "identifier": "@agent-infra/mcp-server-search",
+      "version": "latest",
+      "transport": {
+        "type": "stdio"
+      },
+      "package_arguments": [
+        {
+          "type": "named",
+          "name": "engine",
+          "description": "Search engine to use for browser search (default: google)",
+          "format": "string",
+          "default": "google",
+          "is_required": false
+        },
+        {
+          "type": "named",
+          "name": "api-key",
+          "description": "API key for the search provider",
+          "format": "string",
+          "is_required": false
+        },
+        {
+          "type": "named",
+          "name": "base-url",
+          "description": "Base URL for the search provider",
+          "format": "string",
+          "is_required": false
+        }
+      ]
+    },
+    {
+      "registry_type": "npm",
+      "registry_base_url": "https://registry.npmjs.org",
+      "identifier": "@agent-infra/mcp-server-search",
+      "version": "latest",
+      "runtime_hint": "npx",
+      "transport": {
+        "type": "sse",
+        "url": "http://127.0.0.1:{port}/sse"
+      },
+      "runtime_arguments": [],
+      "package_arguments": [
+        {
+          "type": "named",
+          "name": "engine",
+          "description": "Search engine to use for browser search (default: google)",
+          "format": "string",
+          "default": "google",
+          "is_required": false
+        },
+        {
+          "type": "named",
+          "name": "api-key",
+          "description": "API key for the search provider",
+          "format": "string",
+          "is_required": false
+        },
+        {
+          "type": "named",
+          "name": "base-url",
+          "description": "Base URL for the search provider",
+          "format": "string",
+          "is_required": false
+        },
+        {
+          "type": "named",
+          "name": "port",
+          "description": "Server port number",
+          "format": "number",
+          "is_required": true,
+          "default": "8089"
+        }
+      ],
+      "environment_variables": []
+    },
+    {
+      "registry_type": "npm",
+      "registry_base_url": "https://registry.npmjs.org",
+      "identifier": "@agent-infra/mcp-server-search",
+      "version": "latest",
+      "runtime_hint": "npx",
+      "transport": {
+        "type": "streamable-http",
+        "url": "http://127.0.0.1:{port}/mcp"
+      },
+      "runtime_arguments": [],
+      "package_arguments": [
+        {
+          "type": "named",
+          "name": "engine",
+          "description": "Search engine to use for browser search (default: google)",
+          "format": "string",
+          "default": "google",
+          "is_required": false
+        },
+        {
+          "type": "named",
+          "name": "api-key",
+          "description": "API key for the search provider",
+          "format": "string",
+          "is_required": false
+        },
+        {
+          "type": "named",
+          "name": "base-url",
+          "description": "Base URL for the search provider",
+          "format": "string",
+          "is_required": false
+        },
+        {
+          "type": "named",
+          "name": "port",
+          "description": "Server port number",
+          "format": "number",
+          "is_required": true,
+          "default": "8089"
+        }
+      ],
+      "environment_variables": []
+    }
+  ]
+}

--- a/packages/agent-infra/mcp-shared/CHANGELOG.md
+++ b/packages/agent-infra/mcp-shared/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @agent-infra/mcp-shared
 
+## 1.2.23
+
 ## 1.2.22
 
 ## 1.2.21

--- a/packages/agent-infra/mcp-shared/CHANGELOG.md
+++ b/packages/agent-infra/mcp-shared/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @agent-infra/mcp-shared
 
+## 1.2.22
+
 ## 1.2.21
 
 ## 1.2.20

--- a/packages/agent-infra/mcp-shared/package.json
+++ b/packages/agent-infra/mcp-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-infra/mcp-shared",
-  "version": "1.2.22",
+  "version": "1.2.23",
   "description": "MCP shared",
   "license": "MIT",
   "homepage": "https://github.com/bytedance/UI-TARS-desktop",

--- a/packages/agent-infra/mcp-shared/package.json
+++ b/packages/agent-infra/mcp-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-infra/mcp-shared",
-  "version": "1.2.21",
+  "version": "1.2.22",
   "description": "MCP shared",
   "license": "MIT",
   "homepage": "https://github.com/bytedance/UI-TARS-desktop",


### PR DESCRIPTION
- **feat(mcp-servers): support mcp offical registry**
- **chore: patch**

https://blog.modelcontextprotocol.io/posts/2025-09-08-mcp-registry-preview/

<img width="816" height="346" alt="image" src="https://github.com/user-attachments/assets/43fbb007-0b21-4b84-95eb-1401b9e40528" />
