### PR TITLE
docs: remove duplicate header

### DIFF
--- a/multimodal/websites/docs/docs/en/showcase/index.mdx
+++ b/multimodal/websites/docs/docs/en/showcase/index.mdx
@@ -3,8 +3,6 @@ description: Explore our impressive demos and replays
 pageType: custom
 ---
 
-# Showcase
-
 import { Showcase } from '@components/Showcase';
 
 <Showcase />

--- a/multimodal/websites/docs/docs/zh/showcase/index.mdx
+++ b/multimodal/websites/docs/docs/zh/showcase/index.mdx
@@ -3,8 +3,6 @@ description: Explore our impressive demos and replays
 pageType: custom
 ---
 
-# Showcase
-
 import { Showcase } from '@components/Showcase';
 
 <Showcase />


### PR DESCRIPTION
## Summary

Removed duplicate `# Showcase` header from showcase mdx files that was causing unexpected header display. The `ShowcaseHeader` component already renders the title, making the mdx header redundant.

## Checklist  

- [ ] Added or updated necessary tests (Optional).  
- [ ] Updated documentation to align with changes (Optional).  
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).  
- [x] My change does not involve the above items.