### PR TITLE
fix(tarko-agent-ui): support all SSE line separators in streaming

### DIFF
--- a/multimodal/tarko/agent-ui/src/common/services/apiService.ts
+++ b/multimodal/tarko/agent-ui/src/common/services/apiService.ts
@@ -250,14 +250,15 @@ class ApiService {
         const { done, value } = await reader.read();
         if (done) break;
 
-        // Add the new chunk to the buffer and normalize line endings
-        buffer += decoder.decode(value, { stream: true }).replace(/\r\n?/g, '\n');
+        // Add the new chunk to the buffer
+        buffer += decoder.decode(value, { stream: true });
 
         // Process all complete events in the buffer
         let eventEndIndex;
-        while ((eventEndIndex = buffer.indexOf('\n\n')) !== -1) {
+        while ((eventEndIndex = buffer.search(/\r\n\r\n|\n\n|\r\r/)) !== -1) {
           const eventString = buffer.slice(0, eventEndIndex);
-          buffer = buffer.slice(eventEndIndex + 2);
+          const sepLength = buffer.substr(eventEndIndex, 4) === '\r\n\r\n' ? 4 : 2;
+          buffer = buffer.slice(eventEndIndex + sepLength);
 
           if (eventString.startsWith('data: ')) {
             try {


### PR DESCRIPTION
## Summary

Enhanced SSE event stream parsing in `sendStreamingQuery` to support all three standard line separators: `\r\n` (CRLF), `\n` (LF), and `\r` (CR). The previous implementation only supported `\n\n`, which could cause parsing issues with different server implementations or network conditions.

ref: https://html.spec.whatwg.org/multipage/server-sent-events.html

## Checklist

- [ ] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [x] My change does not involve the above items.