### PR TITLE
docs(tarko): align zh introduction with en version

### DIFF
--- a/multimodal/websites/tarko/docs/zh/guide/get-started/introduction.mdx
+++ b/multimodal/websites/tarko/docs/zh/guide/get-started/introduction.mdx
@@ -11,11 +11,11 @@ description: 了解 Tarko，一个工具增强的 Agent 运行时内核
 
 Tarko 提供以下核心能力：
 
-- **Context Engineering**: 构建支持长程运行的 Agent 核心能力
-- **Tool Call Engine**: 支持多种 LLM Provider 的统一工具调用接口
-- **Event Stream Processing**: 原生流式处理和 Agent Protocol 支持
-- **Agent Hooks**: 强大的扩展能力
-- **Agent Protocol**: Agent 生命周期的标准格式定义
+- **[Context Engineering](/guide/advanced/context-engineering)**: 构建支持长程运行的 Agent 核心能力
+- **[Tool Call Engine](/guide/basic/tool-call-engine)**: 支持多种 LLM Provider 的统一工具调用接口
+- **[Event Stream Processing](/guide/basic/event-stream)**: 原生流式处理和 Agent Protocol 支持
+- **[Agent Hooks](/guide/advanced/agent-hooks)**: 强大的扩展能力
+- **[Agent Protocol](/guide/advanced/agent-protocol)**: Agent 生命周期的标准格式定义
 
 ## 核心特性
 
@@ -47,8 +47,56 @@ Tarko 驱动了多个生产系统：
 - **[UI-TARS-desktop](https://github.com/bytedance/UI-TARS-desktop)**: 桌面自动化
 - **[Agent TARS](https://agent-tars.com/)**: 通用多模态 Agent
 
-## 下一步
+## 文档概览
 
-- [快速开始](/guide/get-started/quick-start) - 创建你的第一个 Tarko Agent
+### 快速入门
+- [快速开始](/guide/get-started/quick-start) - 几分钟内创建你的第一个 Tarko Agent
 - [架构设计](/guide/get-started/architecture) - 了解 Tarko 的设计原理
-- [示例](/examples/getting-started) - 探索实用示例
+- [SDK 参考](/guide/get-started/sdk) - 完整的 API 参考和示例
+
+### 核心概念
+- [配置](/guide/basic/configuration) - 配置 Agent、模型和运行时设置
+- [模型提供商](/guide/basic/model-provider) - OpenAI、Anthropic、Volcengine 和自定义提供商
+- [工具](/guide/basic/tools) - 为你的 Agent 创建和注册自定义工具
+- [Tool Call Engine](/guide/basic/tool-call-engine) - 原生、提示工程和结构化输出
+- [Event Stream](/guide/basic/event-stream) - 实时 Agent 执行监控
+- [故障排除](/guide/basic/troubleshooting) - 常见问题和解决方案
+
+### 高级特性
+- [Agent Hooks](/guide/advanced/agent-hooks) - 使用生命周期钩子自定义 Agent 行为
+- [Agent Protocol](/guide/advanced/agent-protocol) - 标准通信协议
+- [Context Engineering](/guide/advanced/context-engineering) - 长程运行 Agent 的上下文管理
+- [Agent Snapshot](/guide/advanced/agent-snapshot) - 保存和重放 Agent 执行状态
+
+### UI 集成
+- [UI 集成](/guide/basic/ui-integration) - 为你的 Agent 构建 Web 界面
+
+### 部署
+- [CLI 部署](/guide/deployment/cli) - 命令行工具和脚本
+- [服务器部署](/guide/deployment/server) - 生产服务器设置
+
+### API 参考
+- [Agent API](/api/agent) - 完整的 Agent 类参考
+- [Hooks API](/api/hooks) - Agent 生命周期钩子
+- [Tool Call Engine API](/api/tool-call-engine) - 工具执行引擎
+- [Context Engineering API](/api/context-engineering) - 上下文管理
+- [Agent Server API](/api/agent-server) - 服务器端点和协议
+
+### 示例
+- [快速入门](/examples/getting-started) - 基础使用示例
+- [自定义工具](/examples/custom-tools) - 构建领域特定工具
+- [自定义钩子](/examples/custom-hooks) - 扩展 Agent 行为
+- [服务器集成](/examples/server-integration) - Web 服务器集成
+- [协议集成](/examples/protocol-integration) - 自定义协议实现
+
+## 快速导航
+
+**初次使用 Tarko？** 从[快速开始](/guide/get-started/quick-start)开始
+
+**构建 Agent？** 查看[SDK 参考](/guide/get-started/sdk)和[工具](/guide/basic/tools)
+
+**需要自定义？** 探索[Agent Hooks](/guide/advanced/agent-hooks)和[Context Engineering](/guide/advanced/context-engineering)
+
+**部署到生产环境？** 参考[服务器部署](/guide/deployment/server)和[Agent Snapshot](/guide/advanced/agent-snapshot)
+
+**构建 UI？** 从[UI 集成](/guide/basic/ui-integration)开始

--- a/multimodal/websites/tarko/docs/zh/guide/get-started/quick-start.mdx
+++ b/multimodal/websites/tarko/docs/zh/guide/get-started/quick-start.mdx
@@ -151,3 +151,5 @@ npx tsx examples/tool-calls/basic.ts
 # 运行流式示例
 npx tsx examples/streaming/tool-calls.ts
 ```
+
+


### PR DESCRIPTION
## Summary

Align Chinese version of `introduction.mdx` with English version by adding missing documentation sections and internal links.

**Added missing content:**
- Complete "文档概览" (Documentation Overview) section with all subsections
- "快速导航" (Quick Navigation) section
- Internal links in "什么是 Tarko？" section
- All missing navigation links for better user experience

## Checklist

- [ ] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [x] My change does not involve the above items.