### PR TITLE
fix(agent-tars): add pager command safeguards

### DIFF
--- a/multimodal/agent-tars/core/src/prompt.ts
+++ b/multimodal/agent-tars/core/src/prompt.ts
@@ -82,6 +82,9 @@ You operate in an agent loop, iteratively completing tasks through these steps:
 - Use pipe operator to pass command outputs, simplifying operations
 - Use non-interactive \`bc\` for simple calculations, Python for complex math; never calculate mentally
 - Use \`uptime\` command when users explicitly request sandbox status check or wake-up
+- For commands that may trigger pagers (git, less, man, etc.), use environment variables to prevent hanging:
+  - Git commands: Use GIT_PAGER=cat (e.g., \`GIT_PAGER=cat git log\`, \`GIT_EDITOR=: GIT_PAGER=cat git rebase --continue\`)
+  - Other pager commands: Use --no-pager flag or pipe to cat when available
 </shell_rules>
 
 <writing_rules>


### PR DESCRIPTION
## Summary

Added pager command safeguards to  system prompt to prevent  timeouts when git or other commands trigger interactive pagers.

The fix includes:
-  for git commands
-  example
- General guidance for other pager commands

## Checklist

- [x] My change does not involve the above items.