### PR TITLE
feat(tarko-agent-cli): add `--model.displayName` option support

### DIFF
--- a/multimodal/tarko/agent-cli/src/core/options.ts
+++ b/multimodal/tarko/agent-cli/src/core/options.ts
@@ -50,6 +50,7 @@ export function addCommonOptions(command: Command): Command {
       'LLM provider name (deprecated, replaced by `--model.provider`)',
     )
     .option('--model.id [model]', 'Model identifier')
+    .option('--model.displayName [displayName]', 'Model display name')
     .option('--model.apiKey [apiKey]', 'Model API key')
     .option('--apiKey [apiKey]', 'Model API key (deprecated, replaced by `--model.apiKey`)')
     .option('--model.baseURL [baseURL]', 'Model base URL')

--- a/multimodal/tarko/agent-cli/tests/config-builder.test.ts
+++ b/multimodal/tarko/agent-cli/tests/config-builder.test.ts
@@ -99,6 +99,24 @@ describe('buildAppConfig', () => {
       });
     });
 
+    it('should handle model displayName configuration', () => {
+      const cliArgs: AgentCLIArguments = {
+        model: {
+          provider: 'openai',
+          id: 'gpt-4',
+          displayName: 'GPT-4 Turbo',
+        },
+      };
+
+      const result = buildAppConfig(cliArgs, {});
+
+      expect(result.model).toEqual({
+        provider: 'openai',
+        id: 'gpt-4',
+        displayName: 'GPT-4 Turbo',
+      });
+    });
+
     it('should handle thinking configuration', () => {
       const cliArgs: AgentCLIArguments = {
         thinking: {


### PR DESCRIPTION
## Summary

Adds support for `--model.displayName` CLI option in `@tarko/agent-cli`.

The `AgentModel` interface already includes the `displayName?: string` field, but the CLI was missing the corresponding option to set it from command line.

## Checklist

- [x] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [ ] My change does not involve the above items.