### PR TITLE
fix(tarko-pnpm-toolkit): filter canary releases in changelog and github release generation

### DIFF
--- a/multimodal/tarko/pnpm-toolkit/src/utils/github.ts
+++ b/multimodal/tarko/pnpm-toolkit/src/utils/github.ts
@@ -42,6 +42,7 @@ export interface GitHubReleaseOptions {
 /**
  * Gets the previous tag for generating release notes
  * Handles mixed tag formats (v1.0.0 and @agent-tars@1.0.0)
+ * Filters out canary releases
  */
 export async function getPreviousTag(tagName: string, cwd: string): Promise<string | null> {
   try {
@@ -53,18 +54,25 @@ export async function getPreviousTag(tagName: string, cwd: string): Promise<stri
       return null;
     }
 
-    // Find the current tag in the list
-    const currentIndex = allTags.findIndex((tag) => tag === tagName);
+    // Filter out canary releases
+    const nonCanaryTags = allTags.filter((tag) => !tag.includes('canary'));
+
+    if (nonCanaryTags.length === 0) {
+      return null;
+    }
+
+    // Find the current tag in the filtered list
+    const currentIndex = nonCanaryTags.findIndex((tag) => tag === tagName);
 
     if (currentIndex === -1) {
       // If current tag not found, it might be a new tag
-      // Return the most recent tag (first in the list)
-      return allTags[0] || null;
+      // Return the most recent non-canary tag (first in the list)
+      return nonCanaryTags[0] || null;
     }
 
     // Return the next tag (previous in chronological order)
-    if (currentIndex < allTags.length - 1) {
-      return allTags[currentIndex + 1];
+    if (currentIndex < nonCanaryTags.length - 1) {
+      return nonCanaryTags[currentIndex + 1];
     }
 
     return null;


### PR DESCRIPTION
## Summary

Fixes the issue where `ptk release` and `ptk github-release` generate incorrect changelog and release notes by including canary releases in the comparison range.

**Problem**: 
- GitHub Release shows comparison like `v0.3.0-beta.11-canary-e70d431f-20250917163005...v0.3.0-beta.12`
- CHANGELOG.md contains similar incorrect ranges
- This happens because `getPreviousTag` functions don't filter out canary releases

**Solution**:
- Modified `getPreviousTag` in both `github.ts` and `changelog.ts` to filter out tags containing "canary"
- Now only considers stable releases when determining the previous tag for comparison
- Added logging to show filtered non-canary tags for better debugging

**Files Changed**:
- `multimodal/tarko/pnpm-toolkit/src/utils/github.ts`
- `multimodal/tarko/pnpm-toolkit/src/commands/changelog.ts`

## Checklist

- [x] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [x] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [ ] My change does not involve the above items.