### PR TITLE
fix(tarko-agent-ui): navbar overlap on small screens

### DIFF
--- a/multimodal/tarko/agent-ui/src/standalone/navbar/Navbar.tsx
+++ b/multimodal/tarko/agent-ui/src/standalone/navbar/Navbar.tsx
@@ -190,8 +190,8 @@ export const Navbar: React.FC = () => {
           </div>
         )}
 
-        {/* Center section - Agent and Model info display - absolutely positioned for true centering */}
-        <div className="absolute left-1/2 top-1/2 transform -translate-x-1/2 -translate-y-1/2">
+        {/* Center section - Agent and Model info display - responsive positioning */}
+        <div className="absolute left-1/2 top-1/2 transform -translate-x-1/2 -translate-y-1/2 max-[968px]:relative max-[968px]:left-auto max-[968px]:top-auto max-[968px]:transform-none max-[968px]:flex-1 max-[968px]:mx-3">
           <DynamicNavbarCenter
             sessionMetadata={sessionMetadata}
             activeSessionId={activeSessionId}


### PR DESCRIPTION
## Summary

Fixed navbar Agent/Model display overlapping on screens smaller than 968px by switching from absolute positioning to normal flex behavior for responsive layouts.

### Befoe

<img width="3748" height="2612" alt="image" src="https://github.com/user-attachments/assets/b12420b7-3f36-43c6-8819-b223fbb122ba" />

### After

<img width="3748" height="2680" alt="image" src="https://github.com/user-attachments/assets/716e4ca9-9826-4a2a-8bc6-2d0541679e49" />



## Checklist

- [ ] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [x] My change does not involve the above items.