### PR TITLE
fix(tarko): enable raw mode for streaming `write_file` operations

### DIFF
--- a/multimodal/tarko/agent-ui/src/standalone/workspace/WorkspaceDetail.tsx
+++ b/multimodal/tarko/agent-ui/src/standalone/workspace/WorkspaceDetail.tsx
@@ -247,6 +247,18 @@ export const WorkspaceDetail: React.FC = () => {
       const toolMapping = getCurrentToolMapping();
       if (toolMapping) {
         return <RawModeRenderer toolMapping={toolMapping} />;
+      } else if (panelContent.toolCallId && panelContent.arguments) {
+        // For streaming operations, create a synthetic tool mapping
+        const syntheticToolMapping = {
+          toolCall: {
+            toolCallId: panelContent.toolCallId,
+            name: panelContent.title || 'unknown',
+            arguments: panelContent.arguments,
+            timestamp: panelContent.timestamp,
+          },
+          toolResult: null, // Still processing
+        };
+        return <RawModeRenderer toolMapping={syntheticToolMapping} />;
       } else {
         return (
           <div className="flex items-center justify-center h-full">

--- a/multimodal/tarko/agent-ui/src/standalone/workspace/WorkspaceDetail.tsx
+++ b/multimodal/tarko/agent-ui/src/standalone/workspace/WorkspaceDetail.tsx
@@ -247,18 +247,6 @@ export const WorkspaceDetail: React.FC = () => {
       const toolMapping = getCurrentToolMapping();
       if (toolMapping) {
         return <RawModeRenderer toolMapping={toolMapping} />;
-      } else if (panelContent.toolCallId && panelContent.arguments) {
-        // For streaming operations, create a synthetic tool mapping
-        const syntheticToolMapping = {
-          toolCall: {
-            toolCallId: panelContent.toolCallId,
-            name: panelContent.title || 'unknown',
-            arguments: panelContent.arguments,
-            timestamp: panelContent.timestamp,
-          },
-          toolResult: null, // Still processing
-        };
-        return <RawModeRenderer toolMapping={syntheticToolMapping} />;
       } else {
         return (
           <div className="flex items-center justify-center h-full">


### PR DESCRIPTION
## Summary

Fixed `write_file` streaming display showing "No Raw Data Available" in raw mode by creating synthetic tool mapping for streaming operations.

The issue occurred because streaming `write_file` operations set panel content before the complete tool mapping is available in `rawToolMappingAtom`. This PR adds fallback logic to create a synthetic tool mapping from available panel content data, enabling raw mode display during streaming.

## Checklist

- [ ] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [x] My change does not involve the above items.