### PR TITLE
docs(agent-tars): migrate agent-snapshot to tarko docs

### DIFF
--- a/multimodal/websites/docs/docs/en/guide/advanced/_meta.json
+++ b/multimodal/websites/docs/docs/en/guide/advanced/_meta.json
@@ -3,25 +3,5 @@
     "type": "file",
     "name": "agent-snapshot",
     "label": "Agent Snapshot"
-  },
-  {
-    "type": "file",
-    "name": "agent-trace",
-    "label": "Agent Trace"
-  },
-  {
-    "type": "file",
-    "name": "benchmark",
-    "label": "Benchmark"
-  },
-  {
-    "type": "file",
-    "name": "context",
-    "label": "Context"
-  },
-  {
-    "type": "file",
-    "name": "fc-engine",
-    "label": "FC Engine"
   }
 ]

--- a/multimodal/websites/docs/docs/en/guide/advanced/agent-snapshot.md
+++ b/multimodal/websites/docs/docs/en/guide/advanced/agent-snapshot.md
@@ -1,21 +1,23 @@
 # Agent Snapshot
 
-## When to use?
+Agent Snapshot 是 Tarko Agent Framework 的核心调试功能。
 
-If you find some bugs of Agent TARS, you want to know to underlying request, you can use this feature to help you trouble shoot it.
+## 迁移通知
 
-## Quick Start
+此文档已迁移到 Tarko 文档站，请访问：
 
-### 1. 示例
+**📖 [Tarko Agent Snapshot Documentation](https://tarko.ai/guide/advanced/agent-snapshot)**
 
-让我们以一个典型的例子来向你表达 Agent Snapshot 的作用。考虑到不同 Model Provider 的巨大差异，完美地兼容所有模型是一项非常复杂且长期的工作，有时你可能会遇到一些意外的 LLM 调用错误，比如：
+## 快速链接
 
-```
-[Stream] Error in agent loop execution: Error: 400 operation error Bedrock Runtime: ConverseStream, https response error StatusCode: 400, RequestID: 31427985-ebcf-4321-af29-d498c474a20f, ValidationException: The json schema definition at toolConfig.tools.13.toolSpec.inputSchema is invalid. Fix the following errors and try again: $.properties: null found, object expected
-```
-### 2. 开启 Snapshot
+- [Agent Snapshot 概述](https://tarko.ai/guide/advanced/agent-snapshot#what-is-agent-snapshot)
+- [创建快照](https://tarko.ai/guide/advanced/agent-snapshot#creating-snapshots)
+- [回放快照](https://tarko.ai/guide/advanced/agent-snapshot#replaying-snapshots)
+- [调试最佳实践](https://tarko.ai/guide/advanced/agent-snapshot#debugging-with-snapshots)
 
-此时，你可以通过 Global Workspace 的 Config 来开启 Agent Snapshot:
+## Agent TARS 中的使用
+
+在 Agent TARS 中启用 Agent Snapshot：
 
 ```ts
 // agent-tars.config.ts
@@ -31,50 +33,4 @@ export default defineConfig({
 });
 ```
 
-接着，你将能够在 Global Workspace 中找到所有的状态，包含每一轮的 LLM Request、LLM Response：
-
-```bash
-snapshots
-└── c3fMyx8jePXnhjYvHOhKr           # Session id
-    ├── event-stream.jsonl          # Final event stream
-    ├── loop-1                      # Loop 1
-    │   ├── event-stream.jsonl
-    │   ├── llm-request.jsonl
-    │   ├── llm-response.jsonl
-    │   └── tool-calls.jsonl
-    ├── loop-2                      # Loop 2
-    │   ├── event-stream.jsonl
-    │   ├── llm-request.jsonl
-    │   ├── llm-response.jsonl
-    │   └── tool-calls.jsonl
-    └── loop-3                      # Loop 3
-        ├── event-stream.jsonl
-        ├── llm-request.jsonl
-        └── llm-response.jsonl
-```
-
-### 3. 分析 Snapshot
-
-在上面的问题中，我们把 `loop-1/llm-request.jsonl` 和保存信息一起扔给 LLM，LLM 会很快给出答案
-
-> AWS Bedrock 要求 JSON Schema 中当 type 为 "object" 时，必须包含一个 properties 字段（即使为空）。但这里的参数定义中缺少了 properties 字段。
-
-解决方案：需要修改 `browser_get_clickable_elements` 工具的参数定义，添加空的 properties 对象：
-
-```diff
-"type": "function",
-"function": {
-    "name": "browser_get_clickable_elements",
-    "description": "[browser] Get the clickable or hoverable or selectable elements on the current page, don't call this tool multiple times",
-    "parameters": {
-        "type": "object",
-+       "properties": {}
-    }
-}
-```
-
-这便是 Agent TARS 在迭代中的一个真实例子，详见 [#770](https://github.com/bytedance/UI-TARS-desktop/pull/770)。
-
-## 总结
-
-Agent Snapshot 为 Agent TARS 创造了 "白盒化"，我们期望此能力能够让更多的人参与到 Agent TARS 的建设中来。
+更多详细配置和使用方法，请参考 [Tarko 文档](https://tarko.ai/guide/advanced/agent-snapshot)。

--- a/multimodal/websites/docs/docs/en/guide/advanced/agent-trace.md
+++ b/multimodal/websites/docs/docs/en/guide/advanced/agent-trace.md
@@ -1,1 +1,0 @@
-# Agent Trace

--- a/multimodal/websites/docs/docs/en/guide/advanced/benchmark.md
+++ b/multimodal/websites/docs/docs/en/guide/advanced/benchmark.md
@@ -1,1 +1,0 @@
-# Benchmark

--- a/multimodal/websites/docs/docs/en/guide/advanced/context.md
+++ b/multimodal/websites/docs/docs/en/guide/advanced/context.md
@@ -1,1 +1,0 @@
-# Context

--- a/multimodal/websites/docs/docs/en/guide/advanced/fc-engine.md
+++ b/multimodal/websites/docs/docs/en/guide/advanced/fc-engine.md
@@ -1,1 +1,0 @@
-# FC Engine

--- a/multimodal/websites/docs/docs/zh/guide/advanced/_meta.json
+++ b/multimodal/websites/docs/docs/zh/guide/advanced/_meta.json
@@ -3,30 +3,5 @@
     "type": "file",
     "name": "agent-snapshot",
     "label": "Agent Snapshot"
-  },
-  {
-    "type": "file",
-    "name": "agent-trace",
-    "label": "Agent Trace"
-  },
-  {
-    "type": "file",
-    "name": "benchmark",
-    "label": "Benchmark"
-  },
-  {
-    "type": "file",
-    "name": "context",
-    "label": "Context"
-  },
-  {
-    "type": "file",
-    "name": "event-stream",
-    "label": "Event Stream"
-  },
-  {
-    "type": "file",
-    "name": "fc-engine",
-    "label": "FC Engine"
   }
 ]

--- a/multimodal/websites/docs/docs/zh/guide/advanced/agent-snapshot.md
+++ b/multimodal/websites/docs/docs/zh/guide/advanced/agent-snapshot.md
@@ -1,21 +1,23 @@
 # Agent Snapshot
 
-## When to use?
+Agent Snapshot 是 Tarko Agent Framework 的核心调试功能。
 
-If you find some bugs of Agent TARS, you want to know to underlying request, you can use this feature to help you trouble shoot it.
+## 迁移通知
 
-## Quick Start
+此文档已迁移到 Tarko 文档站，请访问：
 
-### 1. 示例
+**📖 [Tarko Agent Snapshot 文档](https://tarko.ai/zh/guide/advanced/agent-snapshot)**
 
-让我们以一个典型的例子来向你表达 Agent Snapshot 的作用。考虑到不同 Model Provider 的巨大差异，完美地兼容所有模型是一项非常复杂且长期的工作，有时你可能会遇到一些意外的 LLM 调用错误，比如：
+## 快速链接
 
-```
-[Stream] Error in agent loop execution: Error: 400 operation error Bedrock Runtime: ConverseStream, https response error StatusCode: 400, RequestID: 31427985-ebcf-4321-af29-d498c474a20f, ValidationException: The json schema definition at toolConfig.tools.13.toolSpec.inputSchema is invalid. Fix the following errors and try again: $.properties: null found, object expected
-```
-### 2. 开启 Snapshot
+- [Agent Snapshot 概述](https://tarko.ai/zh/guide/advanced/agent-snapshot#什么是-agent-snapshot)
+- [创建快照](https://tarko.ai/zh/guide/advanced/agent-snapshot#创建快照)
+- [回放快照](https://tarko.ai/zh/guide/advanced/agent-snapshot#回放快照)
+- [调试最佳实践](https://tarko.ai/zh/guide/advanced/agent-snapshot#使用快照调试)
 
-此时，你可以通过 Global Workspace 的 Config 来开启 Agent Snapshot:
+## 在 Agent TARS 中的使用
+
+在 Agent TARS 中启用 Agent Snapshot：
 
 ```ts
 // agent-tars.config.ts
@@ -31,50 +33,4 @@ export default defineConfig({
 });
 ```
 
-接着，你将能够在 Global Workspace 中找到所有的状态，包含每一轮的 LLM Request、LLM Response：
-
-```bash
-snapshots
-└── c3fMyx8jePXnhjYvHOhKr           # Session id
-    ├── event-stream.jsonl          # Final event stream
-    ├── loop-1                      # Loop 1
-    │   ├── event-stream.jsonl
-    │   ├── llm-request.jsonl
-    │   ├── llm-response.jsonl
-    │   └── tool-calls.jsonl
-    ├── loop-2                      # Loop 2
-    │   ├── event-stream.jsonl
-    │   ├── llm-request.jsonl
-    │   ├── llm-response.jsonl
-    │   └── tool-calls.jsonl
-    └── loop-3                      # Loop 3
-        ├── event-stream.jsonl
-        ├── llm-request.jsonl
-        └── llm-response.jsonl
-```
-
-### 3. 分析 Snapshot
-
-在上面的问题中，我们把 `loop-1/llm-request.jsonl` 和保存信息一起扔给 LLM，LLM 会很快给出答案
-
-> AWS Bedrock 要求 JSON Schema 中当 type 为 "object" 时，必须包含一个 properties 字段（即使为空）。但这里的参数定义中缺少了 properties 字段。
-
-解决方案：需要修改 `browser_get_clickable_elements` 工具的参数定义，添加空的 properties 对象：
-
-```diff
-"type": "function",
-"function": {
-    "name": "browser_get_clickable_elements",
-    "description": "[browser] Get the clickable or hoverable or selectable elements on the current page, don't call this tool multiple times",
-    "parameters": {
-        "type": "object",
-+       "properties": {}
-    }
-}
-```
-
-这便是 Agent TARS 在迭代中的一个真实例子，详见 [#770](https://github.com/bytedance/UI-TARS-desktop/pull/770)。
-
-## 总结
-
-Agent Snapshot 为 Agent TARS 创造了 "白盒化"，我们期望此能力能够让更多的人参与到 Agent TARS 的建设中来。
+更多详细配置和使用方法，请参考 [Tarko 文档](https://tarko.ai/zh/guide/advanced/agent-snapshot)。

--- a/multimodal/websites/docs/docs/zh/guide/advanced/agent-trace.md
+++ b/multimodal/websites/docs/docs/zh/guide/advanced/agent-trace.md
@@ -1,1 +1,0 @@
-# Agent Trace

--- a/multimodal/websites/docs/docs/zh/guide/advanced/benchmark.md
+++ b/multimodal/websites/docs/docs/zh/guide/advanced/benchmark.md
@@ -1,1 +1,0 @@
-# Benchmark

--- a/multimodal/websites/docs/docs/zh/guide/advanced/context.md
+++ b/multimodal/websites/docs/docs/zh/guide/advanced/context.md
@@ -1,1 +1,0 @@
-# Context

--- a/multimodal/websites/docs/docs/zh/guide/advanced/fc-engine.md
+++ b/multimodal/websites/docs/docs/zh/guide/advanced/fc-engine.md
@@ -1,1 +1,0 @@
-# FC Engine


### PR DESCRIPTION
Migrate `agent-snapshot` documentation from Agent TARS to Tarko docs and clean up empty Advanced sections.

## Changes

- Updated `agent-snapshot.md` in Agent TARS to redirect to Tarko documentation
- Removed empty Advanced documentation files (`agent-trace`, `benchmark`, `context`, `fc-engine`)
- Updated `_meta.json` to only include `agent-snapshot`
- Applied changes to both English and Chinese versions

## Rationale

Follows the documentation strategy where Tarko focuses on Agent Framework features while Agent TARS focuses on the application itself.