### PR TITLE
docs(tarko): align zh quick-start formatting

### DIFF
--- a/multimodal/websites/tarko/docs/zh/guide/get-started/quick-start.mdx
+++ b/multimodal/websites/tarko/docs/zh/guide/get-started/quick-start.mdx
@@ -151,3 +151,5 @@ npx tsx examples/tool-calls/basic.ts
 # 运行流式示例
 npx tsx examples/streaming/tool-calls.ts
 ```
+
+


### PR DESCRIPTION
## Summary

Align Chinese version of `quick-start.mdx` formatting with English version by adding missing trailing newlines.

## Checklist

- [ ] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [x] My change does not involve the above items.