### PR TITLE
ci(pnpm-toolkit): add canary release support

### DIFF
--- a/multimodal/package.json
+++ b/multimodal/package.json
@@ -19,6 +19,7 @@
     "coverage": "vitest run --coverage",
     "format": "pnpm prettier --write .",
     "release": "ptk release --push-tag --build --ignore-scripts",
+    "release:canary": "ptk release --canary --push-tag --build --ignore-scripts",
     "release:full": "ptk release --push-tag --build --ignore-scripts --create-github-release",
     "release:ai": "ptk release --push-tag --build --ignore-scripts --use-ai --provider=azure-openai --model=aws_sdk_claude37_sonnet --baseURL=AWS_CLAUDE_API_BASE_URL",
     "release:ai:full": "ptk release --push-tag --build --ignore-scripts --use-ai --provider=azure-openai --model=aws_sdk_claude37_sonnet --baseURL=AWS_CLAUDE_API_BASE_URL --create-github-release",

--- a/multimodal/tarko/pnpm-toolkit/src/cli.ts
+++ b/multimodal/tarko/pnpm-toolkit/src/cli.ts
@@ -93,6 +93,9 @@ export function bootstrapCli() {
     .option('--tag-prefix <prefix>', 'Prefix for git tags', {
       default: 'v',
     })
+    .option('--canary', 'Skip version/tag selection and auto-generate canary version', {
+      default: false,
+    })
     .option('--use-ai', 'Use AI to generate changelog', {
       default: false,
     })

--- a/multimodal/tarko/pnpm-toolkit/src/commands/release.ts
+++ b/multimodal/tarko/pnpm-toolkit/src/commands/release.ts
@@ -33,6 +33,28 @@ interface DependencyBackup {
 }
 
 /**
+ * Generates canary version with format: {version}-canary-{commitHash}-{timestamp}
+ */
+async function generateCanaryVersion(
+  currentVersion: string,
+  cwd: string,
+): Promise<{ version: string; tag: string }> {
+  // Get current commit hash (short)
+  const { stdout: commitHash } = await execa('git', ['rev-parse', '--short', 'HEAD'], { cwd });
+
+  // Generate timestamp
+  const timestamp = new Date().toISOString().replace(/[-:T]/g, '').slice(0, 14); // YYYYMMDDHHMMSS
+
+  // Generate canary version
+  const canaryVersion = `${currentVersion}-canary-${commitHash.trim()}-${timestamp}`;
+
+  return {
+    version: canaryVersion,
+    tag: 'nightly',
+  };
+}
+
+/**
  * Prompts user to select version and tag
  */
 async function selectVersionAndTag(
@@ -206,6 +228,7 @@ export async function release(options: ReleaseOptions = {}): Promise<void> {
     build = false,
     pushTag = false,
     tagPrefix = 'v',
+    canary = false,
     useAi = false,
     createGithubRelease = false,
   } = options;
@@ -221,21 +244,35 @@ export async function release(options: ReleaseOptions = {}): Promise<void> {
 
     logger.info(`Current version: ${currentVersion}`);
 
-    // Prompt for version and tag
-    const { version, tag } = await selectVersionAndTag(currentVersion);
+    // Get version and tag based on canary mode
+    let version: string;
+    let tag: string;
 
-    const { yes } = await inquirer.prompt([
-      {
-        name: 'yes',
-        message: `Confirm releasing ${version} (${tag})?`,
-        type: 'list',
-        choices: ['N', 'Y'],
-      },
-    ]);
+    if (canary) {
+      // Skip prompts for canary release
+      const canaryResult = await generateCanaryVersion(currentVersion, cwd);
+      version = canaryResult.version;
+      tag = canaryResult.tag;
+      logger.info(`Canary release: ${version} (${tag})`);
+    } else {
+      // Prompt for version and tag
+      const result = await selectVersionAndTag(currentVersion);
+      version = result.version;
+      tag = result.tag;
 
-    if (yes === 'N') {
-      logger.info('Release cancelled.');
-      return;
+      const { yes } = await inquirer.prompt([
+        {
+          name: 'yes',
+          message: `Confirm releasing ${version} (${tag})?`,
+          type: 'list',
+          choices: ['N', 'Y'],
+        },
+      ]);
+
+      if (yes === 'N') {
+        logger.info('Release cancelled.');
+        return;
+      }
     }
 
     // Set environment variable for build scripts
@@ -270,25 +307,27 @@ export async function release(options: ReleaseOptions = {}): Promise<void> {
       return;
     }
 
-    // Confirm packages to publish
+    // Confirm packages to publish (skip in canary mode)
     console.log(chalk.bold('\nPackages to be published:'));
     packagesToPublish.forEach((pkg) => {
       console.log(`  - ${chalk.cyan(pkg.name)} (${chalk.gray(pkg.dir)})`);
     });
     console.log();
 
-    const { confirmPublish } = await inquirer.prompt([
-      {
-        name: 'confirmPublish',
-        message: 'Are these the correct packages to publish?',
-        type: 'list',
-        choices: ['Y', 'N'],
-      },
-    ]);
+    if (!canary) {
+      const { confirmPublish } = await inquirer.prompt([
+        {
+          name: 'confirmPublish',
+          message: 'Are these the correct packages to publish?',
+          type: 'list',
+          choices: ['Y', 'N'],
+        },
+      ]);
 
-    if (confirmPublish === 'N') {
-      logger.info('Publication cancelled.');
-      return;
+      if (confirmPublish === 'N') {
+        logger.info('Publication cancelled.');
+        return;
+      }
     }
 
     // Update package versions
@@ -330,19 +369,23 @@ export async function release(options: ReleaseOptions = {}): Promise<void> {
       }
 
       if (hasWorkspaceDeps) {
-        const { continuePublish } = await inquirer.prompt([
-          {
-            name: 'continuePublish',
-            message: 'Unreplaced workspace dependencies found. Continue with publishing?',
-            type: 'list',
-            choices: ['No', 'Yes'],
-          },
-        ]);
+        if (canary) {
+          logger.warn('Unreplaced workspace dependencies found in canary mode, continuing anyway');
+        } else {
+          const { continuePublish } = await inquirer.prompt([
+            {
+              name: 'continuePublish',
+              message: 'Unreplaced workspace dependencies found. Continue with publishing?',
+              type: 'list',
+              choices: ['No', 'Yes'],
+            },
+          ]);
 
-        if (continuePublish === 'No') {
-          await restoreDependencies(backups, dryRun);
-          logger.info('Publishing cancelled, dependencies restored');
-          return;
+          if (continuePublish === 'No') {
+            await restoreDependencies(backups, dryRun);
+            logger.info('Publishing cancelled, dependencies restored');
+            return;
+          }
         }
       } else {
         logger.success('All workspace dependencies properly replaced');
@@ -408,24 +451,38 @@ export async function release(options: ReleaseOptions = {}): Promise<void> {
               logger.info(`You can manually push the tag later with: git push origin ${tagName}`);
             }
           } else {
-            // Ask if user wants to push
-            const { pushToRemote } = await inquirer.prompt([
-              {
-                name: 'pushToRemote',
-                message: `Push tag ${tagName} to remote repository?`,
-                type: 'list',
-                choices: ['Yes', 'No'],
-              },
-            ]);
-
-            if (pushToRemote === 'Yes') {
+            // Ask if user wants to push (skip in canary mode)
+            if (canary) {
+              // Auto-push in canary mode
               try {
-                logger.info(`Pushing git tag to remote...`);
+                logger.info(`Auto-pushing git tag to remote in canary mode...`);
                 await gitPushTag(tagName, true, cwd);
                 logger.success(`Successfully pushed tag and commit to remote`);
               } catch (err) {
                 logger.error(`Failed to push to remote: ${(err as Error).message}`);
                 logger.info(`You can manually push the tag later with: git push origin ${tagName}`);
+              }
+            } else {
+              const { pushToRemote } = await inquirer.prompt([
+                {
+                  name: 'pushToRemote',
+                  message: `Push tag ${tagName} to remote repository?`,
+                  type: 'list',
+                  choices: ['Yes', 'No'],
+                },
+              ]);
+
+              if (pushToRemote === 'Yes') {
+                try {
+                  logger.info(`Pushing git tag to remote...`);
+                  await gitPushTag(tagName, true, cwd);
+                  logger.success(`Successfully pushed tag and commit to remote`);
+                } catch (err) {
+                  logger.error(`Failed to push to remote: ${(err as Error).message}`);
+                  logger.info(
+                    `You can manually push the tag later with: git push origin ${tagName}`,
+                  );
+                }
               }
             }
           }

--- a/multimodal/tarko/pnpm-toolkit/src/types.ts
+++ b/multimodal/tarko/pnpm-toolkit/src/types.ts
@@ -61,6 +61,7 @@ export interface ReleaseOptions extends CommandOptions {
   build?: boolean | string;
   pushTag?: boolean;
   tagPrefix?: string;
+  canary?: boolean;
   useAi?: boolean;
   model?: string;
   apiKey?: string;


### PR DESCRIPTION
## Summary

Adds `--canary` flag support to `pnpm-toolkit` release command for automated canary releases.

**Usage:**
```bash
pnpm run release:canary
# or
ptk release --canary --push-tag --build --ignore-scripts
```

**Example output:**
`0.3.0-beta.11-canary-404367f44-20250916065645`

## Checklist

- [x] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [x] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [ ] My change does not involve the above items.