### PR TITLE
fix(tarko-agent-ui): improve `read_multiple_files` renderer parsing and error handling

### DIFF
--- a/multimodal/tarko/agent-ui/src/standalone/workspace/renderers/TabbedFilesRenderer.tsx
+++ b/multimodal/tarko/agent-ui/src/standalone/workspace/renderers/TabbedFilesRenderer.tsx
@@ -186,9 +186,7 @@ export const TabbedFilesRenderer: React.FC<TabbedFilesRendererProps> = ({
                   ) : (
                     <FiFile size={12} />
                   )}
-                  <span className="truncate max-w-32" title={file.path}>
-                    {tabFileName}
-                  </span>
+                  <span title={file.path}>{tabFileName}</span>
                 </div>
               </button>
             );


### PR DESCRIPTION
## Summary

Fixes multiple issues in the `read_multiple_files` renderer:

1. **File name truncation**: Removed the width limit, the file name can be fully displayed, and the tooltip display of the full path is retained
2. **Incorrect file separator parsing**: Improved logic to only split on `---` when followed by a valid file path pattern, preventing content with `---` from being incorrectly split
3. **Runtime errors**: Added null checks to prevent `Cannot read properties of undefined (reading 'path')` errors

The new parsing algorithm processes files line-by-line and validates file separators to ensure accurate content splitting.

### Before

<img width="4400" height="1706" alt="image" src="https://github.com/user-attachments/assets/21a2c04b-5504-48bd-b3e1-33165da4b0d9" />


###

<img width="4400" height="1788" alt="image" src="https://github.com/user-attachments/assets/5abbe03e-0c45-412f-83f0-a70e59aaa7e8" />


## Checklist

- [x] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [x] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [ ] My change does not involve the above items.