### PR TITLE
fix(tarko-agent-ui): remove duplicate url actions bar from browser renderer

### DIFF
--- a/multimodal/tarko/agent-ui/src/standalone/workspace/renderers/BrowserResultRenderer.tsx
+++ b/multimodal/tarko/agent-ui/src/standalone/workspace/renderers/BrowserResultRenderer.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import { StandardPanelContent } from '../types/panelContent';
-import { FiMonitor, FiExternalLink, FiGlobe, FiBookmark, FiCopy, FiCheck } from 'react-icons/fi';
+import { FiMonitor } from 'react-icons/fi';
 import { MarkdownRenderer, BrowserShell } from '@tarko/ui';
-import { motion } from 'framer-motion';
-import { useState } from 'react';
+
 import { FileDisplayMode } from '../types';
 
 interface BrowserResultRendererProps {
@@ -16,7 +15,6 @@ interface BrowserResultRendererProps {
  * Renders browser navigation and page content results with improved UI
  */
 export const BrowserResultRenderer: React.FC<BrowserResultRendererProps> = ({ panelContent }) => {
-  const [copied, setCopied] = useState(false);
 
   // Extract browser result data from panelContent
   const browserData = extractBrowserResultData(panelContent);
@@ -28,13 +26,7 @@ export const BrowserResultRenderer: React.FC<BrowserResultRendererProps> = ({ pa
   const { url, content, title, contentType, screenshot } = browserData;
   const displayTitle = title || url?.split('/').pop() || 'Browser Result';
 
-  const copyUrl = () => {
-    if (url) {
-      navigator.clipboard.writeText(url);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    }
-  };
+
 
   // Extract URL from text content if it's in the format "Navigated to URL"
   const extractUrlFromContent = () => {
@@ -61,37 +53,7 @@ export const BrowserResultRenderer: React.FC<BrowserResultRendererProps> = ({ pa
   return (
     <div className="space-y-4">
       <div className="mb-4">
-        {/* URL actions bar */}
-        {extractedUrl && (
-          <div className="mb-4 flex items-center">
-            <div className="flex-1 p-3 bg-gray-50 dark:bg-gray-800/80 rounded-lg text-sm border border-gray-100/30 dark:border-gray-700/20 flex items-center overflow-hidden">
-              <FiGlobe className="flex-shrink-0 text-gray-400 dark:text-gray-500 mr-2" size={16} />
-              <span className="truncate text-gray-700 dark:text-gray-300 mr-2">{extractedUrl}</span>
-            </div>
-            <div className="flex ml-2 gap-2">
-              <motion.button
-                whileHover={{ scale: 1.05 }}
-                whileTap={{ scale: 0.95 }}
-                onClick={copyUrl}
-                className="p-2 rounded-lg bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors border border-gray-200/50 dark:border-gray-700/30"
-                title="Copy URL"
-              >
-                {copied ? <FiCheck size={18} className="text-green-500" /> : <FiCopy size={18} />}
-              </motion.button>
-              <motion.a
-                whileHover={{ scale: 1.05 }}
-                whileTap={{ scale: 0.95 }}
-                href={extractedUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="p-2 rounded-lg bg-purple-50 dark:bg-purple-900/20 text-accent-600 dark:text-accent-400 hover:bg-purple-100 dark:hover:bg-purple-800/30 transition-colors border border-purple-200/50 dark:border-purple-800/30"
-                title="Open in new tab"
-              >
-                <FiExternalLink size={18} />
-              </motion.a>
-            </div>
-          </div>
-        )}
+
 
         {/* Content with enhanced browser shell */}
         <BrowserShell title={displayTitle} url={extractedUrl}>


### PR DESCRIPTION
## Summary

Removed redundant URL actions bar from `BrowserResultRenderer` since `BrowserShell` already provides URL display functionality in its address bar.


## Checklist

- [ ] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [x] My change does not involve the above items.