### PR TITLE
fix(tarko): remove language badge from code renderer header

### DIFF
--- a/multimodal/tarko/agent-ui/src/sdk/code-editor/CodeEditor.css
+++ b/multimodal/tarko/agent-ui/src/sdk/code-editor/CodeEditor.css
@@ -75,18 +75,6 @@
   max-width: 300px;
 }
 
-.code-editor-language-badge {
-  background: #21262d;
-  color: #7d8590;
-  padding: 2px 8px;
-  border-radius: 4px;
-  font-size: 11px;
-  font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  border: 1px solid #30363d;
-}
-
 .code-editor-actions {
   display: flex;
   gap: 4px;

--- a/multimodal/tarko/agent-ui/src/sdk/code-editor/CodeEditor.tsx
+++ b/multimodal/tarko/agent-ui/src/sdk/code-editor/CodeEditor.tsx
@@ -5,7 +5,6 @@ import './CodeEditor.css';
 
 interface CodeEditorProps {
   code: string;
-  language: string;
   fileName?: string;
   filePath?: string;
   fileSize?: string;
@@ -18,7 +17,6 @@ interface CodeEditorProps {
 
 export const CodeEditor: React.FC<CodeEditorProps> = ({
   code,
-  language,
   fileName,
   filePath,
   fileSize,
@@ -34,6 +32,10 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
 
   const codeRef = useRef<HTMLElement>(null);
 
+  const displayFileName = fileName || 'script';
+  const fileExtension = displayFileName.split('.').pop()?.toLowerCase() || '';
+  const language = fileExtension || 'text';
+
   useEffect(() => {
     if (codeRef.current) {
       codeRef.current.removeAttribute('data-highlighted');
@@ -48,7 +50,6 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
 
   const lines = code.split('\n');
   const lineCount = lines.length;
-  const displayFileName = fileName || `script.${language}`;
 
   return (
     <div className={`code-editor-container ${className}`}>
@@ -57,7 +58,6 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
           fileName={displayFileName}
           filePath={filePath}
           fileSize={fileSize}
-          language={language}
           onCopy={handleCopy}
         />
 

--- a/multimodal/tarko/agent-ui/src/sdk/code-editor/CodeEditorHeader.tsx
+++ b/multimodal/tarko/agent-ui/src/sdk/code-editor/CodeEditorHeader.tsx
@@ -5,7 +5,6 @@ interface CodeEditorHeaderProps {
   fileName?: string;
   filePath?: string;
   fileSize?: string;
-  language?: string;
   onCopy?: () => void;
   copyButtonTitle?: string;
   children?: React.ReactNode;
@@ -15,7 +14,6 @@ export const CodeEditorHeader: React.FC<CodeEditorHeaderProps> = ({
   fileName,
   filePath,
   fileSize,
-  language,
   onCopy,
   copyButtonTitle = 'Copy code',
   children,
@@ -53,8 +51,6 @@ export const CodeEditorHeader: React.FC<CodeEditorHeaderProps> = ({
         </div>
 
         {children}
-
-        {language && <div className="code-editor-language-badge">{language}</div>}
       </div>
 
       <div className="code-editor-actions">

--- a/multimodal/tarko/agent-ui/src/sdk/code-editor/DiffViewer.tsx
+++ b/multimodal/tarko/agent-ui/src/sdk/code-editor/DiffViewer.tsx
@@ -130,7 +130,6 @@ export const DiffViewer: React.FC<DiffViewerProps> = ({
         <CodeEditorHeader
           fileName={displayFileName}
           filePath={normalizedPath}
-          language={language}
           onCopy={handleCopy}
           copyButtonTitle="Copy diff"
         >

--- a/multimodal/tarko/agent-ui/src/sdk/code-editor/MonacoCodeEditor.tsx
+++ b/multimodal/tarko/agent-ui/src/sdk/code-editor/MonacoCodeEditor.tsx
@@ -6,7 +6,6 @@ import './MonacoCodeEditor.css';
 
 interface MonacoCodeEditorProps {
   code: string;
-  language: string;
   fileName?: string;
   filePath?: string;
   fileSize?: string;
@@ -20,7 +19,6 @@ interface MonacoCodeEditorProps {
 
 export const MonacoCodeEditor: React.FC<MonacoCodeEditorProps> = ({
   code,
-  language,
   fileName,
   filePath,
   fileSize,
@@ -104,8 +102,9 @@ export const MonacoCodeEditor: React.FC<MonacoCodeEditorProps> = ({
     return languageMap[lang.toLowerCase()] || 'plaintext';
   }, []);
 
-  const displayFileName = fileName || `script.${language}`;
-  const monacoLanguage = getMonacoLanguage(language);
+  const displayFileName = fileName || 'script';
+  const fileExtension = displayFileName.split('.').pop()?.toLowerCase() || '';
+  const monacoLanguage = getMonacoLanguage(fileExtension);
 
   return (
     <div className={`code-editor-container ${className}`}>
@@ -114,7 +113,6 @@ export const MonacoCodeEditor: React.FC<MonacoCodeEditorProps> = ({
           fileName={displayFileName}
           filePath={filePath}
           fileSize={fileSize}
-          language={language}
           onCopy={handleCopy}
         />
 

--- a/multimodal/tarko/agent-ui/src/standalone/workspace/renderers/FileResultRenderer.tsx
+++ b/multimodal/tarko/agent-ui/src/standalone/workspace/renderers/FileResultRenderer.tsx
@@ -6,7 +6,7 @@ import { DisplayMode } from './generic/types';
 import { MonacoCodeEditor } from '@/sdk/code-editor';
 import { useStableCodeContent } from '@/common/hooks/useStableValue';
 import { ThrottledHtmlRenderer } from '../components/ThrottledHtmlRenderer';
-import { getLanguageFromExtension, formatBytes } from '../utils/codeUtils';
+import { formatBytes } from '../utils/codeUtils';
 
 // Constants
 const MAX_HEIGHT_CALC = 'calc(100vh - 215px)';
@@ -46,9 +46,6 @@ export const FileResultRenderer: React.FC<FileResultRendererProps> = ({
   // Determine if content is currently streaming
   const isStreaming = panelContent.isStreaming || false;
 
-  // Get language for code highlighting
-  const language = getLanguageFromExtension(fileExtension);
-
   return (
     <div className="space-y-4">
       {/* Content preview area */}
@@ -72,7 +69,6 @@ export const FileResultRenderer: React.FC<FileResultRendererProps> = ({
             <div className="p-0">
               <MonacoCodeEditor
                 code={stableContent}
-                language={language}
                 fileName={fileName}
                 filePath={filePath}
                 fileSize={approximateSize}
@@ -86,7 +82,6 @@ export const FileResultRenderer: React.FC<FileResultRendererProps> = ({
               <div className="p-0">
                 <MonacoCodeEditor
                   code={stableContent}
-                  language="markdown"
                   fileName={fileName}
                   filePath={filePath}
                   fileSize={approximateSize}
@@ -109,7 +104,6 @@ export const FileResultRenderer: React.FC<FileResultRendererProps> = ({
             <div className="p-0">
               <MonacoCodeEditor
                 code={stableContent}
-                language="text"
                 fileName={fileName}
                 filePath={filePath}
                 fileSize={approximateSize}

--- a/multimodal/tarko/agent-ui/src/standalone/workspace/renderers/ScriptResultRenderer.tsx
+++ b/multimodal/tarko/agent-ui/src/standalone/workspace/renderers/ScriptResultRenderer.tsx
@@ -67,8 +67,7 @@ export const ScriptResultRenderer: React.FC<ScriptResultRendererProps> = ({ pane
   const isError = exitCode !== 0 && exitCode !== undefined;
   const hasOutput = stdout || stderr;
 
-  // Get language for syntax highlighting
-  const language = getLanguageFromInterpreter(interpreter);
+
 
   return (
     <div className="space-y-4">
@@ -130,8 +129,7 @@ export const ScriptResultRenderer: React.FC<ScriptResultRendererProps> = ({ pane
           {/* Professional code editor */}
           <CodeEditor
             code={script || ''}
-            language={language}
-            fileName={`script.${LANGUAGE_EXTENSIONS[language]}`}
+            fileName={`script.${LANGUAGE_EXTENSIONS[getLanguageFromInterpreter(interpreter)]}`}
             showLineNumbers={true}
             maxHeight={displayMode === 'both' ? '40vh' : '80vh'}
           />

--- a/multimodal/tarko/agent-ui/src/standalone/workspace/renderers/TabbedFilesRenderer.tsx
+++ b/multimodal/tarko/agent-ui/src/standalone/workspace/renderers/TabbedFilesRenderer.tsx
@@ -3,7 +3,7 @@ import { StandardPanelContent } from '../types/panelContent';
 import { FiFile, FiAlertCircle } from 'react-icons/fi';
 import { CodeEditor } from '@/sdk/code-editor';
 import { getFileTypeInfo } from '../utils/fileTypeUtils';
-import { getLanguageFromExtension, formatBytes } from '../utils/codeUtils';
+import { formatBytes } from '../utils/codeUtils';
 
 interface FileContent {
   path: string;
@@ -108,8 +108,7 @@ export const TabbedFilesRenderer: React.FC<TabbedFilesRendererProps> = ({
   }
 
   const activeFile = files[activeTab];
-  const { fileName, extension } = getFileTypeInfo(activeFile.path);
-  const language = getLanguageFromExtension(extension);
+  const { fileName } = getFileTypeInfo(activeFile.path);
 
   return (
     <div className="space-y-2">
@@ -161,7 +160,6 @@ export const TabbedFilesRenderer: React.FC<TabbedFilesRendererProps> = ({
         ) : (
           <CodeEditor
             code={activeFile.content}
-            language={language}
             fileName={fileName}
             filePath={activeFile.path}
             fileSize={formatBytes(activeFile.content.length)}

--- a/multimodal/tarko/agent-ui/src/standalone/workspace/utils/codeUtils.ts
+++ b/multimodal/tarko/agent-ui/src/standalone/workspace/utils/codeUtils.ts
@@ -3,30 +3,6 @@
  */
 
 /**
- * Get language for syntax highlighting based on file extension
- */
-export const getLanguageFromExtension = (extension: string): string => {
-  const langMap: Record<string, string> = {
-    js: 'javascript',
-    jsx: 'javascript',
-    ts: 'typescript',
-    tsx: 'typescript',
-    py: 'python',
-    html: 'html',
-    css: 'css',
-    json: 'json',
-    yaml: 'yaml',
-    yml: 'yaml',
-    md: 'markdown',
-    xml: 'xml',
-    sh: 'bash',
-    bash: 'bash',
-  };
-
-  return langMap[extension] || 'text';
-};
-
-/**
  * Format file size in bytes to human-readable format
  */
 export const formatBytes = (bytes: number): string => {


### PR DESCRIPTION
## Summary

Removed redundant TypeScript badge from  component since filename already indicates file type.

Changes:
- Removed  prop from  interface
- Removed language badge rendering logic
- Cleaned up unused CSS for 

## Checklist

- [x] My change does not involve the above items.