### PR TITLE
chore: disable `editor.formatOnSave` setting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "[javascript][javascriptreact][typescript][typescriptreact]": {
-    "editor.formatOnSave": true,
+    "editor.formatOnSave": false,
     "editor.codeActionsOnSave": {
       "source.fixAll.eslint": "explicit"
     },


### PR DESCRIPTION
## Summary

Disable `editor.formatOnSave` in `.vscode/settings.json` to prevent auto-formatting from blocking the IDE and causing poor development experience.

## Checklist

- [ ] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [x] My change does not involve the above items.