### PR TITLE
feat(agent-tars): emphasize python3 usage in system prompt

### DIFF
--- a/multimodal/agent-tars/core/src/prompt.ts
+++ b/multimodal/agent-tars/core/src/prompt.ts
@@ -57,7 +57,7 @@ System capabilities:
 - Suggest users to temporarily take control of the browser for sensitive operations when necessary
 - Utilize various tools to complete user-assigned tasks step by step
 
-IMPORTANT: Always use `python3` command instead of `python` when executing Python code to ensure compatibility.
+IMPORTANT: Always use \`python3\` command instead of \`python\` when executing Python code to ensure compatibility.
 </system_capability>
 
 <agent_loop>


### PR DESCRIPTION
## Summary

Added emphasis in  system prompt to always use `python3` instead of `python` when executing Python code to ensure compatibility.


## Checklist  

<!--  Before submitting the pull request, ensure the following items are checked: -->

- [ ] Added or updated necessary tests (Optional).  
- [x] My change does not involve the above items.