### PR TITLE
fix(model-provider): native providers regression issue

### DIFF
--- a/multimodal/tarko/model-provider/src/llm-client.ts
+++ b/multimodal/tarko/model-provider/src/llm-client.ts
@@ -9,13 +9,7 @@ import { LLMRequest, AgentModel } from './types';
 import type { ChatCompletionCreateParamsBase } from './third-party';
 
 // Providers that should not be added to extended model list
-const NATIVE_PROVIDERS = new Set([
-  'openai',
-  'anthropic',
-  'openrouter',
-  'openai-compatible',
-  'azure-openai',
-]);
+const NATIVE_PROVIDERS = new Set(['openrouter', 'openai-compatible', 'azure-openai']);
 
 export type LLMRequestInterceptor = (
   provider: string,

--- a/multimodal/tarko/model-provider/tests/llm-client.test.ts
+++ b/multimodal/tarko/model-provider/tests/llm-client.test.ts
@@ -48,9 +48,9 @@ describe('createLLMClient', () => {
 
   it('should not extend model list for native providers', () => {
     const model: AgentModel = {
-      provider: 'openai',
+      provider: 'openrouter',
       id: 'gpt-4o',
-      baseProvider: 'openai',
+      baseProvider: 'openrouter',
     };
 
     createLLMClient(model);
@@ -60,16 +60,58 @@ describe('createLLMClient', () => {
 
   it('should extend model list for non-native providers', () => {
     const model: AgentModel = {
-      provider: 'ollama',
-      id: 'llama3.2',
-      baseProvider: 'custom-provider' as any, // Use a non-native provider
+      provider: 'volcengine',
+      id: 'ep-20250613182556-7z8pl',
+      baseProvider: 'openai',
     };
 
     createLLMClient(model);
 
     expect(mockTokenJSInstance.extendModelList).toHaveBeenCalledWith(
-      'custom-provider',
-      'llama3.2',
+      'openai',
+      'ep-20250613182556-7z8pl',
+      {
+        streaming: true,
+        json: true,
+        toolCalls: true,
+        images: true,
+      },
+    );
+  });
+
+  it('should extend model list for openai-based providers like volcengine', () => {
+    const model: AgentModel = {
+      provider: 'volcengine',
+      id: 'ep-20250613182556-7z8pl',
+      baseProvider: 'openai',
+    };
+
+    createLLMClient(model);
+
+    expect(mockTokenJSInstance.extendModelList).toHaveBeenCalledWith(
+      'openai',
+      'ep-20250613182556-7z8pl',
+      {
+        streaming: true,
+        json: true,
+        toolCalls: true,
+        images: true,
+      },
+    );
+  });
+
+  it('should extend model list for anthropic-based providers', () => {
+    const model: AgentModel = {
+      provider: 'custom-anthropic',
+      id: 'custom-claude',
+      baseProvider: 'anthropic',
+    };
+
+    createLLMClient(model);
+
+    expect(mockTokenJSInstance.extendModelList).toHaveBeenCalledWith(
+      'anthropic',
+      'custom-claude',
       {
         streaming: true,
         json: true,


### PR DESCRIPTION
## Summary

Reverts the breaking change from PR #1489 that added `'openai'` and `'anthropic'` to `NATIVE_PROVIDERS`. This change broke providers like `volcengine` that use `baseProvider: 'openai'` and need `extendModelList()` to register their custom models (e.g., `ep-20250613182556-7z8pl`).

**Root Cause**: High-level providers like `volcengine` use OpenAI-compatible APIs but with custom model IDs. They rely on `extendModelList()` to register these models with the underlying `@tarko/llm-client`. When `'openai'` was added to `NATIVE_PROVIDERS`, these providers were incorrectly treated as native and their models weren't extended, causing "Invalid 'model' field" errors.

**Technical Chain**:
1. `volcengine` provider → `baseProvider: 'openai'` → custom model `ep-20250613182556-7z8pl`
2. `createLLMClient()` checks `NATIVE_PROVIDERS.has('openai')` → `true` (after #1489)
3. Skips `extendModelList()` call → model not registered
4. `@tarko/llm-client` rejects unknown model → `InputError: Invalid 'model' field`

**Future Evolution**: Consider distinguishing between "native provider instances" vs "provider protocols" to allow OpenAI-compatible providers to extend models while keeping true native providers unchanged.

## Checklist

- [x] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [x] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [ ] My change does not involve the above items.