### PR TITLE
feat(tarko-agent-ui): support line breaks in LinkReaderRenderer

### DIFF
--- a/multimodal/tarko/agent-ui/src/sdk/markdown-renderer/MarkdownRenderer.tsx
+++ b/multimodal/tarko/agent-ui/src/sdk/markdown-renderer/MarkdownRenderer.tsx
@@ -22,7 +22,7 @@ interface MarkdownRendererProps {
   author?: string;
   className?: string;
   forceDarkTheme?: boolean;
-  preserveWhitespace?: boolean;
+  codeBlockStyle?: React.CSSProperties;
 }
 
 /**
@@ -47,7 +47,7 @@ const MarkdownRendererContent: React.FC<MarkdownRendererProps> = ({
   author,
   className = '',
   forceDarkTheme = false,
-  preserveWhitespace = false,
+  codeBlockStyle,
 }) => {
   const [openImage, setOpenImage] = useState<string | null>(null);
   const [renderError, setRenderError] = useState<Error | null>(null);
@@ -93,7 +93,7 @@ const MarkdownRendererContent: React.FC<MarkdownRendererProps> = ({
    */
   const components = useMarkdownComponents({
     onImageClick: handleImageClick,
-    preserveWhitespace,
+    codeBlockStyle,
   });
 
   /**

--- a/multimodal/tarko/agent-ui/src/sdk/markdown-renderer/components/CodeBlock.tsx
+++ b/multimodal/tarko/agent-ui/src/sdk/markdown-renderer/components/CodeBlock.tsx
@@ -4,10 +4,10 @@ interface CodeBlockProps {
   inline?: boolean;
   className?: string;
   children: React.ReactNode;
-  preserveWhitespace?: boolean;
+  style?: React.CSSProperties;
 }
 
-export const CodeBlock: React.FC<CodeBlockProps> = ({ inline, className, children, preserveWhitespace = false }) => {
+export const CodeBlock: React.FC<CodeBlockProps> = ({ inline, className, children, style }) => {
   const match = /language-(\w+)/.exec(className || '');
 
   if (inline || !match) {
@@ -18,11 +18,12 @@ export const CodeBlock: React.FC<CodeBlockProps> = ({ inline, className, childre
     );
   }
 
-  const preClasses = `bg-[#f5f5f5] dark:bg-[#111111] dark:border-gray-700/50 rounded-xl p-4 text-xs overflow-x-auto${preserveWhitespace ? ' whitespace-pre-wrap' : ''}`;
-
   return (
     <div className="my-2">
-      <pre className={preClasses}>
+      <pre 
+        className="bg-[#f5f5f5] dark:bg-[#111111] dark:border-gray-700/50 rounded-xl p-4 text-xs overflow-x-auto"
+        style={style}
+      >
         <code className={`${className} text-gray-800 dark:text-gray-200`}>{children}</code>
       </pre>
     </div>

--- a/multimodal/tarko/agent-ui/src/sdk/markdown-renderer/hooks/useMarkdownComponents.tsx
+++ b/multimodal/tarko/agent-ui/src/sdk/markdown-renderer/hooks/useMarkdownComponents.tsx
@@ -24,13 +24,13 @@ import {
 
 interface UseMarkdownComponentsProps {
   onImageClick: (src: string) => void;
-  preserveWhitespace?: boolean;
+  codeBlockStyle?: React.CSSProperties;
 }
 
 /**
  * Custom hook that provides markdown components configuration
  */
-export const useMarkdownComponents = ({ onImageClick, preserveWhitespace = false }: UseMarkdownComponentsProps): Components => {
+export const useMarkdownComponents = ({ onImageClick, codeBlockStyle }: UseMarkdownComponentsProps): Components => {
   return React.useMemo(
     () => ({
       // Headings
@@ -52,7 +52,7 @@ export const useMarkdownComponents = ({ onImageClick, preserveWhitespace = false
 
       // Code
       code: ({ className, children, ...props }) => (
-        <CodeBlock className={className} preserveWhitespace={preserveWhitespace} {...props}>
+        <CodeBlock className={className} style={codeBlockStyle} {...props}>
           {children}
         </CodeBlock>
       ),
@@ -71,6 +71,6 @@ export const useMarkdownComponents = ({ onImageClick, preserveWhitespace = false
       // Override strikethrough (del) to render as normal text
       del: ({ children }) => <span>{children}</span>,
     }),
-    [onImageClick, preserveWhitespace],
+    [onImageClick, codeBlockStyle],
   );
 };

--- a/multimodal/tarko/agent-ui/src/standalone/workspace/renderers/LinkReaderRenderer.tsx
+++ b/multimodal/tarko/agent-ui/src/standalone/workspace/renderers/LinkReaderRenderer.tsx
@@ -125,7 +125,11 @@ export const LinkReaderRenderer: React.FC<LinkReaderRendererProps> = ({ panelCon
 
               {/* Content area */}
               <div>
-                <MarkdownRenderer content={wrapMarkdown(result.content)} forceDarkTheme preserveWhitespace />
+                <MarkdownRenderer 
+                  content={wrapMarkdown(result.content)} 
+                  forceDarkTheme 
+                  codeBlockStyle={{ whiteSpace: 'pre-wrap' }}
+                />
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary

Fixed line break support in `LinkReaderRenderer` by adding a flexible `codeBlockStyle` prop to `MarkdownRenderer`. This allows custom styling of code blocks without affecting existing usage.

### Before

<img width="4400" height="2590" alt="image" src="https://github.com/user-attachments/assets/f52b5624-8ff2-4970-94e4-d5fba62c57e9" />

### After

<img width="1280" height="752" alt="image" src="https://github.com/user-attachments/assets/124dd241-a0e5-4639-831f-6064a3fc01b2" />



## Checklist

- [ ] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [x] My change does not involve the above items.