### PR TITLE
feat(tarko-mcp-agent): adjust defaultConnectionTimeout from 180 to 60 seconds

### DIFF
--- a/multimodal/tarko/mcp-agent-interface/src/index.ts
+++ b/multimodal/tarko/mcp-agent-interface/src/index.ts
@@ -39,7 +39,7 @@ export interface MCPAgentOptions extends AgentOptions {
   /**
    * Default timeout for MCP client connections in seconds.
    *
-   * @defaultValue 180
+   * @defaultValue 60
    */
   defaultConnectionTimeout?: number;
 }

--- a/multimodal/tarko/mcp-agent/src/mcp-agent.ts
+++ b/multimodal/tarko/mcp-agent/src/mcp-agent.ts
@@ -69,7 +69,7 @@ export class MCPAgent<T extends MCPAgentOptions = MCPAgentOptions> extends Agent
 
         // Create appropriate client based on clientVersion
         let mcpClient: IMCPClient;
-        const defaultTimeout = this.options.defaultConnectionTimeout ?? 180;
+        const defaultTimeout = this.options.defaultConnectionTimeout ?? 60;
 
         if (this.clientVersion === 'v2') {
           mcpClient = new MCPClientV2(serverName, config, this.logger, defaultTimeout);

--- a/multimodal/tarko/mcp-agent/src/mcp-client-v2.ts
+++ b/multimodal/tarko/mcp-agent/src/mcp-client-v2.ts
@@ -21,7 +21,7 @@ export class MCPClientV2 implements IMCPClient {
     serverName: string,
     config: MCPServerConfig,
     private logger: Logger,
-    defaultTimeout = 180,
+    defaultTimeout = 60,
   ) {
     this.serverName = serverName;
 


### PR DESCRIPTION
## Summary

Adjust `defaultConnectionTimeout` from 180 to 60 seconds to address timeout issues in MCP agent connections.

Updated timeout values in:
- `@tarko/mcp-agent` - MCPAgent initialization
- `@tarko/mcp-agent` - MCPClientV2 constructor
- `@tarko/mcp-agent-interface` - interface documentation

## Checklist

- [x] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [x] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [ ] My change does not involve the above items.