### PR TITLE
docs(agent-tars): add blog index page

### DIFF
--- a/multimodal/websites/docs/docs/en/_nav.json
+++ b/multimodal/websites/docs/docs/en/_nav.json
@@ -11,7 +11,8 @@
   },
   {
     "text": "Blog",
-    "link": "/blog/2025-06-25-introducing-agent-tars-beta.html"
+    "link": "/blog",
+    "activeMatch": "/blog/"
   },
   {
     "text": "Version",

--- a/multimodal/websites/docs/docs/en/blog/index.mdx
+++ b/multimodal/websites/docs/docs/en/blog/index.mdx
@@ -1,0 +1,19 @@
+---
+description: Latest updates, insights, and announcements from the Agent TARS team
+pageType: custom
+---
+
+import { BlogIndex } from '@components/BlogIndex';
+
+<BlogIndex 
+  posts={[
+    {
+      title: "Introducing Agent TARS Beta",
+      date: "June 25, 2025",
+      author: "Agent TARS Team",
+      excerpt: "We're excited to announce the Beta release of Agent TARS, bringing a new CLI-based architecture, hybrid browser GUI agent, better cross-model compatibility, and much more.",
+      href: "/blog/2025-06-25-introducing-agent-tars-beta.html",
+      tags: ["release", "beta", "cli", "gui-agent"]
+    }
+  ]}
+/>

--- a/multimodal/websites/docs/docs/zh/_nav.json
+++ b/multimodal/websites/docs/docs/zh/_nav.json
@@ -11,7 +11,8 @@
   },
   {
     "text": "Blog",
-    "link": "/blog/2025-06-25-introducing-agent-tars-beta.html"
+    "link": "/blog",
+    "activeMatch": "/blog/"
   },
   {
     "text": "Version",

--- a/multimodal/websites/docs/docs/zh/blog/index.mdx
+++ b/multimodal/websites/docs/docs/zh/blog/index.mdx
@@ -1,0 +1,19 @@
+---
+description: Agent TARS 团队的最新更新、见解和公告
+pageType: custom
+---
+
+import { BlogIndex } from '@components/BlogIndex';
+
+<BlogIndex 
+  posts={[
+    {
+      title: "Introducing Agent TARS Beta",
+      date: "2025年6月25日",
+      author: "Agent TARS Team",
+      excerpt: "我们很高兴地宣布 Agent TARS Beta 版本的发布，带来了全新的 CLI 架构、混合浏览器 GUI Agent、更好的跨模型兼容性等更多功能。",
+      href: "/blog/2025-06-25-introducing-agent-tars-beta.html",
+      tags: ["发布", "beta", "cli", "gui-agent"]
+    }
+  ]}
+/>

--- a/multimodal/websites/docs/src/components/BlogCard.tsx
+++ b/multimodal/websites/docs/src/components/BlogCard.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { Link } from './Link';
+import './BlogIndex.css';
+
+interface BlogCardProps {
+  title: string;
+  date: string;
+  author: string;
+  excerpt: string;
+  href: string;
+  tags?: string[];
+}
+
+export function BlogCard({ title, date, author, excerpt, href, tags = [] }: BlogCardProps) {
+  return (
+    <Link 
+      href={href} 
+      className="blog-card"
+      forceTraditionalLink={false}
+    >
+      <article className="blog-card-content">
+        <div className="blog-card-meta">
+          <time className="blog-card-date">{date}</time>
+          <span className="blog-card-author">by {author}</span>
+        </div>
+        
+        <h2 className="blog-card-title">{title}</h2>
+        
+        <p className="blog-card-excerpt">{excerpt}</p>
+        
+        {tags.length > 0 && (
+          <div className="blog-card-tags">
+            {tags.map((tag) => (
+              <span key={tag} className="blog-card-tag">
+                {tag}
+              </span>
+            ))}
+          </div>
+        )}
+        
+        <div className="blog-card-arrow">Read more →</div>
+      </article>
+    </Link>
+  );
+}

--- a/multimodal/websites/docs/src/components/BlogIndex.css
+++ b/multimodal/websites/docs/src/components/BlogIndex.css
@@ -1,0 +1,173 @@
+/* Blog Index Styles */
+.blog-index {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+}
+
+.blog-index-header {
+  text-align: center;
+  margin-bottom: 4rem;
+}
+
+.blog-index-title {
+  font-size: 3rem;
+  font-weight: 700;
+  margin: 0 0 1rem 0;
+  color: var(--rp-c-text-1);
+  letter-spacing: -0.02em;
+}
+
+.blog-index-description {
+  font-size: 1.125rem;
+  color: var(--rp-c-text-2);
+  margin: 0;
+  max-width: 600px;
+  margin-left: auto;
+  margin-right: auto;
+  line-height: 1.6;
+}
+
+.blog-index-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+  gap: 2rem;
+  margin-bottom: 3rem;
+}
+
+.blog-index-empty {
+  text-align: center;
+  padding: 4rem 2rem;
+  color: var(--rp-c-text-2);
+  font-size: 1.125rem;
+}
+
+/* Blog Card Styles */
+.blog-card {
+  display: block;
+  text-decoration: none;
+  color: inherit;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.blog-card:hover {
+  transform: translateY(-4px);
+  text-decoration: none;
+}
+
+.blog-card-content {
+  border: 1px solid var(--rp-c-divider);
+  border-radius: 12px;
+  padding: 2rem;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  background: var(--rp-c-bg);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.blog-card:hover .blog-card-content {
+  border-color: var(--rp-c-text-3);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1);
+}
+
+.blog-card-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+  font-size: 0.875rem;
+  color: var(--rp-c-text-2);
+}
+
+.blog-card-date {
+  font-weight: 500;
+}
+
+.blog-card-author {
+  opacity: 0.8;
+}
+
+.blog-card-title {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin: 0 0 1rem 0;
+  color: var(--rp-c-text-1);
+  line-height: 1.3;
+}
+
+.blog-card-excerpt {
+  color: var(--rp-c-text-2);
+  line-height: 1.6;
+  margin: 0 0 1.5rem 0;
+  flex-grow: 1;
+  font-size: 0.95rem;
+}
+
+.blog-card-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.blog-card-tag {
+  background: var(--rp-c-bg-soft);
+  color: var(--rp-c-text-2);
+  padding: 0.25rem 0.75rem;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  border: 1px solid var(--rp-c-divider);
+}
+
+.blog-card-arrow {
+  color: var(--rp-c-text-2);
+  font-size: 0.875rem;
+  font-weight: 500;
+  transition: color 0.2s ease, transform 0.2s ease;
+  align-self: flex-start;
+}
+
+.blog-card:hover .blog-card-arrow {
+  color: var(--rp-c-text-1);
+  transform: translateX(4px);
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+  .blog-index {
+    padding: 1.5rem 1rem;
+  }
+  
+  .blog-index-title {
+    font-size: 2.5rem;
+  }
+  
+  .blog-index-header {
+    margin-bottom: 3rem;
+  }
+  
+  .blog-index-grid {
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+  }
+  
+  .blog-card-content {
+    padding: 1.5rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .blog-index-title {
+    font-size: 2rem;
+  }
+  
+  .blog-card-content {
+    padding: 1.25rem;
+  }
+  
+  .blog-card-title {
+    font-size: 1.25rem;
+  }
+}

--- a/multimodal/websites/docs/src/components/BlogIndex.tsx
+++ b/multimodal/websites/docs/src/components/BlogIndex.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { BlogCard } from './BlogCard';
+import './BlogIndex.css';
+
+interface BlogPost {
+  title: string;
+  date: string;
+  author: string;
+  excerpt: string;
+  href: string;
+  tags?: string[];
+}
+
+interface BlogIndexProps {
+  posts: BlogPost[];
+}
+
+export function BlogIndex({ posts }: BlogIndexProps) {
+  return (
+    <div className="blog-index">
+      <header className="blog-index-header">
+        <h1 className="blog-index-title">Blog</h1>
+        <p className="blog-index-description">
+          Latest updates, insights, and announcements from the Agent TARS team
+        </p>
+      </header>
+      
+      <div className="blog-index-grid">
+        {posts.map((post, index) => (
+          <BlogCard
+            key={index}
+            title={post.title}
+            date={post.date}
+            author={post.author}
+            excerpt={post.excerpt}
+            href={post.href}
+            tags={post.tags}
+          />
+        ))}
+      </div>
+      
+      {posts.length === 0 && (
+        <div className="blog-index-empty">
+          <p>No blog posts available yet. Stay tuned for updates!</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/multimodal/websites/docs/src/components/index.ts
+++ b/multimodal/websites/docs/src/components/index.ts
@@ -10,6 +10,8 @@ export * from './NotFoundLayout';
 export * from './UnderConstructionLayout';
 export * from './SocialCallout';
 export * from './Link';
+export * from './BlogCard';
+export * from './BlogIndex';
 
 export * from './Banner';
 export * from './Replay';


### PR DESCRIPTION
## Summary

Added a minimal and elegant Blog Index Page to replace the direct link to a specific blog post in the navigation. This enables better blog management and user experience.

## Snapshot

<img width="4400" height="2618" alt="image" src="https://github.com/user-attachments/assets/a77e402e-7b7b-4655-95cf-f5dc1cb5a675" />



## Checklist

- [ ] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [x] My change does not involve the above items.