### PR TITLE
docs(tarko): restructure cli documentation into separate sections

### DIFF
--- a/multimodal/websites/tarko/docs/en/guide/_meta.json
+++ b/multimodal/websites/tarko/docs/en/guide/_meta.json
@@ -15,6 +15,13 @@
   },
   {
     "type": "dir",
+    "name": "cli",
+    "label": "CLI",
+    "collapsible": false,
+    "collapsed": false
+  },
+  {
+    "type": "dir",
     "name": "tool",
     "label": "Tool",
     "collapsible": false,

--- a/multimodal/websites/tarko/docs/en/guide/cli/_meta.json
+++ b/multimodal/websites/tarko/docs/en/guide/cli/_meta.json
@@ -1,21 +1,21 @@
 [
   {
-    "type": "page",
+    "type": "file",
     "name": "overview",
     "label": "Overview"
   },
   {
-    "type": "page",
+    "type": "file",
     "name": "commands",
     "label": "Commands"
   },
   {
-    "type": "page",
+    "type": "file",
     "name": "configuration",
     "label": "Configuration"
   },
   {
-    "type": "page",
+    "type": "file",
     "name": "built-in-agents",
     "label": "Built-in Agents"
   }

--- a/multimodal/websites/tarko/docs/en/guide/cli/_meta.json
+++ b/multimodal/websites/tarko/docs/en/guide/cli/_meta.json
@@ -1,0 +1,22 @@
+[
+  {
+    "type": "page",
+    "name": "overview",
+    "label": "Overview"
+  },
+  {
+    "type": "page",
+    "name": "commands",
+    "label": "Commands"
+  },
+  {
+    "type": "page",
+    "name": "configuration",
+    "label": "Configuration"
+  },
+  {
+    "type": "page",
+    "name": "built-in-agents",
+    "label": "Built-in Agents"
+  }
+]

--- a/multimodal/websites/tarko/docs/en/guide/cli/built-in-agents.mdx
+++ b/multimodal/websites/tarko/docs/en/guide/cli/built-in-agents.mdx
@@ -1,0 +1,364 @@
+---
+title: Built-in Agents
+description: Using pre-built agents included with Tarko CLI
+---
+
+# Built-in Agents
+
+Tarko CLI includes several ready-to-use agents that demonstrate different capabilities and use cases. These agents are immediately available without any additional setup.
+
+## Available Agents
+
+### `agent-tars`
+
+**Agent TARS** - Advanced task automation and reasoning system designed for complex problem-solving and multi-step workflows.
+
+#### Capabilities
+- Advanced reasoning and planning
+- Multi-step task execution
+- Context-aware decision making
+- Tool orchestration
+- Error handling and recovery
+
+#### Use Cases
+- Complex automation tasks
+- Multi-step workflows
+- Problem-solving scenarios
+- Research and analysis
+- Code generation and debugging
+
+#### Usage
+
+```bash
+# Interactive mode with Web UI
+tarko run agent-tars
+
+# Headless server deployment
+tarko serve agent-tars --port 8080
+
+# Scripting mode
+tarko run agent-tars --headless --input "Analyze this codebase and suggest improvements"
+
+# With custom configuration
+tarko run agent-tars --config ./tars-config.ts
+```
+
+#### Example Tasks
+
+```bash
+# Code analysis and improvement
+tarko run agent-tars --headless --input "Review the code in ./src and provide optimization suggestions"
+
+# Project setup automation
+tarko run agent-tars --headless --input "Set up a new React TypeScript project with best practices"
+
+# Documentation generation
+tarko run agent-tars --headless --input "Generate comprehensive documentation for this API"
+
+# Testing strategy
+tarko run agent-tars --headless --input "Create a testing strategy for this application"
+```
+
+### `omni-tars`
+
+**Omni-TARS** - Multi-modal agent with comprehensive capabilities for handling text, images, files, and web interactions.
+
+#### Capabilities
+- Multi-modal input processing (text, images, documents)
+- Web browsing and scraping
+- File system operations
+- Image analysis and generation
+- Document processing
+- API integrations
+
+#### Use Cases
+- Content creation and editing
+- Web research and data collection
+- Document analysis and processing
+- Image analysis and manipulation
+- Multi-modal workflows
+
+#### Usage
+
+```bash
+# Interactive mode with Web UI
+tarko run omni-tars
+
+# Headless server deployment
+tarko serve omni-tars --port 8080
+
+# Scripting mode with file input
+tarko run omni-tars --headless --input "Analyze the images in ./assets and create a summary"
+
+# Web research mode
+tarko run omni-tars --headless --input "Research the latest trends in AI and create a report"
+```
+
+#### Example Tasks
+
+```bash
+# Image analysis
+tarko run omni-tars --headless --input "Analyze the screenshot in ./image.png and describe what you see"
+
+# Web research
+tarko run omni-tars --headless --input "Research the latest developments in quantum computing"
+
+# Document processing
+tarko run omni-tars --headless --input "Summarize the PDF documents in ./reports/"
+
+# Content creation
+tarko run omni-tars --headless --input "Create a blog post about sustainable technology based on recent news"
+```
+
+### `mcp-agent`
+
+**MCP Agent** - Model Context Protocol agent specialized in tool integration and external service connectivity.
+
+#### Capabilities
+- MCP server management
+- Tool discovery and integration
+- External service connectivity
+- Protocol handling
+- Resource management
+
+#### Use Cases
+- Tool integration testing
+- MCP server development
+- External API integration
+- Service orchestration
+- Protocol debugging
+
+#### Usage
+
+```bash
+# Interactive mode for tool exploration
+tarko run mcp-agent
+
+# List available tools and servers
+tarko run mcp-agent --headless --input "List all available tools and their capabilities"
+
+# Test MCP server connectivity
+tarko run mcp-agent --headless --input "Test connectivity to all configured MCP servers"
+
+# Tool integration workflow
+tarko serve mcp-agent --port 8080
+```
+
+#### Example Tasks
+
+```bash
+# Tool discovery
+tarko run mcp-agent --headless --input "Discover and list all available tools"
+
+# MCP server status
+tarko run mcp-agent --headless --input "Check the status of all MCP servers"
+
+# Tool testing
+tarko run mcp-agent --headless --input "Test the file system tools with a simple read operation"
+
+# Integration workflow
+tarko run mcp-agent --headless --input "Demonstrate a workflow using multiple tools"
+```
+
+## Agent Comparison
+
+| Feature | agent-tars | omni-tars | mcp-agent |
+|---------|------------|-----------|----------|
+| **Primary Focus** | Reasoning & Automation | Multi-modal Processing | Tool Integration |
+| **Complexity** | High | Medium-High | Medium |
+| **Use Case** | Complex workflows | Content & research | Tool development |
+| **Multi-modal** | Limited | Full support | Limited |
+| **Web Browsing** | Yes | Yes | Limited |
+| **File Operations** | Yes | Yes | Yes |
+| **Tool Integration** | Advanced | Standard | Specialized |
+| **MCP Support** | Yes | Yes | Primary focus |
+
+## Configuration
+
+### Agent-Specific Configuration
+
+Each built-in agent can be configured with specific settings:
+
+```typescript
+// tarko.config.ts
+import { AgentAppConfig } from '@tarko/interface';
+
+const config: AgentAppConfig = {
+  // Agent-specific configuration
+  agent: {
+    type: 'agent-tars', // or 'omni-tars', 'mcp-agent'
+    config: {
+      // Agent-specific settings
+      maxSteps: 10,
+      timeoutMs: 30000,
+      retryAttempts: 3,
+    },
+  },
+  
+  // Model configuration for the agent
+  model: {
+    provider: 'openai',
+    id: 'gpt-4',
+    temperature: 0.7,
+  },
+  
+  // Tool filtering for specific agents
+  tool: {
+    include: ['file_*', 'web_*'], // Customize available tools
+  },
+};
+
+export default config;
+```
+
+### Environment-Specific Agents
+
+```bash
+# Development with agent-tars
+NODE_ENV=development tarko run agent-tars --debug
+
+# Production deployment with omni-tars
+NODE_ENV=production tarko serve omni-tars --port 8080
+
+# Testing with mcp-agent
+tarko run mcp-agent --headless --input "Run diagnostics"
+```
+
+## Custom Agent Development
+
+While built-in agents provide immediate functionality, you can also create custom agents:
+
+### Creating a Custom Agent
+
+```typescript
+// my-custom-agent.ts
+import { Agent } from '@tarko/agent';
+import { AgentOptions } from '@tarko/interface';
+
+class MyCustomAgent extends Agent {
+  constructor(options: AgentOptions) {
+    super({
+      ...options,
+      name: 'MyCustomAgent',
+      description: 'A custom agent for specific tasks',
+    });
+  }
+  
+  async processInput(input: string): Promise<string> {
+    // Custom agent logic
+    return `Processed: ${input}`;
+  }
+}
+
+export default MyCustomAgent;
+```
+
+### Using Custom Agents
+
+```bash
+# Run custom agent
+tarko run ./my-custom-agent.ts
+
+# Deploy custom agent
+tarko serve ./my-custom-agent.ts --port 8080
+
+# Test custom agent
+tarko run ./my-custom-agent.ts --headless --input "Test input"
+```
+
+## Agent Selection Guidelines
+
+### Choose `agent-tars` when:
+- You need complex reasoning and planning
+- Working with multi-step workflows
+- Require advanced problem-solving capabilities
+- Building automation systems
+- Need sophisticated error handling
+
+### Choose `omni-tars` when:
+- Working with multiple content types (text, images, documents)
+- Need web browsing and research capabilities
+- Processing multimedia content
+- Creating content across different formats
+- Require comprehensive tool access
+
+### Choose `mcp-agent` when:
+- Developing or testing MCP servers
+- Integrating external tools and services
+- Debugging protocol implementations
+- Building tool-centric workflows
+- Need specialized MCP functionality
+
+## Performance Considerations
+
+### Resource Usage
+
+| Agent | Memory Usage | CPU Usage | Network Usage |
+|-------|-------------|-----------|---------------|
+| agent-tars | High | High | Medium |
+| omni-tars | Medium-High | Medium | High |
+| mcp-agent | Medium | Low-Medium | Low |
+
+### Optimization Tips
+
+```bash
+# Optimize memory usage
+NODE_OPTIONS="--max-old-space-size=2048" tarko run agent-tars
+
+# Limit concurrent operations
+tarko run omni-tars --config ./optimized-config.ts
+
+# Use caching for better performance
+tarko run mcp-agent --cache-enabled
+```
+
+## Troubleshooting
+
+### Common Issues
+
+**Agent not found:**
+```bash
+# Verify agent name
+tarko run agent-tars --dry-run
+
+# List available agents
+tarko --help
+```
+
+**Performance issues:**
+```bash
+# Enable debug mode
+tarko run omni-tars --debug
+
+# Monitor resource usage
+tarko run agent-tars --metrics-enabled
+```
+
+**Tool access issues:**
+```bash
+# Check tool configuration
+tarko run mcp-agent --show-config
+
+# Test tool connectivity
+tarko run mcp-agent --headless --input "Test tools"
+```
+
+### Debug Mode
+
+```bash
+# Debug agent execution
+DEBUG=tarko:agent:* tarko run agent-tars --debug
+
+# Verbose logging
+tarko run omni-tars --debug --verbose
+
+# Performance profiling
+tarko run mcp-agent --debug --profile
+```
+
+## Next Steps
+
+- [CLI Commands](/guide/cli/commands) - Learn all available CLI commands
+- [Configuration](/guide/cli/configuration) - Advanced configuration options
+- [Deployment](/guide/deployment/cli) - Production deployment strategies
+- [Tool Integration](/guide/basic/tool-call-engine) - Adding custom tools

--- a/multimodal/websites/tarko/docs/en/guide/cli/built-in-agents.mdx
+++ b/multimodal/websites/tarko/docs/en/guide/cli/built-in-agents.mdx
@@ -5,360 +5,129 @@ description: Using pre-built agents included with Tarko CLI
 
 # Built-in Agents
 
-Tarko CLI includes several ready-to-use agents that demonstrate different capabilities and use cases. These agents are immediately available without any additional setup.
+Tarko CLI 包含三个内置 Agent，可以直接使用。
 
-## Available Agents
+## 可用的 Agent
 
 ### `agent-tars`
 
-**Agent TARS** - Advanced task automation and reasoning system designed for complex problem-solving and multi-step workflows.
-
-#### Capabilities
-- Advanced reasoning and planning
-- Multi-step task execution
-- Context-aware decision making
-- Tool orchestration
-- Error handling and recovery
-
-#### Use Cases
-- Complex automation tasks
-- Multi-step workflows
-- Problem-solving scenarios
-- Research and analysis
-- Code generation and debugging
-
-#### Usage
+高级任务自动化和推理系统。
 
 ```bash
-# Interactive mode with Web UI
+# 启动 Web UI
 tarko run agent-tars
 
-# Headless server deployment
-tarko serve agent-tars --port 8080
+# 无头模式
+tarko run agent-tars --headless --input "分析当前目录结构"
 
-# Scripting mode
-tarko run agent-tars --headless --input "Analyze this codebase and suggest improvements"
-
-# With custom configuration
-tarko run agent-tars --config ./tars-config.ts
-```
-
-#### Example Tasks
-
-```bash
-# Code analysis and improvement
-tarko run agent-tars --headless --input "Review the code in ./src and provide optimization suggestions"
-
-# Project setup automation
-tarko run agent-tars --headless --input "Set up a new React TypeScript project with best practices"
-
-# Documentation generation
-tarko run agent-tars --headless --input "Generate comprehensive documentation for this API"
-
-# Testing strategy
-tarko run agent-tars --headless --input "Create a testing strategy for this application"
+# 服务器模式
+tarko serve agent-tars
 ```
 
 ### `omni-tars`
 
-**Omni-TARS** - Multi-modal agent with comprehensive capabilities for handling text, images, files, and web interactions.
-
-#### Capabilities
-- Multi-modal input processing (text, images, documents)
-- Web browsing and scraping
-- File system operations
-- Image analysis and generation
-- Document processing
-- API integrations
-
-#### Use Cases
-- Content creation and editing
-- Web research and data collection
-- Document analysis and processing
-- Image analysis and manipulation
-- Multi-modal workflows
-
-#### Usage
+多模态 Agent，支持文本、图像、文件处理。
 
 ```bash
-# Interactive mode with Web UI
+# 启动 Web UI
 tarko run omni-tars
 
-# Headless server deployment
-tarko serve omni-tars --port 8080
+# 无头模式
+tarko run omni-tars --headless --input "分析这个图片"
 
-# Scripting mode with file input
-tarko run omni-tars --headless --input "Analyze the images in ./assets and create a summary"
-
-# Web research mode
-tarko run omni-tars --headless --input "Research the latest trends in AI and create a report"
-```
-
-#### Example Tasks
-
-```bash
-# Image analysis
-tarko run omni-tars --headless --input "Analyze the screenshot in ./image.png and describe what you see"
-
-# Web research
-tarko run omni-tars --headless --input "Research the latest developments in quantum computing"
-
-# Document processing
-tarko run omni-tars --headless --input "Summarize the PDF documents in ./reports/"
-
-# Content creation
-tarko run omni-tars --headless --input "Create a blog post about sustainable technology based on recent news"
+# 服务器模式
+tarko serve omni-tars
 ```
 
 ### `mcp-agent`
 
-**MCP Agent** - Model Context Protocol agent specialized in tool integration and external service connectivity.
-
-#### Capabilities
-- MCP server management
-- Tool discovery and integration
-- External service connectivity
-- Protocol handling
-- Resource management
-
-#### Use Cases
-- Tool integration testing
-- MCP server development
-- External API integration
-- Service orchestration
-- Protocol debugging
-
-#### Usage
+**Model Context Protocol** Agent，专门用于 Tool 集成。
 
 ```bash
-# Interactive mode for tool exploration
+# 启动 Web UI
 tarko run mcp-agent
 
-# List available tools and servers
-tarko run mcp-agent --headless --input "List all available tools and their capabilities"
+# 无头模式
+tarko run mcp-agent --headless --input "列出所有可用工具"
 
-# Test MCP server connectivity
-tarko run mcp-agent --headless --input "Test connectivity to all configured MCP servers"
-
-# Tool integration workflow
-tarko serve mcp-agent --port 8080
+# 服务器模式
+tarko serve mcp-agent
 ```
 
-#### Example Tasks
+## 使用自定义 Agent
 
-```bash
-# Tool discovery
-tarko run mcp-agent --headless --input "Discover and list all available tools"
-
-# MCP server status
-tarko run mcp-agent --headless --input "Check the status of all MCP servers"
-
-# Tool testing
-tarko run mcp-agent --headless --input "Test the file system tools with a simple read operation"
-
-# Integration workflow
-tarko run mcp-agent --headless --input "Demonstrate a workflow using multiple tools"
-```
-
-## Agent Comparison
-
-| Feature | agent-tars | omni-tars | mcp-agent |
-|---------|------------|-----------|----------|
-| **Primary Focus** | Reasoning & Automation | Multi-modal Processing | Tool Integration |
-| **Complexity** | High | Medium-High | Medium |
-| **Use Case** | Complex workflows | Content & research | Tool development |
-| **Multi-modal** | Limited | Full support | Limited |
-| **Web Browsing** | Yes | Yes | Limited |
-| **File Operations** | Yes | Yes | Yes |
-| **Tool Integration** | Advanced | Standard | Specialized |
-| **MCP Support** | Yes | Yes | Primary focus |
-
-## Configuration
-
-### Agent-Specific Configuration
-
-Each built-in agent can be configured with specific settings:
+除了内置 Agent，你也可以创建自定义 Agent：
 
 ```typescript
-// tarko.config.ts
+// my-agent.ts
+import { Agent } from '@tarko/agent';
+
+class MyAgent extends Agent {
+  constructor(options = {}) {
+    super({
+      ...options,
+      name: 'MyAgent',
+      instructions: '你是一个专门的助手...'
+    });
+  }
+}
+
+export default MyAgent;
+```
+
+使用自定义 Agent：
+
+```bash
+# 运行自定义 Agent
+tarko run ./my-agent.ts
+
+# 部署自定义 Agent
+tarko serve ./my-agent.ts
+```
+
+## Agent 架构
+
+```mermaid
+graph TD
+    A[CLI Input] --> B[Agent Selection]
+    B --> C{Agent Type}
+    
+    C -->|agent-tars| D[Advanced Reasoning]
+    C -->|omni-tars| E[Multi-modal Processing]
+    C -->|mcp-agent| F[Tool Integration]
+    C -->|custom| G[Custom Logic]
+    
+    D --> H[Tool Manager]
+    E --> H
+    F --> H
+    G --> H
+    
+    H --> I[LLM Provider]
+    I --> J[Response]
+```
+
+## 配置 Agent
+
+在 `tarko.config.ts` 中配置默认 Agent：
+
+```typescript
 import { AgentAppConfig } from '@tarko/interface';
 
 const config: AgentAppConfig = {
-  // Agent-specific configuration
-  agent: {
-    type: 'agent-tars', // or 'omni-tars', 'mcp-agent'
-    config: {
-      // Agent-specific settings
-      maxSteps: 10,
-      timeoutMs: 30000,
-      retryAttempts: 3,
-    },
-  },
-  
-  // Model configuration for the agent
   model: {
     provider: 'openai',
-    id: 'gpt-4',
-    temperature: 0.7,
+    id: 'gpt-4'
   },
-  
-  // Tool filtering for specific agents
   tool: {
-    include: ['file_*', 'web_*'], // Customize available tools
-  },
+    include: ['file_*', 'web_*']
+  }
 };
 
 export default config;
 ```
 
-### Environment-Specific Agents
+## 下一步
 
-```bash
-# Development with agent-tars
-NODE_ENV=development tarko run agent-tars --debug
-
-# Production deployment with omni-tars
-NODE_ENV=production tarko serve omni-tars --port 8080
-
-# Testing with mcp-agent
-tarko run mcp-agent --headless --input "Run diagnostics"
-```
-
-## Custom Agent Development
-
-While built-in agents provide immediate functionality, you can also create custom agents:
-
-### Creating a Custom Agent
-
-```typescript
-// my-custom-agent.ts
-import { Agent } from '@tarko/agent';
-import { AgentOptions } from '@tarko/interface';
-
-class MyCustomAgent extends Agent {
-  constructor(options: AgentOptions) {
-    super({
-      ...options,
-      name: 'MyCustomAgent',
-      description: 'A custom agent for specific tasks',
-    });
-  }
-  
-  async processInput(input: string): Promise<string> {
-    // Custom agent logic
-    return `Processed: ${input}`;
-  }
-}
-
-export default MyCustomAgent;
-```
-
-### Using Custom Agents
-
-```bash
-# Run custom agent
-tarko run ./my-custom-agent.ts
-
-# Deploy custom agent
-tarko serve ./my-custom-agent.ts --port 8080
-
-# Test custom agent
-tarko run ./my-custom-agent.ts --headless --input "Test input"
-```
-
-## Agent Selection Guidelines
-
-### Choose `agent-tars` when:
-- You need complex reasoning and planning
-- Working with multi-step workflows
-- Require advanced problem-solving capabilities
-- Building automation systems
-- Need sophisticated error handling
-
-### Choose `omni-tars` when:
-- Working with multiple content types (text, images, documents)
-- Need web browsing and research capabilities
-- Processing multimedia content
-- Creating content across different formats
-- Require comprehensive tool access
-
-### Choose `mcp-agent` when:
-- Developing or testing MCP servers
-- Integrating external tools and services
-- Debugging protocol implementations
-- Building tool-centric workflows
-- Need specialized MCP functionality
-
-## Performance Considerations
-
-### Resource Usage
-
-| Agent | Memory Usage | CPU Usage | Network Usage |
-|-------|-------------|-----------|---------------|
-| agent-tars | High | High | Medium |
-| omni-tars | Medium-High | Medium | High |
-| mcp-agent | Medium | Low-Medium | Low |
-
-### Optimization Tips
-
-```bash
-# Optimize memory usage
-NODE_OPTIONS="--max-old-space-size=2048" tarko run agent-tars
-
-# Limit concurrent operations
-tarko run omni-tars --config ./optimized-config.ts
-
-# Use caching for better performance
-tarko run mcp-agent --cache-enabled
-```
-
-## Troubleshooting
-
-### Common Issues
-
-**Agent not found:**
-```bash
-# Verify agent name
-tarko run agent-tars --dry-run
-
-# List available agents
-tarko --help
-```
-
-**Performance issues:**
-```bash
-# Enable debug mode
-tarko run omni-tars --debug
-
-# Monitor resource usage
-tarko run agent-tars --metrics-enabled
-```
-
-**Tool access issues:**
-```bash
-# Check tool configuration
-tarko run mcp-agent --show-config
-
-# Test tool connectivity
-tarko run mcp-agent --headless --input "Test tools"
-```
-
-### Debug Mode
-
-```bash
-# Debug agent execution
-DEBUG=tarko:agent:* tarko run agent-tars --debug
-
-# Verbose logging
-tarko run omni-tars --debug --verbose
-
-# Performance profiling
-tarko run mcp-agent --debug --profile
-```
-
-## Next Steps
-
-- [CLI Commands](/guide/cli/commands) - Learn all available CLI commands
-- [Configuration](/guide/cli/configuration) - Advanced configuration options
-- [Deployment](/guide/deployment/cli) - Production deployment strategies
-- [Tool Integration](/guide/basic/tool-call-engine) - Adding custom tools
+- [CLI Commands](/guide/cli/commands) - 完整命令参考
+- [Configuration](/guide/cli/configuration) - 配置选项
+- [Tool Integration](/guide/basic/tool-call-engine) - 添加自定义 Tool

--- a/multimodal/websites/tarko/docs/en/guide/cli/commands.mdx
+++ b/multimodal/websites/tarko/docs/en/guide/cli/commands.mdx
@@ -194,9 +194,6 @@ tarko request --provider openai --model gpt-4 --body request.json --format seman
 # Initialize new workspace in current directory
 tarko workspace --init
 
-# Initialize with custom name
-tarko workspace --init --name my-agent-workspace
-
 # Open workspace in VSCode
 tarko workspace --open
 
@@ -208,9 +205,6 @@ tarko workspace --disable
 
 # Show workspace status and configuration
 tarko workspace --status
-
-# Clean workspace (remove temp files)
-tarko workspace --clean
 ```
 
 ### Workspace Structure

--- a/multimodal/websites/tarko/docs/en/guide/cli/commands.mdx
+++ b/multimodal/websites/tarko/docs/en/guide/cli/commands.mdx
@@ -1,0 +1,353 @@
+---
+title: CLI Commands
+description: Complete reference for all Tarko CLI commands
+---
+
+# CLI Commands
+
+Complete reference for all Tarko Agent CLI commands and their options.
+
+## `tarko` / `tarko run`
+
+Launches **interactive Web UI** for real-time conversation and file browsing.
+
+### Basic Usage
+
+```bash
+# Start interactive Web UI (default)
+tarko
+
+# Equivalent explicit command
+tarko run
+
+# Run with specific agent
+tarko run ./my-agent.js
+
+# Run with built-in agents
+tarko run agent-tars
+tarko run omni-tars
+tarko run mcp-agent
+```
+
+### Options
+
+```bash
+# Custom port and auto-open browser
+tarko run --port 8888 --open
+
+# Development mode with hot reload
+tarko run --dev
+
+# Debug mode with verbose logging
+tarko run --debug
+
+# Custom configuration file
+tarko run --config ./custom-config.ts
+
+# Custom workspace
+tarko run --workspace ./my-workspace
+```
+
+### Headless Mode
+
+**Silent mode** execution with stdout output, perfect for scripting:
+
+```bash
+# Direct input with text output (default)
+tarko run --headless --input "Analyze current directory structure"
+
+# Pipeline input
+echo "Summarize this code" | tarko run --headless
+
+# JSON output for programmatic use
+tarko run --headless --input "Analyze files" --format json
+
+# Include debug logs in output
+tarko run --headless --input "Analyze files" --include-logs
+
+# Disable cache for fresh execution
+tarko run --headless --input "Analyze files" --use-cache false
+
+# Combine with built-in agents
+tarko run agent-tars --headless --input "List directory contents"
+```
+
+#### Headless Options
+
+| Option | Description | Default |
+|--------|-------------|----------|
+| `--input <text>` | Direct input text | - |
+| `--format <type>` | Output format: `text`, `json` | `text` |
+| `--include-logs` | Include debug logs in output | `false` |
+| `--use-cache <bool>` | Enable/disable caching | `true` |
+
+## `tarko serve`
+
+Starts **headless API server** for system integration and production deployment.
+
+### Basic Usage
+
+```bash
+# Start headless server
+tarko serve
+
+# Start server with specific agent
+tarko serve ./my-agent
+
+# Start server with built-in agent
+tarko serve omni-tars
+
+# Custom port and configuration
+tarko serve --port 8888 --config ./production.config.ts
+```
+
+### Options
+
+```bash
+# Custom port (default: 3000)
+tarko serve --port 8888
+
+# Custom host (default: localhost)
+tarko serve --host 0.0.0.0
+
+# Debug mode
+tarko serve --debug
+
+# Custom configuration
+tarko serve --config ./server.config.yaml
+
+# Custom workspace
+tarko serve --workspace ./server-workspace
+```
+
+### API Endpoints
+
+When running `tarko serve`, the following endpoints are available:
+
+- `GET /api/v1/health` - Health check
+- `GET /api/v1/status` - Detailed status
+- `POST /api/v1/chat` - Chat with agent
+- `GET /api/v1/events` - Event stream (WebSocket)
+- `GET /metrics` - Prometheus metrics (if enabled)
+
+## `tarko request`
+
+Direct **LLM requests** for debugging and testing purposes.
+
+### Basic Usage
+
+```bash
+# Basic request
+tarko request --provider openai --model gpt-4 --body '{"messages":[{"role":"user","content":"Hello"}]}'
+
+# Load request from file
+tarko request --provider openai --model gpt-4 --body ./request.json
+```
+
+### Advanced Options
+
+```bash
+# Custom API configuration
+tarko request --provider openai --model gpt-4 \
+  --apiKey sk-xxx \
+  --baseURL https://api.openai.com/v1 \
+  --body request.json
+
+# Streaming mode
+tarko request --provider openai --model gpt-4 --body request.json --stream
+
+# Reasoning mode (for supported models like o1)
+tarko request --provider openai --model o1-preview --body request.json --thinking
+
+# Semantic output format
+tarko request --provider openai --model gpt-4 --body request.json --format semantic
+```
+
+### Supported Providers
+
+- `openai` - OpenAI GPT models
+- `anthropic` - Anthropic Claude models
+- `azure` - Azure OpenAI Service
+- `ollama` - Local Ollama models
+- `gemini` - Google Gemini models
+
+### Request Body Format
+
+```json
+{
+  "messages": [
+    {"role": "system", "content": "You are a helpful assistant."},
+    {"role": "user", "content": "Hello!"}
+  ],
+  "temperature": 0.7,
+  "max_tokens": 1000
+}
+```
+
+## `tarko workspace`
+
+**Workspace management** utilities for organizing agent projects.
+
+### Commands
+
+```bash
+# Initialize new workspace in current directory
+tarko workspace --init
+
+# Initialize with custom name
+tarko workspace --init --name my-agent-workspace
+
+# Open workspace in VSCode
+tarko workspace --open
+
+# Enable global workspace
+tarko workspace --enable
+
+# Disable global workspace
+tarko workspace --disable
+
+# Show workspace status and configuration
+tarko workspace --status
+
+# Clean workspace (remove temp files)
+tarko workspace --clean
+```
+
+### Workspace Structure
+
+Initializing a workspace creates:
+
+```
+my-workspace/
+├── tarko.config.ts          # Main configuration
+├── agents/                   # Custom agents
+├── tools/                    # Custom tools
+├── data/                     # Agent data and cache
+├── logs/                     # Execution logs
+└── .tarko/                   # Internal workspace data
+```
+
+## Global Options
+
+These options work with all commands:
+
+### Configuration
+
+```bash
+# Model configuration
+tarko --model.provider openai --model.id gpt-4 --model.apiKey sk-xxx
+
+# Custom configuration file
+tarko --config ./custom.config.ts
+
+# Custom workspace
+tarko --workspace ./my-workspace
+```
+
+### Debugging
+
+```bash
+# Enable debug logging
+tarko --debug
+
+# Verbose output
+tarko --verbose
+
+# Dry run (show what would be executed)
+tarko --dry-run
+
+# Show configuration and exit
+tarko --show-config
+```
+
+### Tool and MCP Filtering
+
+```bash
+# Include specific tools
+tarko --tool.include "file_*,web_*"
+
+# Exclude specific tools
+tarko --tool.exclude "dangerous_*"
+
+# Include specific MCP servers
+tarko --mcpServer.include "filesystem,browser"
+
+# Exclude specific MCP servers
+tarko --mcpServer.exclude "experimental_*"
+```
+
+## Environment Variables
+
+Alternative to CLI options:
+
+```bash
+# Model configuration
+export OPENAI_API_KEY=your-api-key
+export ANTHROPIC_API_KEY=your-api-key
+
+# Server configuration
+export TARKO_PORT=3000
+export TARKO_HOST=0.0.0.0
+
+# Debug settings
+export DEBUG=tarko:*
+export TARKO_LOG_LEVEL=debug
+
+# Workspace
+export TARKO_WORKSPACE=./my-workspace
+```
+
+## Exit Codes
+
+| Code | Description |
+|------|-------------|
+| 0 | Success |
+| 1 | General error |
+| 2 | Configuration error |
+| 3 | Network error |
+| 4 | Authentication error |
+| 5 | Agent execution error |
+
+## Examples
+
+### Development Workflow
+
+```bash
+# 1. Initialize workspace
+tarko workspace --init --name my-project
+
+# 2. Start development with UI
+tarko run --dev --open
+
+# 3. Test with headless mode
+tarko run --headless --input "Test my agent"
+
+# 4. Deploy to production
+tarko serve --port 3000 --config production.config.ts
+```
+
+### CI/CD Integration
+
+```bash
+# Test agent functionality
+tarko run agent-tars --headless --input "Run tests" --format json > results.json
+
+# Validate configuration
+tarko --dry-run --show-config
+
+# Health check
+curl -f http://localhost:3000/api/v1/health || exit 1
+```
+
+### Debugging
+
+```bash
+# Debug with verbose logging
+DEBUG=tarko:* tarko run --debug --verbose
+
+# Test direct LLM requests
+tarko request --provider openai --model gpt-4 --body '{"messages":[{"role":"user","content":"Hello"}]}' --debug
+
+# Inspect configuration
+tarko --show-config --debug
+```

--- a/multimodal/websites/tarko/docs/en/guide/cli/configuration.mdx
+++ b/multimodal/websites/tarko/docs/en/guide/cli/configuration.mdx
@@ -1,0 +1,577 @@
+---
+title: CLI Configuration
+description: Complete guide to configuring Tarko CLI
+---
+
+# CLI Configuration
+
+Tarko CLI supports multiple configuration formats and sources with a clear priority system.
+
+## Configuration Files
+
+Tarko CLI automatically discovers configuration files in the following order:
+
+1. `tarko.config.ts` (TypeScript)
+2. `tarko.config.yaml` (YAML)
+3. `tarko.config.json` (JSON)
+
+### TypeScript Configuration
+
+```typescript
+// tarko.config.ts
+import { AgentAppConfig } from '@tarko/interface';
+
+const config: AgentAppConfig = {
+  // Model configuration
+  model: {
+    provider: 'openai',
+    id: 'gpt-4',
+    apiKey: process.env.OPENAI_API_KEY,
+    baseURL: 'https://api.openai.com/v1',
+    temperature: 0.7,
+    maxTokens: 4000,
+  },
+  
+  // Workspace settings
+  workspace: './workspace',
+  
+  // Server configuration
+  server: {
+    port: 8888,
+    host: '0.0.0.0',
+    cors: true,
+  },
+  
+  // Tool filtering
+  tool: {
+    include: ['file_*', 'web_*'],
+    exclude: ['dangerous_*'],
+  },
+  
+  // MCP Server filtering
+  mcpServer: {
+    include: ['filesystem', 'browser'],
+    exclude: ['experimental_*'],
+  },
+  
+  // UI configuration
+  ui: {
+    enabled: true,
+    title: 'My Agent',
+    theme: 'default',
+    autoOpen: false,
+  },
+  
+  // Logging configuration
+  logging: {
+    level: 'info',
+    format: 'json',
+    output: {
+      console: true,
+      file: {
+        enabled: true,
+        path: './logs/agent.log',
+        maxSize: '10m',
+        maxFiles: 5,
+      },
+    },
+  },
+  
+  // Metrics configuration
+  metrics: {
+    enabled: true,
+    endpoint: '/metrics',
+    collectors: {
+      requests: true,
+      responses: true,
+      toolCalls: true,
+      errors: true,
+    },
+  },
+};
+
+export default config;
+```
+
+### YAML Configuration
+
+```yaml
+# tarko.config.yaml
+model:
+  provider: openai
+  id: gpt-4
+  apiKey: ${OPENAI_API_KEY}
+  baseURL: https://api.openai.com/v1
+  temperature: 0.7
+  maxTokens: 4000
+
+workspace: ./workspace
+
+server:
+  port: 8888
+  host: 0.0.0.0
+  cors: true
+
+tool:
+  include:
+    - 'file_*'
+    - 'web_*'
+  exclude:
+    - 'dangerous_*'
+
+mcpServer:
+  include:
+    - filesystem
+    - browser
+  exclude:
+    - 'experimental_*'
+
+ui:
+  enabled: true
+  title: My Agent
+  theme: default
+  autoOpen: false
+
+logging:
+  level: info
+  format: json
+  output:
+    console: true
+    file:
+      enabled: true
+      path: ./logs/agent.log
+      maxSize: 10m
+      maxFiles: 5
+
+metrics:
+  enabled: true
+  endpoint: /metrics
+  collectors:
+    requests: true
+    responses: true
+    toolCalls: true
+    errors: true
+```
+
+### JSON Configuration
+
+```json
+{
+  "model": {
+    "provider": "openai",
+    "id": "gpt-4",
+    "apiKey": "${OPENAI_API_KEY}",
+    "baseURL": "https://api.openai.com/v1",
+    "temperature": 0.7,
+    "maxTokens": 4000
+  },
+  "workspace": "./workspace",
+  "server": {
+    "port": 8888,
+    "host": "0.0.0.0",
+    "cors": true
+  },
+  "tool": {
+    "include": ["file_*", "web_*"],
+    "exclude": ["dangerous_*"]
+  },
+  "mcpServer": {
+    "include": ["filesystem", "browser"],
+    "exclude": ["experimental_*"]
+  },
+  "ui": {
+    "enabled": true,
+    "title": "My Agent",
+    "theme": "default",
+    "autoOpen": false
+  },
+  "logging": {
+    "level": "info",
+    "format": "json",
+    "output": {
+      "console": true,
+      "file": {
+        "enabled": true,
+        "path": "./logs/agent.log",
+        "maxSize": "10m",
+        "maxFiles": 5
+      }
+    }
+  },
+  "metrics": {
+    "enabled": true,
+    "endpoint": "/metrics",
+    "collectors": {
+      "requests": true,
+      "responses": true,
+      "toolCalls": true,
+      "errors": true
+    }
+  }
+}
+```
+
+## Configuration Priority
+
+Configuration is resolved in the following priority order (highest to lowest):
+
+1. **CLI arguments** (highest priority)
+2. **Workspace configuration**
+3. **User configuration file** (`--config`)
+4. **Remote configuration URL**
+5. **Default configuration** (lowest priority)
+
+### CLI Arguments Override
+
+```bash
+# Override model configuration
+tarko --model.provider openai --model.id gpt-4 --model.apiKey sk-xxx
+
+# Override server settings
+tarko serve --port 3000 --host 0.0.0.0
+
+# Override workspace
+tarko --workspace ./custom-workspace
+
+# Override tool filtering
+tarko --tool.include "file_*,web_*" --tool.exclude "dangerous_*"
+```
+
+## Environment Variables
+
+Environment variables provide an alternative to configuration files:
+
+### Model Configuration
+
+```bash
+# API Keys
+export OPENAI_API_KEY=your-openai-key
+export ANTHROPIC_API_KEY=your-anthropic-key
+export AZURE_OPENAI_API_KEY=your-azure-key
+export GEMINI_API_KEY=your-gemini-key
+
+# Model settings
+export TARKO_MODEL_PROVIDER=openai
+export TARKO_MODEL_ID=gpt-4
+export TARKO_MODEL_BASE_URL=https://api.openai.com/v1
+export TARKO_MODEL_TEMPERATURE=0.7
+export TARKO_MODEL_MAX_TOKENS=4000
+```
+
+### Server Configuration
+
+```bash
+# Server settings
+export TARKO_PORT=3000
+export TARKO_HOST=0.0.0.0
+export TARKO_CORS=true
+
+# Workspace
+export TARKO_WORKSPACE=./my-workspace
+
+# UI settings
+export TARKO_UI_ENABLED=true
+export TARKO_UI_TITLE="My Agent"
+export TARKO_UI_THEME=default
+export TARKO_UI_AUTO_OPEN=false
+```
+
+### Debug and Logging
+
+```bash
+# Debug settings
+export DEBUG=tarko:*
+export TARKO_LOG_LEVEL=debug
+export TARKO_LOG_FORMAT=json
+
+# Metrics
+export TARKO_METRICS_ENABLED=true
+export TARKO_METRICS_ENDPOINT=/metrics
+```
+
+## Configuration Sections
+
+### Model Configuration
+
+```typescript
+model: {
+  provider: 'openai' | 'anthropic' | 'azure' | 'ollama' | 'gemini',
+  id: string,              // Model ID (e.g., 'gpt-4', 'claude-3-opus')
+  apiKey?: string,          // API key (use env vars for security)
+  baseURL?: string,         // Custom API endpoint
+  temperature?: number,     // Creativity (0-1)
+  maxTokens?: number,       // Maximum response tokens
+  topP?: number,            // Nucleus sampling
+  frequencyPenalty?: number,// Frequency penalty
+  presencePenalty?: number, // Presence penalty
+  timeout?: number,         // Request timeout (ms)
+  retries?: number,         // Retry attempts
+}
+```
+
+### Server Configuration
+
+```typescript
+server: {
+  port?: number,            // Server port (default: 3000)
+  host?: string,            // Server host (default: 'localhost')
+  cors?: boolean,           // Enable CORS (default: true)
+  rateLimit?: {             // Rate limiting
+    windowMs: number,       // Time window (ms)
+    max: number,            // Max requests per window
+  },
+  ssl?: {                   // SSL configuration
+    enabled: boolean,
+    cert: string,           // Certificate path
+    key: string,            // Private key path
+  },
+}
+```
+
+### Tool Filtering
+
+```typescript
+tool: {
+  include?: string[],       // Tool patterns to include
+  exclude?: string[],       // Tool patterns to exclude
+}
+
+// Examples:
+// include: ['file_*', 'web_*'] - Include all file and web tools
+// exclude: ['dangerous_*'] - Exclude dangerous tools
+// include: ['file_read', 'file_write'] - Include specific tools
+```
+
+### MCP Server Filtering
+
+```typescript
+mcpServer: {
+  include?: string[],       // MCP server patterns to include
+  exclude?: string[],       // MCP server patterns to exclude
+}
+
+// Examples:
+// include: ['filesystem', 'browser'] - Include specific servers
+// exclude: ['experimental_*'] - Exclude experimental servers
+```
+
+### UI Configuration
+
+```typescript
+ui: {
+  enabled?: boolean,        // Enable Web UI (default: true)
+  title?: string,           // UI title
+  theme?: 'default' | 'dark' | 'light',
+  autoOpen?: boolean,       // Auto-open browser (default: false)
+  customization?: {
+    logo?: string,          // Custom logo path
+    primaryColor?: string,  // Primary color hex
+    layout?: 'sidebar' | 'topbar',
+  },
+}
+```
+
+### Logging Configuration
+
+```typescript
+logging: {
+  level?: 'debug' | 'info' | 'warn' | 'error',
+  format?: 'json' | 'text',
+  output?: {
+    console?: boolean,      // Log to console
+    file?: {
+      enabled: boolean,
+      path: string,         // Log file path
+      maxSize: string,      // Max file size (e.g., '10m')
+      maxFiles: number,     // Max number of files
+    },
+    syslog?: {              // Syslog configuration
+      enabled: boolean,
+      host: string,
+      port: number,
+      facility: string,
+    },
+  },
+}
+```
+
+### Metrics Configuration
+
+```typescript
+metrics: {
+  enabled?: boolean,        // Enable metrics collection
+  endpoint?: string,        // Metrics endpoint (default: '/metrics')
+  collectors?: {
+    requests?: boolean,     // HTTP request metrics
+    responses?: boolean,    // HTTP response metrics
+    toolCalls?: boolean,    // Tool call metrics
+    errors?: boolean,       // Error metrics
+    memory?: boolean,       // Memory usage metrics
+    cpu?: boolean,          // CPU usage metrics
+  },
+}
+```
+
+## Advanced Configuration
+
+### Remote Configuration
+
+Load configuration from a remote URL:
+
+```bash
+tarko --config https://example.com/agent-config.json
+```
+
+### Environment-Specific Configurations
+
+```typescript
+// tarko.config.ts
+import { AgentAppConfig } from '@tarko/interface';
+
+const baseConfig: AgentAppConfig = {
+  model: {
+    provider: 'openai',
+    id: 'gpt-4',
+  },
+};
+
+const developmentConfig: AgentAppConfig = {
+  ...baseConfig,
+  server: { port: 3000 },
+  logging: { level: 'debug' },
+  ui: { autoOpen: true },
+};
+
+const productionConfig: AgentAppConfig = {
+  ...baseConfig,
+  server: { port: 8080, host: '0.0.0.0' },
+  logging: { level: 'info', format: 'json' },
+  ui: { enabled: false },
+  metrics: { enabled: true },
+};
+
+const config = process.env.NODE_ENV === 'production' 
+  ? productionConfig 
+  : developmentConfig;
+
+export default config;
+```
+
+### Workspace Configuration
+
+Workspace-specific configuration in `.tarko/config.ts`:
+
+```typescript
+// .tarko/config.ts
+import { AgentAppConfig } from '@tarko/interface';
+
+const config: AgentAppConfig = {
+  // Workspace-specific settings
+  workspace: '.',
+  tool: {
+    include: ['file_*'], // Only file tools for this workspace
+  },
+};
+
+export default config;
+```
+
+## Configuration Validation
+
+Tarko CLI validates configuration at startup:
+
+```bash
+# Validate configuration without running
+tarko --dry-run --show-config
+
+# Show resolved configuration
+tarko --show-config
+
+# Debug configuration resolution
+tarko --debug --show-config
+```
+
+## Configuration Examples
+
+### Development Setup
+
+```typescript
+// tarko.config.ts
+export default {
+  model: {
+    provider: 'openai',
+    id: 'gpt-4',
+    apiKey: process.env.OPENAI_API_KEY,
+  },
+  server: { port: 3000 },
+  ui: { autoOpen: true },
+  logging: { level: 'debug' },
+};
+```
+
+### Production Setup
+
+```typescript
+// tarko.config.ts
+export default {
+  model: {
+    provider: 'openai',
+    id: 'gpt-4',
+    apiKey: process.env.OPENAI_API_KEY,
+  },
+  server: {
+    port: 8080,
+    host: '0.0.0.0',
+    cors: true,
+    rateLimit: {
+      windowMs: 15 * 60 * 1000,
+      max: 100,
+    },
+  },
+  ui: { enabled: false },
+  logging: {
+    level: 'info',
+    format: 'json',
+    output: {
+      console: false,
+      file: {
+        enabled: true,
+        path: './logs/agent.log',
+        maxSize: '100m',
+        maxFiles: 10,
+      },
+    },
+  },
+  metrics: { enabled: true },
+};
+```
+
+### Security-Focused Setup
+
+```typescript
+// tarko.config.ts
+export default {
+  model: {
+    provider: 'openai',
+    id: 'gpt-4',
+    apiKey: process.env.OPENAI_API_KEY,
+  },
+  tool: {
+    exclude: ['dangerous_*', 'system_*', 'network_*'],
+  },
+  mcpServer: {
+    include: ['filesystem'], // Only allow filesystem access
+  },
+  server: {
+    cors: false,
+    rateLimit: {
+      windowMs: 15 * 60 * 1000,
+      max: 50, // Strict rate limiting
+    },
+  },
+  logging: {
+    level: 'info',
+    format: 'json',
+  },
+};
+```

--- a/multimodal/websites/tarko/docs/en/guide/cli/configuration.mdx
+++ b/multimodal/websites/tarko/docs/en/guide/cli/configuration.mdx
@@ -5,95 +5,59 @@ description: Complete guide to configuring Tarko CLI
 
 # CLI Configuration
 
-Tarko CLI supports multiple configuration formats and sources with a clear priority system.
+Tarko CLI 支持多种配置格式，优先级从高到低：CLI 参数 > 配置文件 > 环境变量。
 
-## Configuration Files
+## 配置文件
 
-Tarko CLI automatically discovers configuration files in the following order:
+自动发现配置文件顺序：
 
 1. `tarko.config.ts` (TypeScript)
-2. `tarko.config.yaml` (YAML)
+2. `tarko.config.yaml` (YAML) 
 3. `tarko.config.json` (JSON)
 
-### TypeScript Configuration
+### TypeScript 配置
 
 ```typescript
 // tarko.config.ts
 import { AgentAppConfig } from '@tarko/interface';
 
 const config: AgentAppConfig = {
-  // Model configuration
+  // Model 配置
   model: {
     provider: 'openai',
     id: 'gpt-4',
     apiKey: process.env.OPENAI_API_KEY,
-    baseURL: 'https://api.openai.com/v1',
     temperature: 0.7,
-    maxTokens: 4000,
   },
   
-  // Workspace settings
-  workspace: './workspace',
-  
-  // Server configuration
+  // 服务器配置
   server: {
     port: 8888,
-    host: '0.0.0.0',
-    cors: true,
+    exclusive: false, // 独占模式
   },
   
-  // Tool filtering
+  // Tool 过滤
   tool: {
     include: ['file_*', 'web_*'],
     exclude: ['dangerous_*'],
   },
   
-  // MCP Server filtering
+  // MCP Server 过滤
   mcpServer: {
     include: ['filesystem', 'browser'],
     exclude: ['experimental_*'],
   },
   
-  // UI configuration
-  ui: {
-    enabled: true,
-    title: 'My Agent',
-    theme: 'default',
-    autoOpen: false,
-  },
-  
-  // Logging configuration
-  logging: {
-    level: 'info',
-    format: 'json',
-    output: {
-      console: true,
-      file: {
-        enabled: true,
-        path: './logs/agent.log',
-        maxSize: '10m',
-        maxFiles: 5,
-      },
-    },
-  },
-  
-  // Metrics configuration
-  metrics: {
-    enabled: true,
-    endpoint: '/metrics',
-    collectors: {
-      requests: true,
-      responses: true,
-      toolCalls: true,
-      errors: true,
-    },
+  // 分享配置
+  share: {
+    provider: 'https://share.example.com',
   },
 };
 
 export default config;
 ```
 
-### YAML Configuration
+### YAML 配置
 
 ```yaml
 # tarko.config.yaml
@@ -101,16 +65,11 @@ model:
   provider: openai
   id: gpt-4
   apiKey: ${OPENAI_API_KEY}
-  baseURL: https://api.openai.com/v1
   temperature: 0.7
-  maxTokens: 4000
-
-workspace: ./workspace
 
 server:
   port: 8888
-  host: 0.0.0.0
-  cors: true
+  exclusive: false
 
 tool:
   include:
@@ -126,34 +85,11 @@ mcpServer:
   exclude:
     - 'experimental_*'
 
-ui:
-  enabled: true
-  title: My Agent
-  theme: default
-  autoOpen: false
-
-logging:
-  level: info
-  format: json
-  output:
-    console: true
-    file:
-      enabled: true
-      path: ./logs/agent.log
-      maxSize: 10m
-      maxFiles: 5
-
-metrics:
-  enabled: true
-  endpoint: /metrics
-  collectors:
-    requests: true
-    responses: true
-    toolCalls: true
-    errors: true
+share:
+  provider: https://share.example.com
 ```
 
-### JSON Configuration
+### JSON 配置
 
 ```json
 {
@@ -161,15 +97,11 @@ metrics:
     "provider": "openai",
     "id": "gpt-4",
     "apiKey": "${OPENAI_API_KEY}",
-    "baseURL": "https://api.openai.com/v1",
-    "temperature": 0.7,
-    "maxTokens": 4000
+    "temperature": 0.7
   },
-  "workspace": "./workspace",
   "server": {
     "port": 8888,
-    "host": "0.0.0.0",
-    "cors": true
+    "exclusive": false
   },
   "tool": {
     "include": ["file_*", "web_*"],
@@ -179,321 +111,104 @@ metrics:
     "include": ["filesystem", "browser"],
     "exclude": ["experimental_*"]
   },
-  "ui": {
-    "enabled": true,
-    "title": "My Agent",
-    "theme": "default",
-    "autoOpen": false
-  },
-  "logging": {
-    "level": "info",
-    "format": "json",
-    "output": {
-      "console": true,
-      "file": {
-        "enabled": true,
-        "path": "./logs/agent.log",
-        "maxSize": "10m",
-        "maxFiles": 5
-      }
-    }
-  },
-  "metrics": {
-    "enabled": true,
-    "endpoint": "/metrics",
-    "collectors": {
-      "requests": true,
-      "responses": true,
-      "toolCalls": true,
-      "errors": true
-    }
+  "share": {
+    "provider": "https://share.example.com"
   }
 }
 ```
 
-## Configuration Priority
+## 配置优先级
 
-Configuration is resolved in the following priority order (highest to lowest):
+配置解析优先级（从高到低）：
 
-1. **CLI arguments** (highest priority)
-2. **Workspace configuration**
-3. **User configuration file** (`--config`)
-4. **Remote configuration URL**
-5. **Default configuration** (lowest priority)
+1. **CLI 参数**（最高优先级）
+2. **工作区配置**
+3. **用户配置文件**（`--config`）
+4. **默认配置**（最低优先级）
 
-### CLI Arguments Override
+### CLI 参数覆盖
 
 ```bash
-# Override model configuration
+# 覆盖 Model 配置
 tarko --model.provider openai --model.id gpt-4 --model.apiKey sk-xxx
 
-# Override server settings
-tarko serve --port 3000 --host 0.0.0.0
+# 覆盖服务器设置
+tarko serve --port 3000
 
-# Override workspace
+# 覆盖工作区
 tarko --workspace ./custom-workspace
 
-# Override tool filtering
+# 覆盖 Tool 过滤
 tarko --tool.include "file_*,web_*" --tool.exclude "dangerous_*"
 ```
 
-## Environment Variables
-
-Environment variables provide an alternative to configuration files:
-
-### Model Configuration
+## 环境变量
 
 ```bash
 # API Keys
 export OPENAI_API_KEY=your-openai-key
 export ANTHROPIC_API_KEY=your-anthropic-key
 export AZURE_OPENAI_API_KEY=your-azure-key
-export GEMINI_API_KEY=your-gemini-key
 
-# Model settings
-export TARKO_MODEL_PROVIDER=openai
-export TARKO_MODEL_ID=gpt-4
-export TARKO_MODEL_BASE_URL=https://api.openai.com/v1
-export TARKO_MODEL_TEMPERATURE=0.7
-export TARKO_MODEL_MAX_TOKENS=4000
-```
-
-### Server Configuration
-
-```bash
-# Server settings
+# 服务器设置
 export TARKO_PORT=3000
-export TARKO_HOST=0.0.0.0
-export TARKO_CORS=true
-
-# Workspace
 export TARKO_WORKSPACE=./my-workspace
 
-# UI settings
-export TARKO_UI_ENABLED=true
-export TARKO_UI_TITLE="My Agent"
-export TARKO_UI_THEME=default
-export TARKO_UI_AUTO_OPEN=false
-```
-
-### Debug and Logging
-
-```bash
-# Debug settings
+# 调试设置
 export DEBUG=tarko:*
-export TARKO_LOG_LEVEL=debug
-export TARKO_LOG_FORMAT=json
-
-# Metrics
-export TARKO_METRICS_ENABLED=true
-export TARKO_METRICS_ENDPOINT=/metrics
 ```
 
-## Configuration Sections
+## 主要配置选项
 
-### Model Configuration
+### Model 配置
 
 ```typescript
 model: {
-  provider: 'openai' | 'anthropic' | 'azure' | 'ollama' | 'gemini',
-  id: string,              // Model ID (e.g., 'gpt-4', 'claude-3-opus')
-  apiKey?: string,          // API key (use env vars for security)
-  baseURL?: string,         // Custom API endpoint
-  temperature?: number,     // Creativity (0-1)
-  maxTokens?: number,       // Maximum response tokens
-  topP?: number,            // Nucleus sampling
-  frequencyPenalty?: number,// Frequency penalty
-  presencePenalty?: number, // Presence penalty
-  timeout?: number,         // Request timeout (ms)
-  retries?: number,         // Retry attempts
+  provider: 'openai' | 'anthropic' | 'azure' | 'ollama',
+  id: string,              // Model ID (如 'gpt-4')
+  apiKey?: string,         // API key (建议使用环境变量)
+  temperature?: number,    // 创造性 (0-1)
 }
 ```
 
-### Server Configuration
+### Server 配置
 
 ```typescript
 server: {
-  port?: number,            // Server port (default: 3000)
-  host?: string,            // Server host (default: 'localhost')
-  cors?: boolean,           // Enable CORS (default: true)
-  rateLimit?: {             // Rate limiting
-    windowMs: number,       // Time window (ms)
-    max: number,            // Max requests per window
-  },
-  ssl?: {                   // SSL configuration
-    enabled: boolean,
-    cert: string,           // Certificate path
-    key: string,            // Private key path
-  },
+  port?: number,           // 服务器端口 (默认: 8888)
+  exclusive?: boolean,     // 独占模式 (默认: false)
 }
 ```
 
-### Tool Filtering
+### Tool 过滤
 
 ```typescript
 tool: {
-  include?: string[],       // Tool patterns to include
-  exclude?: string[],       // Tool patterns to exclude
+  include?: string[],      // 包含的 Tool 模式
+  exclude?: string[],      // 排除的 Tool 模式
 }
 
-// Examples:
-// include: ['file_*', 'web_*'] - Include all file and web tools
-// exclude: ['dangerous_*'] - Exclude dangerous tools
-// include: ['file_read', 'file_write'] - Include specific tools
+// 示例:
+// include: ['file_*', 'web_*'] - 包含所有文件和网络工具
+// exclude: ['dangerous_*'] - 排除危险工具
 ```
 
-### MCP Server Filtering
+### MCP Server 过滤
 
 ```typescript
 mcpServer: {
-  include?: string[],       // MCP server patterns to include
-  exclude?: string[],       // MCP server patterns to exclude
+  include?: string[],      // 包含的 MCP server 模式
+  exclude?: string[],      // 排除的 MCP server 模式
 }
 
-// Examples:
-// include: ['filesystem', 'browser'] - Include specific servers
-// exclude: ['experimental_*'] - Exclude experimental servers
+// 示例:
+// include: ['filesystem', 'browser'] - 包含特定服务器
+// exclude: ['experimental_*'] - 排除实验性服务器
 ```
 
-### UI Configuration
+## 配置示例
 
-```typescript
-ui: {
-  enabled?: boolean,        // Enable Web UI (default: true)
-  title?: string,           // UI title
-  theme?: 'default' | 'dark' | 'light',
-  autoOpen?: boolean,       // Auto-open browser (default: false)
-  customization?: {
-    logo?: string,          // Custom logo path
-    primaryColor?: string,  // Primary color hex
-    layout?: 'sidebar' | 'topbar',
-  },
-}
-```
-
-### Logging Configuration
-
-```typescript
-logging: {
-  level?: 'debug' | 'info' | 'warn' | 'error',
-  format?: 'json' | 'text',
-  output?: {
-    console?: boolean,      // Log to console
-    file?: {
-      enabled: boolean,
-      path: string,         // Log file path
-      maxSize: string,      // Max file size (e.g., '10m')
-      maxFiles: number,     // Max number of files
-    },
-    syslog?: {              // Syslog configuration
-      enabled: boolean,
-      host: string,
-      port: number,
-      facility: string,
-    },
-  },
-}
-```
-
-### Metrics Configuration
-
-```typescript
-metrics: {
-  enabled?: boolean,        // Enable metrics collection
-  endpoint?: string,        // Metrics endpoint (default: '/metrics')
-  collectors?: {
-    requests?: boolean,     // HTTP request metrics
-    responses?: boolean,    // HTTP response metrics
-    toolCalls?: boolean,    // Tool call metrics
-    errors?: boolean,       // Error metrics
-    memory?: boolean,       // Memory usage metrics
-    cpu?: boolean,          // CPU usage metrics
-  },
-}
-```
-
-## Advanced Configuration
-
-### Remote Configuration
-
-Load configuration from a remote URL:
-
-```bash
-tarko --config https://example.com/agent-config.json
-```
-
-### Environment-Specific Configurations
-
-```typescript
-// tarko.config.ts
-import { AgentAppConfig } from '@tarko/interface';
-
-const baseConfig: AgentAppConfig = {
-  model: {
-    provider: 'openai',
-    id: 'gpt-4',
-  },
-};
-
-const developmentConfig: AgentAppConfig = {
-  ...baseConfig,
-  server: { port: 3000 },
-  logging: { level: 'debug' },
-  ui: { autoOpen: true },
-};
-
-const productionConfig: AgentAppConfig = {
-  ...baseConfig,
-  server: { port: 8080, host: '0.0.0.0' },
-  logging: { level: 'info', format: 'json' },
-  ui: { enabled: false },
-  metrics: { enabled: true },
-};
-
-const config = process.env.NODE_ENV === 'production' 
-  ? productionConfig 
-  : developmentConfig;
-
-export default config;
-```
-
-### Workspace Configuration
-
-Workspace-specific configuration in `.tarko/config.ts`:
-
-```typescript
-// .tarko/config.ts
-import { AgentAppConfig } from '@tarko/interface';
-
-const config: AgentAppConfig = {
-  // Workspace-specific settings
-  workspace: '.',
-  tool: {
-    include: ['file_*'], // Only file tools for this workspace
-  },
-};
-
-export default config;
-```
-
-## Configuration Validation
-
-Tarko CLI validates configuration at startup:
-
-```bash
-# Validate configuration without running
-tarko --dry-run --show-config
-
-# Show resolved configuration
-tarko --show-config
-
-# Debug configuration resolution
-tarko --debug --show-config
-```
-
-## Configuration Examples
-
-### Development Setup
+### 开发环境
 
 ```typescript
 // tarko.config.ts
@@ -504,12 +219,10 @@ export default {
     apiKey: process.env.OPENAI_API_KEY,
   },
   server: { port: 3000 },
-  ui: { autoOpen: true },
-  logging: { level: 'debug' },
 };
 ```
 
-### Production Setup
+### 生产环境
 
 ```typescript
 // tarko.config.ts
@@ -521,57 +234,10 @@ export default {
   },
   server: {
     port: 8080,
-    host: '0.0.0.0',
-    cors: true,
-    rateLimit: {
-      windowMs: 15 * 60 * 1000,
-      max: 100,
-    },
-  },
-  ui: { enabled: false },
-  logging: {
-    level: 'info',
-    format: 'json',
-    output: {
-      console: false,
-      file: {
-        enabled: true,
-        path: './logs/agent.log',
-        maxSize: '100m',
-        maxFiles: 10,
-      },
-    },
-  },
-  metrics: { enabled: true },
-};
-```
-
-### Security-Focused Setup
-
-```typescript
-// tarko.config.ts
-export default {
-  model: {
-    provider: 'openai',
-    id: 'gpt-4',
-    apiKey: process.env.OPENAI_API_KEY,
+    exclusive: true,
   },
   tool: {
-    exclude: ['dangerous_*', 'system_*', 'network_*'],
-  },
-  mcpServer: {
-    include: ['filesystem'], // Only allow filesystem access
-  },
-  server: {
-    cors: false,
-    rateLimit: {
-      windowMs: 15 * 60 * 1000,
-      max: 50, // Strict rate limiting
-    },
-  },
-  logging: {
-    level: 'info',
-    format: 'json',
+    exclude: ['dangerous_*'],
   },
 };
 ```

--- a/multimodal/websites/tarko/docs/en/guide/cli/overview.mdx
+++ b/multimodal/websites/tarko/docs/en/guide/cli/overview.mdx
@@ -80,19 +80,16 @@ tarko --tool.include "file_*,web_*" --tool.exclude "dangerous_*"
 tarko --mcpServer.include "filesystem" --mcpServer.exclude "experimental_*"
 ```
 
-### Console Interception
+### 调试支持
 
-Capture and process console output during execution:
+通过 `--debug` 参数启用详细日志：
 
-```typescript
-import { ConsoleInterceptor } from '@tarko/agent-cli';
+```bash
+# 启用调试模式
+tarko run --debug
 
-const { result, logs } = await ConsoleInterceptor.run(
-  async () => {
-    return await agent.run('input');
-  },
-  { silent: true, capture: true }
-);
+# 使用环境变量
+DEBUG=tarko:* tarko run
 ```
 
 ## Use Cases

--- a/multimodal/websites/tarko/docs/en/guide/cli/overview.mdx
+++ b/multimodal/websites/tarko/docs/en/guide/cli/overview.mdx
@@ -1,0 +1,144 @@
+---
+title: CLI Overview
+description: Introduction to Tarko Agent CLI
+---
+
+# CLI Overview
+
+The **Tarko Agent CLI** is a flexible framework built on top of the **Agent Kernel** ([`@tarko/agent`](https://www.npmjs.com/package/@tarko/agent)). It provides a comprehensive command-line interface for deploying and running agents with ease, featuring built-in Web UI and powerful extensibility.
+
+## Installation
+
+Install globally via npm:
+
+```bash
+npm install -g @tarko/agent-cli
+```
+
+Or use with npx for one-time execution:
+
+```bash
+npx @tarko/agent-cli run my-agent
+```
+
+## Quick Start
+
+```bash
+# Start interactive Web UI (default)
+tarko
+
+# Run with built-in agents
+tarko run agent-tars  # Agent TARS
+tarko run omni-tars   # Omni-TARS
+tarko run mcp-agent   # MCP Agent
+
+# Run with custom agent
+tarko run ./my-agent.js
+
+# Start headless API server
+tarko serve
+
+# Headless mode with direct input
+tarko run --headless --input "Analyze current directory structure"
+
+# Pipeline input
+echo "Summarize this code" | tarko run --headless
+```
+
+## Core Concepts
+
+### Deployment Modes
+
+- **Interactive Mode** (`tarko run`) - Web UI for development and testing
+- **Server Mode** (`tarko serve`) - Headless API server for production
+- **Scripting Mode** (`tarko run --headless`) - Silent execution for automation
+
+### Built-in Agents
+
+Tarko CLI includes several ready-to-use agents:
+
+- **`agent-tars`** - Advanced task automation and reasoning system
+- **`omni-tars`** - Multi-modal agent with comprehensive capabilities
+- **`mcp-agent`** - Model Context Protocol agent for tool integration
+
+### Configuration Flexibility
+
+Supports multiple configuration formats with auto-discovery:
+- `tarko.config.ts` - TypeScript configuration
+- `tarko.config.yaml` - YAML configuration
+- `tarko.config.json` - JSON configuration
+- Environment variables and CLI arguments
+
+## Key Features
+
+### Event-Driven Architecture
+
+Built on event-driven architecture for monitoring agent execution:
+
+```typescript
+const eventStream = agent.getEventStream();
+eventStream.subscribe((event) => {
+  console.log('Event:', event.type, event);
+});
+```
+
+### Tool & MCP Server Filtering
+
+Filter available tools and MCP servers via configuration:
+
+```bash
+tarko --tool.include "file_*,web_*" --tool.exclude "dangerous_*"
+tarko --mcpServer.include "filesystem" --mcpServer.exclude "experimental_*"
+```
+
+### Console Interception
+
+Capture and process console output during execution:
+
+```typescript
+import { ConsoleInterceptor } from '@tarko/agent-cli';
+
+const { result, logs } = await ConsoleInterceptor.run(
+  async () => {
+    return await agent.run('input');
+  },
+  { silent: true, capture: true }
+);
+```
+
+## Use Cases
+
+### Development
+- Interactive agent development with Web UI
+- Real-time debugging and testing
+- Hot reload and development mode
+
+### Production
+- Headless API server deployment
+- Docker and Kubernetes integration
+- Load balancing and scaling
+
+### Automation
+- CI/CD pipeline integration
+- Batch processing and scripting
+- Silent execution with structured output
+
+### Testing
+- Direct LLM requests for debugging
+- Agent behavior validation
+- Performance testing and benchmarking
+
+## Next Steps
+
+- [Commands Reference](/guide/cli/commands) - Detailed command documentation
+- [Configuration Guide](/guide/cli/configuration) - Advanced configuration options
+- [Built-in Agents](/guide/cli/built-in-agents) - Using pre-built agents
+- [Deployment Guide](/guide/deployment/cli) - Production deployment strategies
+
+## API Reference
+
+For detailed TypeScript definitions:
+
+- [`@tarko/agent-interface`](https://www.npmjs.com/package/@tarko/agent-interface) - Core agent interfaces
+- [`@tarko/interface`](https://www.npmjs.com/package/@tarko/interface) - Application layer interfaces
+- [`@tarko/agent-cli`](https://www.npmjs.com/package/@tarko/agent-cli) - CLI framework interfaces

--- a/multimodal/websites/tarko/docs/en/guide/cli/overview.mdx
+++ b/multimodal/websites/tarko/docs/en/guide/cli/overview.mdx
@@ -71,17 +71,6 @@ Supports multiple configuration formats with auto-discovery:
 
 ## Key Features
 
-### Event-Driven Architecture
-
-Built on event-driven architecture for monitoring agent execution:
-
-```typescript
-const eventStream = agent.getEventStream();
-eventStream.subscribe((event) => {
-  console.log('Event:', event.type, event);
-});
-```
-
 ### Tool & MCP Server Filtering
 
 Filter available tools and MCP servers via configuration:

--- a/multimodal/websites/tarko/docs/en/guide/deployment/cli.mdx
+++ b/multimodal/websites/tarko/docs/en/guide/deployment/cli.mdx
@@ -1,313 +1,441 @@
 ---
 title: CLI Deployment
-description: Deploy Tarko Agents using the CLI
+description: Production deployment strategies using Tarko CLI
 ---
 
 # CLI Deployment
 
-The **Tarko Agent CLI** provides a simple way to deploy and run Tarko-based Agents in various environments. Use `tarko run [agent]` to create headless or headful Agent runtime environments.
+This guide covers production deployment strategies using the Tarko CLI. For complete CLI reference and commands, see the [CLI Guide](/guide/cli/overview).
 
-## Installation
+## Overview
 
-Install the Tarko CLI globally:
+Tarko CLI provides multiple deployment modes optimized for different environments:
 
-```bash
-npm install -g @tarko/agent-cli
-```
+- **Production Server** (`tarko serve`) - Headless API server for production
+- **Development** (`tarko run`) - Interactive UI for development and testing
+- **Automation** (`tarko run --headless`) - Scripting and CI/CD integration
 
-Or use with npx:
+For detailed command reference, see [CLI Commands](/guide/cli/commands).
 
-```bash
-npx @tarko/agent-cli run my-agent
-```
+## Production Server Deployment
 
-## Basic Usage
+### Basic Server Setup
 
-### Run an Agent
+Deploy a headless API server for production use:
 
 ```bash
-# Run agent in current directory
-tarko run
+# Start production server
+tarko serve --port 8080 --host 0.0.0.0
 
-# Run specific agent
-tarko run ./my-agent
+# With specific agent
+tarko serve agent-tars --port 8080
 
-# Run with custom configuration
-tarko run --config ./custom-config.json
+# With production configuration
+tarko serve --config production.config.ts --port 8080
 ```
 
-### Development Mode
+The server exposes REST and WebSocket APIs at:
+- `GET /api/v1/health` - Health check
+- `POST /api/v1/chat` - Chat endpoint
+- `GET /api/v1/events` - Event stream (WebSocket)
 
-```bash
-# Run in development mode with hot reload
-tarko run --dev
+### Production Configuration
 
-# Run with debug logging
-tarko run --debug
+Create a production-optimized configuration:
 
-# Run with specific port
-tarko run --port 3001
-```
+```typescript
+// production.config.ts
+import { AgentAppConfig } from '@tarko/interface';
 
-## Configuration
-
-### CLI Configuration File
-
-Create a `tarko.config.js` file:
-
-```javascript
-module.exports = {
-  name: 'MyAgent',
-  description: 'A helpful assistant',
-  
-  // Runtime configuration
-  runtime: {
-    port: 3000,
-    host: '0.0.0.0',
-    mode: 'production' // or 'development'
-  },
-  
-  // Model configuration
+const config: AgentAppConfig = {
   model: {
     provider: 'openai',
+    id: 'gpt-4',
     apiKey: process.env.OPENAI_API_KEY,
-    model: 'gpt-4'
   },
   
-  // Tools
-  tools: [
-    '@tarko/tools/file-system',
-    '@tarko/tools/browser',
-    './custom-tools/weather'
-  ],
-  
-  // UI configuration
-  ui: {
-    enabled: true,
-    theme: 'default',
-    title: 'My Agent'
-  }
-};
-```
-
-### Environment Variables
-
-```bash
-# Model configuration
-export TARKO_MODEL_PROVIDER=openai
-export TARKO_MODEL_API_KEY=your-api-key
-export TARKO_MODEL_NAME=gpt-4
-
-# Runtime configuration
-export TARKO_PORT=3000
-export TARKO_HOST=0.0.0.0
-export TARKO_MODE=production
-
-# UI configuration
-export TARKO_UI_ENABLED=true
-export TARKO_UI_THEME=default
-```
-
-## Deployment Modes
-
-### Headless Mode
-
-Run without UI for API-only access:
-
-```bash
-tarko run --headless
-```
-
-Configuration:
-
-```javascript
-module.exports = {
-  runtime: {
-    mode: 'headless',
-    api: {
-      enabled: true,
-      cors: true,
-      rateLimit: {
-        windowMs: 15 * 60 * 1000, // 15 minutes
-        max: 100 // limit each IP to 100 requests per windowMs
-      }
-    }
+  server: {
+    port: 8080,
+    host: '0.0.0.0',
+    cors: true,
+    rateLimit: {
+      windowMs: 15 * 60 * 1000, // 15 minutes
+      max: 100, // requests per window
+    },
   },
+  
   ui: {
-    enabled: false
-  }
-};
-```
-
-### Headful Mode
-
-Run with web UI:
-
-```bash
-tarko run --ui
-```
-
-Configuration:
-
-```javascript
-module.exports = {
-  ui: {
+    enabled: false, // Disable UI for production
+  },
+  
+  logging: {
+    level: 'info',
+    format: 'json',
+    output: {
+      console: false,
+      file: {
+        enabled: true,
+        path: './logs/agent.log',
+        maxSize: '100m',
+        maxFiles: 10,
+      },
+    },
+  },
+  
+  metrics: {
     enabled: true,
-    title: 'My Agent',
-    theme: 'default',
-    customization: {
-      logo: './assets/logo.png',
-      primaryColor: '#007bff',
-      layout: 'sidebar' // or 'topbar'
-    }
-  }
+    endpoint: '/metrics',
+  },
 };
+
+export default config;
 ```
 
-## Production Deployment
+For complete configuration options, see [CLI Configuration](/guide/cli/configuration).
+
+## Container Deployment
 
 ### Docker
 
-Create a `Dockerfile`:
+Create a production Docker image:
 
 ```dockerfile
+# Dockerfile
 FROM node:18-alpine
 
 WORKDIR /app
 
-# Copy package files
+# Install dependencies
 COPY package*.json ./
 RUN npm ci --only=production
 
-# Copy agent code
+# Copy application code
 COPY . .
 
-# Install Tarko CLI
+# Install Tarko CLI globally
 RUN npm install -g @tarko/agent-cli
 
-EXPOSE 3000
+# Create non-root user
+RUN addgroup -g 1001 -S tarko && \
+    adduser -S tarko -u 1001
+USER tarko
 
-CMD ["tarko", "run", "--port", "3000", "--host", "0.0.0.0"]
+# Expose port
+EXPOSE 8080
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+  CMD curl -f http://localhost:8080/api/v1/health || exit 1
+
+# Start server
+CMD ["tarko", "serve", "--port", "8080", "--host", "0.0.0.0"]
 ```
 
 Build and run:
 
 ```bash
-docker build -t my-agent .
-docker run -p 3000:3000 -e OPENAI_API_KEY=your-key my-agent
+# Build image
+docker build -t my-agent:latest .
+
+# Run container
+docker run -d \
+  --name my-agent \
+  -p 8080:8080 \
+  -e OPENAI_API_KEY=${OPENAI_API_KEY} \
+  -v $(pwd)/logs:/app/logs \
+  --restart unless-stopped \
+  my-agent:latest
+
+# Check health
+docker exec my-agent curl -f http://localhost:8080/api/v1/health
 ```
 
 ### Docker Compose
 
+For multi-service deployments:
+
 ```yaml
+# docker-compose.yml
 version: '3.8'
 
 services:
   agent:
     build: .
     ports:
-      - "3000:3000"
+      - "8080:8080"
     environment:
-      - TARKO_MODEL_PROVIDER=openai
-      - TARKO_MODEL_API_KEY=${OPENAI_API_KEY}
-      - TARKO_MODEL_NAME=gpt-4
-      - TARKO_MODE=production
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - NODE_ENV=production
     volumes:
-      - ./data:/app/data
+      - ./workspace:/app/workspace
+      - ./logs:/app/logs
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/api/v1/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    depends_on:
+      - redis
 
   redis:
-    image: redis:alpine
+    image: redis:7-alpine
     ports:
       - "6379:6379"
     volumes:
       - redis_data:/data
+    restart: unless-stopped
+    command: redis-server --appendonly yes
+
+  nginx:
+    image: nginx:alpine
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./ssl:/etc/nginx/ssl:ro
+    depends_on:
+      - agent
     restart: unless-stopped
 
 volumes:
   redis_data:
 ```
 
-### Process Manager (PM2)
+Deploy the stack:
+
+```bash
+# Start services
+docker-compose up -d
+
+# View logs
+docker-compose logs -f agent
+
+# Scale agents
+docker-compose up -d --scale agent=3
+
+# Health check
+curl -f http://localhost:8080/api/v1/health
+```
+
+## Kubernetes Deployment
+
+### Basic Deployment
+
+```yaml
+# k8s/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tarko-agent
+  labels:
+    app: tarko-agent
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: tarko-agent
+  template:
+    metadata:
+      labels:
+        app: tarko-agent
+    spec:
+      containers:
+      - name: agent
+        image: my-agent:latest
+        ports:
+        - containerPort: 8080
+        env:
+        - name: OPENAI_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: api-secrets
+              key: openai-key
+        - name: NODE_ENV
+          value: "production"
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "250m"
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+        livenessProbe:
+          httpGet:
+            path: /api/v1/health
+            port: 8080
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /api/v1/health
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        volumeMounts:
+        - name: workspace
+          mountPath: /app/workspace
+        - name: logs
+          mountPath: /app/logs
+      volumes:
+      - name: workspace
+        persistentVolumeClaim:
+          claimName: agent-workspace
+      - name: logs
+        persistentVolumeClaim:
+          claimName: agent-logs
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tarko-agent-service
+spec:
+  selector:
+    app: tarko-agent
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 8080
+  type: ClusterIP
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: tarko-agent-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+  - host: agent.example.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: tarko-agent-service
+            port:
+              number: 80
+```
+
+Deploy to Kubernetes:
+
+```bash
+# Create secrets
+kubectl create secret generic api-secrets \
+  --from-literal=openai-key=${OPENAI_API_KEY}
+
+# Apply manifests
+kubectl apply -f k8s/
+
+# Check deployment
+kubectl get pods -l app=tarko-agent
+kubectl logs -l app=tarko-agent
+
+# Port forward for testing
+kubectl port-forward svc/tarko-agent-service 8080:80
+```
+
+## Process Management
+
+### PM2
+
+For traditional server deployments:
 
 ```javascript
 // ecosystem.config.js
 module.exports = {
   apps: [{
-    name: 'my-agent',
+    name: 'tarko-agent',
     script: 'tarko',
-    args: 'run --port 3000',
-    instances: 1,
+    args: 'serve --port 8080 --config production.config.ts',
+    instances: 'max', // Use all CPU cores
+    exec_mode: 'cluster',
     autorestart: true,
     watch: false,
     max_memory_restart: '1G',
     env: {
       NODE_ENV: 'production',
-      TARKO_MODEL_PROVIDER: 'openai',
-      TARKO_MODEL_API_KEY: process.env.OPENAI_API_KEY
-    }
+      OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+    },
+    error_file: './logs/err.log',
+    out_file: './logs/out.log',
+    log_file: './logs/combined.log',
+    time: true,
   }]
 };
 ```
 
-Deploy:
+Deploy with PM2:
 
 ```bash
+# Install PM2
 npm install -g pm2
+
+# Start application
 pm2 start ecosystem.config.js
+
+# Save PM2 configuration
 pm2 save
+
+# Setup startup script
 pm2 startup
+sudo env PATH=$PATH:/usr/bin pm2 startup systemd -u $USER --hp $HOME
+
+# Monitor
+pm2 monit
+pm2 logs tarko-agent
+
+# Restart
+pm2 restart tarko-agent
+
+# Stop
+pm2 stop tarko-agent
 ```
 
-## Monitoring and Logging
+### Systemd Service
 
-### Health Checks
+Create a systemd service:
+
+```ini
+# /etc/systemd/system/tarko-agent.service
+[Unit]
+Description=Tarko Agent Server
+After=network.target
+
+[Service]
+Type=simple
+User=tarko
+WorkingDirectory=/opt/tarko-agent
+Environment=NODE_ENV=production
+Environment=OPENAI_API_KEY=your-api-key
+ExecStart=/usr/bin/tarko serve --port 8080 --config production.config.ts
+Restart=always
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Manage the service:
 
 ```bash
-# Check agent status
-curl http://localhost:3000/health
+# Enable and start
+sudo systemctl enable tarko-agent
+sudo systemctl start tarko-agent
 
-# Check detailed status
-curl http://localhost:3000/status
-```
+# Check status
+sudo systemctl status tarko-agent
 
-### Logging Configuration
+# View logs
+sudo journalctl -u tarko-agent -f
 
-```javascript
-module.exports = {
-  logging: {
-    level: 'info', // debug, info, warn, error
-    format: 'json', // json, text
-    output: {
-      console: true,
-      file: {
-        enabled: true,
-        path: './logs/agent.log',
-        maxSize: '10m',
-        maxFiles: 5
-      }
-    }
-  }
-};
-```
-
-### Metrics
-
-Enable metrics collection:
-
-```javascript
-module.exports = {
-  metrics: {
-    enabled: true,
-    endpoint: '/metrics',
-    collectors: {
-      requests: true,
-      responses: true,
-      toolCalls: true,
-      errors: true
-    }
-  }
-};
+# Restart
+sudo systemctl restart tarko-agent
 ```
 
 ## Load Balancing
@@ -315,15 +443,36 @@ module.exports = {
 ### Nginx Configuration
 
 ```nginx
+# nginx.conf
 upstream tarko_agents {
-    server localhost:3000;
-    server localhost:3001;
-    server localhost:3002;
+    least_conn;
+    server localhost:8080 max_fails=3 fail_timeout=30s;
+    server localhost:8081 max_fails=3 fail_timeout=30s;
+    server localhost:8082 max_fails=3 fail_timeout=30s;
 }
 
 server {
     listen 80;
-    server_name my-agent.example.com;
+    server_name agent.example.com;
+    
+    # Redirect HTTP to HTTPS
+    return 301 https://$server_name$request_uri;
+}
+
+server {
+    listen 443 ssl http2;
+    server_name agent.example.com;
+    
+    # SSL configuration
+    ssl_certificate /etc/nginx/ssl/cert.pem;
+    ssl_certificate_key /etc/nginx/ssl/key.pem;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers HIGH:!aNULL:!MD5;
+    
+    # Security headers
+    add_header X-Frame-Options DENY;
+    add_header X-Content-Type-Options nosniff;
+    add_header X-XSS-Protection "1; mode=block";
     
     location / {
         proxy_pass http://tarko_agents;
@@ -335,7 +484,204 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_cache_bypass $http_upgrade;
+        proxy_read_timeout 86400;
+        
+        # Rate limiting
+        limit_req zone=api burst=20 nodelay;
     }
+    
+    # Health check endpoint
+    location /health {
+        access_log off;
+        proxy_pass http://tarko_agents/api/v1/health;
+    }
+    
+    # Metrics endpoint (restrict access)
+    location /metrics {
+        allow 10.0.0.0/8;
+        deny all;
+        proxy_pass http://tarko_agents/metrics;
+    }
+}
+
+# Rate limiting
+http {
+    limit_req_zone $binary_remote_addr zone=api:10m rate=10r/s;
+}
+```
+
+## Monitoring and Observability
+
+### Health Checks
+
+```bash
+# Basic health check
+curl -f http://localhost:8080/api/v1/health
+
+# Detailed status
+curl http://localhost:8080/api/v1/status
+
+# Metrics (Prometheus format)
+curl http://localhost:8080/metrics
+```
+
+### Logging
+
+Configure structured logging for production:
+
+```typescript
+// In production.config.ts
+logging: {
+  level: 'info',
+  format: 'json',
+  output: {
+    console: false,
+    file: {
+      enabled: true,
+      path: './logs/agent.log',
+      maxSize: '100m',
+      maxFiles: 10,
+    },
+  },
+}
+```
+
+Log aggregation with ELK stack or similar:
+
+```yaml
+# docker-compose.override.yml
+version: '3.8'
+services:
+  agent:
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+        labels: "service=tarko-agent"
+```
+
+### Metrics and Alerting
+
+Enable Prometheus metrics:
+
+```typescript
+// In production.config.ts
+metrics: {
+  enabled: true,
+  endpoint: '/metrics',
+  collectors: {
+    requests: true,
+    responses: true,
+    toolCalls: true,
+    errors: true,
+    memory: true,
+    cpu: true,
+  },
+}
+```
+
+## CI/CD Integration
+
+### GitHub Actions
+
+```yaml
+# .github/workflows/deploy.yml
+name: Deploy Agent
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Setup Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: '18'
+        cache: 'npm'
+    
+    - name: Install dependencies
+      run: npm ci
+    
+    - name: Install Tarko CLI
+      run: npm install -g @tarko/agent-cli
+    
+    - name: Test agent
+      run: |
+        tarko run --headless --input "Health check" --format json
+      env:
+        OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+    
+    - name: Build Docker image
+      run: |
+        docker build -t my-agent:${{ github.sha }} .
+        docker tag my-agent:${{ github.sha }} my-agent:latest
+    
+    - name: Deploy to production
+      run: |
+        # Deploy to your infrastructure
+        echo "Deploying to production..."
+```
+
+### Deployment Scripts
+
+```bash
+#!/bin/bash
+# deploy.sh
+
+set -e
+
+echo "Deploying Tarko Agent..."
+
+# Build and push image
+docker build -t my-agent:latest .
+docker push my-agent:latest
+
+# Update Kubernetes deployment
+kubectl set image deployment/tarko-agent agent=my-agent:latest
+kubectl rollout status deployment/tarko-agent
+
+# Verify deployment
+kubectl get pods -l app=tarko-agent
+echo "Deployment complete!"
+```
+
+## Security Considerations
+
+### Environment Variables
+
+```bash
+# Use secure environment variable management
+export OPENAI_API_KEY=$(cat /run/secrets/openai_key)
+export ANTHROPIC_API_KEY=$(cat /run/secrets/anthropic_key)
+
+# Or use container secrets
+docker run -d \
+  --secret openai_key \
+  --secret anthropic_key \
+  my-agent:latest
+```
+
+### Network Security
+
+```typescript
+// Restrict tool access in production
+tool: {
+  exclude: ['dangerous_*', 'system_*', 'network_*'],
+},
+
+// Enable CORS only for trusted domains
+server: {
+  cors: {
+    origin: ['https://trusted-domain.com'],
+    credentials: true,
+  },
 }
 ```
 
@@ -343,42 +689,49 @@ server {
 
 ### Common Issues
 
-**Port already in use:**
+**Port conflicts:**
 ```bash
-# Find process using port
-lsof -i :3000
+# Check port usage
+lsof -i :8080
 
-# Kill process
-kill -9 <PID>
-
-# Or use different port
-tarko run --port 3001
-```
-
-**Permission errors:**
-```bash
-# Run with sudo (not recommended)
-sudo tarko run
-
-# Or change port to non-privileged
-tarko run --port 8080
+# Use different port
+tarko serve --port 8081
 ```
 
 **Memory issues:**
 ```bash
-# Increase Node.js memory limit
-NODE_OPTIONS="--max-old-space-size=4096" tarko run
+# Increase Node.js memory
+NODE_OPTIONS="--max-old-space-size=4096" tarko serve
+
+# Monitor memory usage
+top -p $(pgrep -f "tarko serve")
+```
+
+**Configuration errors:**
+```bash
+# Validate configuration
+tarko --show-config --dry-run
+
+# Debug configuration loading
+DEBUG=tarko:config tarko serve --debug
 ```
 
 ### Debug Mode
 
 ```bash
 # Enable debug logging
-DEBUG=tarko:* tarko run --debug
+DEBUG=tarko:* tarko serve --debug
 
-# Enable Node.js inspector
-tarko run --inspect
+# Monitor with verbose output
+tarko serve --debug --verbose
 
-# Enable verbose output
-tarko run --verbose
+# Performance profiling
+NODE_OPTIONS="--inspect" tarko serve
 ```
+
+## Next Steps
+
+- [CLI Overview](/guide/cli/overview) - Complete CLI reference
+- [CLI Configuration](/guide/cli/configuration) - Advanced configuration
+- [Built-in Agents](/guide/cli/built-in-agents) - Using pre-built agents
+- [Server API](/guide/deployment/server) - Server API reference

--- a/multimodal/websites/tarko/docs/zh/guide/_meta.json
+++ b/multimodal/websites/tarko/docs/zh/guide/_meta.json
@@ -15,6 +15,13 @@
   },
   {
     "type": "dir",
+    "name": "cli",
+    "label": "CLI",
+    "collapsible": false,
+    "collapsed": false
+  },
+  {
+    "type": "dir",
     "name": "tool",
     "label": "工具",
     "collapsible": false,

--- a/multimodal/websites/tarko/docs/zh/guide/cli/_meta.json
+++ b/multimodal/websites/tarko/docs/zh/guide/cli/_meta.json
@@ -1,21 +1,21 @@
 [
   {
-    "type": "page",
+    "type": "file",
     "name": "overview",
     "label": "概述"
   },
   {
-    "type": "page",
+    "type": "file",
     "name": "commands",
     "label": "命令"
   },
   {
-    "type": "page",
+    "type": "file",
     "name": "configuration",
     "label": "配置"
   },
   {
-    "type": "page",
+    "type": "file",
     "name": "built-in-agents",
     "label": "内置 Agent"
   }

--- a/multimodal/websites/tarko/docs/zh/guide/cli/_meta.json
+++ b/multimodal/websites/tarko/docs/zh/guide/cli/_meta.json
@@ -1,0 +1,22 @@
+[
+  {
+    "type": "page",
+    "name": "overview",
+    "label": "概述"
+  },
+  {
+    "type": "page",
+    "name": "commands",
+    "label": "命令"
+  },
+  {
+    "type": "page",
+    "name": "configuration",
+    "label": "配置"
+  },
+  {
+    "type": "page",
+    "name": "built-in-agents",
+    "label": "内置 Agent"
+  }
+]

--- a/multimodal/websites/tarko/docs/zh/guide/cli/built-in-agents.mdx
+++ b/multimodal/websites/tarko/docs/zh/guide/cli/built-in-agents.mdx
@@ -1,0 +1,364 @@
+---
+title: 内置 Agent
+description: 使用 Tarko CLI 包含的预构建 Agent
+---
+
+# 内置 Agent
+
+Tarko CLI 包含几个即用型 Agent，展示了不同的能力和使用场景。这些 Agent 无需任何额外设置即可立即使用。
+
+## 可用 Agent
+
+### `agent-tars`
+
+**Agent TARS** - 高级任务自动化和推理系统，专为复杂问题解决和多步骤工作流而设计。
+
+#### 能力
+- 高级推理和规划
+- 多步骤任务执行
+- 上下文感知决策
+- 工具编排
+- 错误处理和恢复
+
+#### 使用场景
+- 复杂自动化任务
+- 多步骤工作流
+- 问题解决场景
+- 研究和分析
+- 代码生成和调试
+
+#### 用法
+
+```bash
+# 交互模式带 Web UI
+tarko run agent-tars
+
+# 无头服务器部署
+tarko serve agent-tars --port 8080
+
+# 脚本模式
+tarko run agent-tars --headless --input "分析这个代码库并提出改进建议"
+
+# 使用自定义配置
+tarko run agent-tars --config ./tars-config.ts
+```
+
+#### 示例任务
+
+```bash
+# 代码分析和改进
+tarko run agent-tars --headless --input "审查 ./src 中的代码并提供优化建议"
+
+# 项目设置自动化
+tarko run agent-tars --headless --input "使用最佳实践设置一个新的 React TypeScript 项目"
+
+# 文档生成
+tarko run agent-tars --headless --input "为这个 API 生成全面的文档"
+
+# 测试策略
+tarko run agent-tars --headless --input "为这个应用程序创建测试策略"
+```
+
+### `omni-tars`
+
+**Omni-TARS** - 多模态 Agent，具有处理文本、图像、文件和网络交互的综合能力。
+
+#### 能力
+- 多模态输入处理（文本、图像、文档）
+- 网络浏览和抓取
+- 文件系统操作
+- 图像分析和生成
+- 文档处理
+- API 集成
+
+#### 使用场景
+- 内容创建和编辑
+- 网络研究和数据收集
+- 文档分析和处理
+- 图像分析和操作
+- 多模态工作流
+
+#### 用法
+
+```bash
+# 交互模式带 Web UI
+tarko run omni-tars
+
+# 无头服务器部署
+tarko serve omni-tars --port 8080
+
+# 带文件输入的脚本模式
+tarko run omni-tars --headless --input "分析 ./assets 中的图像并创建摘要"
+
+# 网络研究模式
+tarko run omni-tars --headless --input "研究 AI 的最新趋势并创建报告"
+```
+
+#### 示例任务
+
+```bash
+# 图像分析
+tarko run omni-tars --headless --input "分析 ./image.png 中的截图并描述你看到的内容"
+
+# 网络研究
+tarko run omni-tars --headless --input "研究量子计算的最新发展"
+
+# 文档处理
+tarko run omni-tars --headless --input "总结 ./reports/ 中的 PDF 文档"
+
+# 内容创建
+tarko run omni-tars --headless --input "基于最近的新闻创建一篇关于可持续技术的博客文章"
+```
+
+### `mcp-agent`
+
+**MCP Agent** - 专门用于工具集成和外部服务连接的模型上下文协议 Agent。
+
+#### 能力
+- MCP 服务器管理
+- 工具发现和集成
+- 外部服务连接
+- 协议处理
+- 资源管理
+
+#### 使用场景
+- 工具集成测试
+- MCP 服务器开发
+- 外部 API 集成
+- 服务编排
+- 协议调试
+
+#### 用法
+
+```bash
+# 用于工具探索的交互模式
+tarko run mcp-agent
+
+# 列出可用工具和服务器
+tarko run mcp-agent --headless --input "列出所有可用工具及其能力"
+
+# 测试 MCP 服务器连接
+tarko run mcp-agent --headless --input "测试所有配置的 MCP 服务器的连接"
+
+# 工具集成工作流
+tarko serve mcp-agent --port 8080
+```
+
+#### 示例任务
+
+```bash
+# 工具发现
+tarko run mcp-agent --headless --input "发现并列出所有可用工具"
+
+# MCP 服务器状态
+tarko run mcp-agent --headless --input "检查所有 MCP 服务器的状态"
+
+# 工具测试
+tarko run mcp-agent --headless --input "使用简单的读取操作测试文件系统工具"
+
+# 集成工作流
+tarko run mcp-agent --headless --input "演示使用多个工具的工作流"
+```
+
+## Agent 比较
+
+| 功能 | agent-tars | omni-tars | mcp-agent |
+|------|------------|-----------|----------|
+| **主要焦点** | 推理和自动化 | 多模态处理 | 工具集成 |
+| **复杂性** | 高 | 中高 | 中 |
+| **使用场景** | 复杂工作流 | 内容和研究 | 工具开发 |
+| **多模态** | 有限 | 完全支持 | 有限 |
+| **网络浏览** | 是 | 是 | 有限 |
+| **文件操作** | 是 | 是 | 是 |
+| **工具集成** | 高级 | 标准 | 专业化 |
+| **MCP 支持** | 是 | 是 | 主要焦点 |
+
+## 配置
+
+### Agent 特定配置
+
+每个内置 Agent 都可以使用特定设置进行配置：
+
+```typescript
+// tarko.config.ts
+import { AgentAppConfig } from '@tarko/interface';
+
+const config: AgentAppConfig = {
+  // Agent 特定配置
+  agent: {
+    type: 'agent-tars', // 或 'omni-tars', 'mcp-agent'
+    config: {
+      // Agent 特定设置
+      maxSteps: 10,
+      timeoutMs: 30000,
+      retryAttempts: 3,
+    },
+  },
+  
+  // Agent 的模型配置
+  model: {
+    provider: 'openai',
+    id: 'gpt-4',
+    temperature: 0.7,
+  },
+  
+  // 特定 Agent 的工具过滤
+  tool: {
+    include: ['file_*', 'web_*'], // 自定义可用工具
+  },
+};
+
+export default config;
+```
+
+### 环境特定 Agent
+
+```bash
+# 使用 agent-tars 进行开发
+NODE_ENV=development tarko run agent-tars --debug
+
+# 使用 omni-tars 进行生产部署
+NODE_ENV=production tarko serve omni-tars --port 8080
+
+# 使用 mcp-agent 进行测试
+tarko run mcp-agent --headless --input "运行诊断"
+```
+
+## 自定义 Agent 开发
+
+虽然内置 Agent 提供了即时功能，但你也可以创建自定义 Agent：
+
+### 创建自定义 Agent
+
+```typescript
+// my-custom-agent.ts
+import { Agent } from '@tarko/agent';
+import { AgentOptions } from '@tarko/interface';
+
+class MyCustomAgent extends Agent {
+  constructor(options: AgentOptions) {
+    super({
+      ...options,
+      name: 'MyCustomAgent',
+      description: '用于特定任务的自定义 Agent',
+    });
+  }
+  
+  async processInput(input: string): Promise<string> {
+    // 自定义 Agent 逻辑
+    return `已处理：${input}`;
+  }
+}
+
+export default MyCustomAgent;
+```
+
+### 使用自定义 Agent
+
+```bash
+# 运行自定义 Agent
+tarko run ./my-custom-agent.ts
+
+# 部署自定义 Agent
+tarko serve ./my-custom-agent.ts --port 8080
+
+# 测试自定义 Agent
+tarko run ./my-custom-agent.ts --headless --input "测试输入"
+```
+
+## Agent 选择指南
+
+### 选择 `agent-tars` 当：
+- 需要复杂推理和规划
+- 处理多步骤工作流
+- 需要高级问题解决能力
+- 构建自动化系统
+- 需要复杂的错误处理
+
+### 选择 `omni-tars` 当：
+- 处理多种内容类型（文本、图像、文档）
+- 需要网络浏览和研究能力
+- 处理多媒体内容
+- 跨不同格式创建内容
+- 需要全面的工具访问
+
+### 选择 `mcp-agent` 当：
+- 开发或测试 MCP 服务器
+- 集成外部工具和服务
+- 调试协议实现
+- 构建以工具为中心的工作流
+- 需要专业的 MCP 功能
+
+## 性能考虑
+
+### 资源使用
+
+| Agent | 内存使用 | CPU 使用 | 网络使用 |
+|-------|----------|----------|----------|
+| agent-tars | 高 | 高 | 中 |
+| omni-tars | 中高 | 中 | 高 |
+| mcp-agent | 中 | 低中 | 低 |
+
+### 优化技巧
+
+```bash
+# 优化内存使用
+NODE_OPTIONS="--max-old-space-size=2048" tarko run agent-tars
+
+# 限制并发操作
+tarko run omni-tars --config ./optimized-config.ts
+
+# 使用缓存以获得更好的性能
+tarko run mcp-agent --cache-enabled
+```
+
+## 故障排除
+
+### 常见问题
+
+**找不到 Agent：**
+```bash
+# 验证 Agent 名称
+tarko run agent-tars --dry-run
+
+# 列出可用 Agent
+tarko --help
+```
+
+**性能问题：**
+```bash
+# 启用调试模式
+tarko run omni-tars --debug
+
+# 监控资源使用
+tarko run agent-tars --metrics-enabled
+```
+
+**工具访问问题：**
+```bash
+# 检查工具配置
+tarko run mcp-agent --show-config
+
+# 测试工具连接
+tarko run mcp-agent --headless --input "测试工具"
+```
+
+### 调试模式
+
+```bash
+# 调试 Agent 执行
+DEBUG=tarko:agent:* tarko run agent-tars --debug
+
+# 详细日志
+tarko run omni-tars --debug --verbose
+
+# 性能分析
+tarko run mcp-agent --debug --profile
+```
+
+## 下一步
+
+- [CLI 命令](/guide/cli/commands) - 学习所有可用的 CLI 命令
+- [配置](/guide/cli/configuration) - 高级配置选项
+- [部署](/guide/deployment/cli) - 生产部署策略
+- [Tool 集成](/guide/basic/tool-call-engine) - 为你的 Agent 添加自定义工具

--- a/multimodal/websites/tarko/docs/zh/guide/cli/built-in-agents.mdx
+++ b/multimodal/websites/tarko/docs/zh/guide/cli/built-in-agents.mdx
@@ -5,360 +5,129 @@ description: 使用 Tarko CLI 包含的预构建 Agent
 
 # 内置 Agent
 
-Tarko CLI 包含几个即用型 Agent，展示了不同的能力和使用场景。这些 Agent 无需任何额外设置即可立即使用。
+Tarko CLI 包含三个内置 Agent，可以直接使用。
 
-## 可用 Agent
+## 可用的 Agent
 
 ### `agent-tars`
 
-**Agent TARS** - 高级任务自动化和推理系统，专为复杂问题解决和多步骤工作流而设计。
-
-#### 能力
-- 高级推理和规划
-- 多步骤任务执行
-- 上下文感知决策
-- 工具编排
-- 错误处理和恢复
-
-#### 使用场景
-- 复杂自动化任务
-- 多步骤工作流
-- 问题解决场景
-- 研究和分析
-- 代码生成和调试
-
-#### 用法
+高级任务自动化和推理系统。
 
 ```bash
-# 交互模式带 Web UI
+# 启动 Web UI
 tarko run agent-tars
 
-# 无头服务器部署
-tarko serve agent-tars --port 8080
+# 无头模式
+tarko run agent-tars --headless --input "分析当前目录结构"
 
-# 脚本模式
-tarko run agent-tars --headless --input "分析这个代码库并提出改进建议"
-
-# 使用自定义配置
-tarko run agent-tars --config ./tars-config.ts
-```
-
-#### 示例任务
-
-```bash
-# 代码分析和改进
-tarko run agent-tars --headless --input "审查 ./src 中的代码并提供优化建议"
-
-# 项目设置自动化
-tarko run agent-tars --headless --input "使用最佳实践设置一个新的 React TypeScript 项目"
-
-# 文档生成
-tarko run agent-tars --headless --input "为这个 API 生成全面的文档"
-
-# 测试策略
-tarko run agent-tars --headless --input "为这个应用程序创建测试策略"
+# 服务器模式
+tarko serve agent-tars
 ```
 
 ### `omni-tars`
 
-**Omni-TARS** - 多模态 Agent，具有处理文本、图像、文件和网络交互的综合能力。
-
-#### 能力
-- 多模态输入处理（文本、图像、文档）
-- 网络浏览和抓取
-- 文件系统操作
-- 图像分析和生成
-- 文档处理
-- API 集成
-
-#### 使用场景
-- 内容创建和编辑
-- 网络研究和数据收集
-- 文档分析和处理
-- 图像分析和操作
-- 多模态工作流
-
-#### 用法
+多模态 Agent，支持文本、图像、文件处理。
 
 ```bash
-# 交互模式带 Web UI
+# 启动 Web UI
 tarko run omni-tars
 
-# 无头服务器部署
-tarko serve omni-tars --port 8080
+# 无头模式
+tarko run omni-tars --headless --input "分析这个图片"
 
-# 带文件输入的脚本模式
-tarko run omni-tars --headless --input "分析 ./assets 中的图像并创建摘要"
-
-# 网络研究模式
-tarko run omni-tars --headless --input "研究 AI 的最新趋势并创建报告"
-```
-
-#### 示例任务
-
-```bash
-# 图像分析
-tarko run omni-tars --headless --input "分析 ./image.png 中的截图并描述你看到的内容"
-
-# 网络研究
-tarko run omni-tars --headless --input "研究量子计算的最新发展"
-
-# 文档处理
-tarko run omni-tars --headless --input "总结 ./reports/ 中的 PDF 文档"
-
-# 内容创建
-tarko run omni-tars --headless --input "基于最近的新闻创建一篇关于可持续技术的博客文章"
+# 服务器模式
+tarko serve omni-tars
 ```
 
 ### `mcp-agent`
 
-**MCP Agent** - 专门用于工具集成和外部服务连接的模型上下文协议 Agent。
-
-#### 能力
-- MCP 服务器管理
-- 工具发现和集成
-- 外部服务连接
-- 协议处理
-- 资源管理
-
-#### 使用场景
-- 工具集成测试
-- MCP 服务器开发
-- 外部 API 集成
-- 服务编排
-- 协议调试
-
-#### 用法
+**Model Context Protocol** Agent，专门用于 Tool 集成。
 
 ```bash
-# 用于工具探索的交互模式
+# 启动 Web UI
 tarko run mcp-agent
 
-# 列出可用工具和服务器
-tarko run mcp-agent --headless --input "列出所有可用工具及其能力"
+# 无头模式
+tarko run mcp-agent --headless --input "列出所有可用工具"
 
-# 测试 MCP 服务器连接
-tarko run mcp-agent --headless --input "测试所有配置的 MCP 服务器的连接"
-
-# 工具集成工作流
-tarko serve mcp-agent --port 8080
+# 服务器模式
+tarko serve mcp-agent
 ```
 
-#### 示例任务
+## 使用自定义 Agent
 
-```bash
-# 工具发现
-tarko run mcp-agent --headless --input "发现并列出所有可用工具"
-
-# MCP 服务器状态
-tarko run mcp-agent --headless --input "检查所有 MCP 服务器的状态"
-
-# 工具测试
-tarko run mcp-agent --headless --input "使用简单的读取操作测试文件系统工具"
-
-# 集成工作流
-tarko run mcp-agent --headless --input "演示使用多个工具的工作流"
-```
-
-## Agent 比较
-
-| 功能 | agent-tars | omni-tars | mcp-agent |
-|------|------------|-----------|----------|
-| **主要焦点** | 推理和自动化 | 多模态处理 | 工具集成 |
-| **复杂性** | 高 | 中高 | 中 |
-| **使用场景** | 复杂工作流 | 内容和研究 | 工具开发 |
-| **多模态** | 有限 | 完全支持 | 有限 |
-| **网络浏览** | 是 | 是 | 有限 |
-| **文件操作** | 是 | 是 | 是 |
-| **工具集成** | 高级 | 标准 | 专业化 |
-| **MCP 支持** | 是 | 是 | 主要焦点 |
-
-## 配置
-
-### Agent 特定配置
-
-每个内置 Agent 都可以使用特定设置进行配置：
+除了内置 Agent，你也可以创建自定义 Agent：
 
 ```typescript
-// tarko.config.ts
+// my-agent.ts
+import { Agent } from '@tarko/agent';
+
+class MyAgent extends Agent {
+  constructor(options = {}) {
+    super({
+      ...options,
+      name: 'MyAgent',
+      instructions: '你是一个专门的助手...'
+    });
+  }
+}
+
+export default MyAgent;
+```
+
+使用自定义 Agent：
+
+```bash
+# 运行自定义 Agent
+tarko run ./my-agent.ts
+
+# 部署自定义 Agent
+tarko serve ./my-agent.ts
+```
+
+## Agent 架构
+
+```mermaid
+graph TD
+    A[CLI Input] --> B[Agent Selection]
+    B --> C{Agent Type}
+    
+    C -->|agent-tars| D[Advanced Reasoning]
+    C -->|omni-tars| E[Multi-modal Processing]
+    C -->|mcp-agent| F[Tool Integration]
+    C -->|custom| G[Custom Logic]
+    
+    D --> H[Tool Manager]
+    E --> H
+    F --> H
+    G --> H
+    
+    H --> I[LLM Provider]
+    I --> J[Response]
+```
+
+## 配置 Agent
+
+在 `tarko.config.ts` 中配置默认 Agent：
+
+```typescript
 import { AgentAppConfig } from '@tarko/interface';
 
 const config: AgentAppConfig = {
-  // Agent 特定配置
-  agent: {
-    type: 'agent-tars', // 或 'omni-tars', 'mcp-agent'
-    config: {
-      // Agent 特定设置
-      maxSteps: 10,
-      timeoutMs: 30000,
-      retryAttempts: 3,
-    },
-  },
-  
-  // Agent 的模型配置
   model: {
     provider: 'openai',
-    id: 'gpt-4',
-    temperature: 0.7,
+    id: 'gpt-4'
   },
-  
-  // 特定 Agent 的工具过滤
   tool: {
-    include: ['file_*', 'web_*'], // 自定义可用工具
-  },
+    include: ['file_*', 'web_*']
+  }
 };
 
 export default config;
 ```
 
-### 环境特定 Agent
-
-```bash
-# 使用 agent-tars 进行开发
-NODE_ENV=development tarko run agent-tars --debug
-
-# 使用 omni-tars 进行生产部署
-NODE_ENV=production tarko serve omni-tars --port 8080
-
-# 使用 mcp-agent 进行测试
-tarko run mcp-agent --headless --input "运行诊断"
-```
-
-## 自定义 Agent 开发
-
-虽然内置 Agent 提供了即时功能，但你也可以创建自定义 Agent：
-
-### 创建自定义 Agent
-
-```typescript
-// my-custom-agent.ts
-import { Agent } from '@tarko/agent';
-import { AgentOptions } from '@tarko/interface';
-
-class MyCustomAgent extends Agent {
-  constructor(options: AgentOptions) {
-    super({
-      ...options,
-      name: 'MyCustomAgent',
-      description: '用于特定任务的自定义 Agent',
-    });
-  }
-  
-  async processInput(input: string): Promise<string> {
-    // 自定义 Agent 逻辑
-    return `已处理：${input}`;
-  }
-}
-
-export default MyCustomAgent;
-```
-
-### 使用自定义 Agent
-
-```bash
-# 运行自定义 Agent
-tarko run ./my-custom-agent.ts
-
-# 部署自定义 Agent
-tarko serve ./my-custom-agent.ts --port 8080
-
-# 测试自定义 Agent
-tarko run ./my-custom-agent.ts --headless --input "测试输入"
-```
-
-## Agent 选择指南
-
-### 选择 `agent-tars` 当：
-- 需要复杂推理和规划
-- 处理多步骤工作流
-- 需要高级问题解决能力
-- 构建自动化系统
-- 需要复杂的错误处理
-
-### 选择 `omni-tars` 当：
-- 处理多种内容类型（文本、图像、文档）
-- 需要网络浏览和研究能力
-- 处理多媒体内容
-- 跨不同格式创建内容
-- 需要全面的工具访问
-
-### 选择 `mcp-agent` 当：
-- 开发或测试 MCP 服务器
-- 集成外部工具和服务
-- 调试协议实现
-- 构建以工具为中心的工作流
-- 需要专业的 MCP 功能
-
-## 性能考虑
-
-### 资源使用
-
-| Agent | 内存使用 | CPU 使用 | 网络使用 |
-|-------|----------|----------|----------|
-| agent-tars | 高 | 高 | 中 |
-| omni-tars | 中高 | 中 | 高 |
-| mcp-agent | 中 | 低中 | 低 |
-
-### 优化技巧
-
-```bash
-# 优化内存使用
-NODE_OPTIONS="--max-old-space-size=2048" tarko run agent-tars
-
-# 限制并发操作
-tarko run omni-tars --config ./optimized-config.ts
-
-# 使用缓存以获得更好的性能
-tarko run mcp-agent --cache-enabled
-```
-
-## 故障排除
-
-### 常见问题
-
-**找不到 Agent：**
-```bash
-# 验证 Agent 名称
-tarko run agent-tars --dry-run
-
-# 列出可用 Agent
-tarko --help
-```
-
-**性能问题：**
-```bash
-# 启用调试模式
-tarko run omni-tars --debug
-
-# 监控资源使用
-tarko run agent-tars --metrics-enabled
-```
-
-**工具访问问题：**
-```bash
-# 检查工具配置
-tarko run mcp-agent --show-config
-
-# 测试工具连接
-tarko run mcp-agent --headless --input "测试工具"
-```
-
-### 调试模式
-
-```bash
-# 调试 Agent 执行
-DEBUG=tarko:agent:* tarko run agent-tars --debug
-
-# 详细日志
-tarko run omni-tars --debug --verbose
-
-# 性能分析
-tarko run mcp-agent --debug --profile
-```
-
 ## 下一步
 
-- [CLI 命令](/guide/cli/commands) - 学习所有可用的 CLI 命令
-- [配置](/guide/cli/configuration) - 高级配置选项
-- [部署](/guide/deployment/cli) - 生产部署策略
-- [Tool 集成](/guide/basic/tool-call-engine) - 为你的 Agent 添加自定义工具
+- [CLI Commands](/guide/cli/commands) - 完整命令参考
+- [Configuration](/guide/cli/configuration) - 配置选项
+- [Tool Integration](/guide/basic/tool-call-engine) - 添加自定义 Tool

--- a/multimodal/websites/tarko/docs/zh/guide/cli/commands.mdx
+++ b/multimodal/websites/tarko/docs/zh/guide/cli/commands.mdx
@@ -1,0 +1,353 @@
+---
+title: CLI 命令
+description: 所有 Tarko CLI 命令的完整参考
+---
+
+# CLI 命令
+
+所有 Tarko Agent CLI 命令及其选项的完整参考。
+
+## `tarko` / `tarko run`
+
+启动**交互式 Web UI** 进行实时对话和文件浏览。
+
+### 基本用法
+
+```bash
+# 启动交互式 Web UI（默认）
+tarko
+
+# 等效的显式命令
+tarko run
+
+# 运行特定 Agent
+tarko run ./my-agent.js
+
+# 运行内置 Agent
+tarko run agent-tars
+tarko run omni-tars
+tarko run mcp-agent
+```
+
+### 选项
+
+```bash
+# 自定义端口并自动打开浏览器
+tarko run --port 8888 --open
+
+# 开发模式带热重载
+tarko run --dev
+
+# 调试模式带详细日志
+tarko run --debug
+
+# 自定义配置文件
+tarko run --config ./custom-config.ts
+
+# 自定义工作区
+tarko run --workspace ./my-workspace
+```
+
+### 无头模式
+
+**静默模式**执行，输出到 stdout，非常适合脚本使用：
+
+```bash
+# 直接输入，文本输出（默认）
+tarko run --headless --input "分析当前目录结构"
+
+# 管道输入
+echo "总结这段代码" | tarko run --headless
+
+# JSON 输出用于程序化使用
+tarko run --headless --input "分析文件" --format json
+
+# 在输出中包含调试日志
+tarko run --headless --input "分析文件" --include-logs
+
+# 禁用缓存进行全新执行
+tarko run --headless --input "分析文件" --use-cache false
+
+# 与内置 Agent 结合使用
+tarko run agent-tars --headless --input "列出目录内容"
+```
+
+#### 无头模式选项
+
+| 选项 | 描述 | 默认值 |
+|------|------|--------|
+| `--input <text>` | 直接输入文本 | - |
+| `--format <type>` | 输出格式：`text`、`json` | `text` |
+| `--include-logs` | 在输出中包含调试日志 | `false` |
+| `--use-cache <bool>` | 启用/禁用缓存 | `true` |
+
+## `tarko serve`
+
+启动**无头 API 服务器**用于系统集成和生产部署。
+
+### 基本用法
+
+```bash
+# 启动无头服务器
+tarko serve
+
+# 使用特定 Agent 启动服务器
+tarko serve ./my-agent
+
+# 使用内置 Agent 启动服务器
+tarko serve omni-tars
+
+# 自定义端口和配置
+tarko serve --port 8888 --config ./production.config.ts
+```
+
+### 选项
+
+```bash
+# 自定义端口（默认：3000）
+tarko serve --port 8888
+
+# 自定义主机（默认：localhost）
+tarko serve --host 0.0.0.0
+
+# 调试模式
+tarko serve --debug
+
+# 自定义配置
+tarko serve --config ./server.config.yaml
+
+# 自定义工作区
+tarko serve --workspace ./server-workspace
+```
+
+### API 端点
+
+运行 `tarko serve` 时，以下端点可用：
+
+- `GET /api/v1/health` - 健康检查
+- `GET /api/v1/status` - 详细状态
+- `POST /api/v1/chat` - 与 Agent 聊天
+- `GET /api/v1/events` - 事件流（WebSocket）
+- `GET /metrics` - Prometheus 指标（如果启用）
+
+## `tarko request`
+
+直接**LLM 请求**用于调试和测试目的。
+
+### 基本用法
+
+```bash
+# 基本请求
+tarko request --provider openai --model gpt-4 --body '{"messages":[{"role":"user","content":"你好"}]}'
+
+# 从文件加载请求
+tarko request --provider openai --model gpt-4 --body ./request.json
+```
+
+### 高级选项
+
+```bash
+# 自定义 API 配置
+tarko request --provider openai --model gpt-4 \
+  --apiKey sk-xxx \
+  --baseURL https://api.openai.com/v1 \
+  --body request.json
+
+# 流式模式
+tarko request --provider openai --model gpt-4 --body request.json --stream
+
+# 推理模式（支持的模型如 o1）
+tarko request --provider openai --model o1-preview --body request.json --thinking
+
+# 语义输出格式
+tarko request --provider openai --model gpt-4 --body request.json --format semantic
+```
+
+### 支持的提供商
+
+- `openai` - OpenAI GPT 模型
+- `anthropic` - Anthropic Claude 模型
+- `azure` - Azure OpenAI 服务
+- `ollama` - 本地 Ollama 模型
+- `gemini` - Google Gemini 模型
+
+### 请求体格式
+
+```json
+{
+  "messages": [
+    {"role": "system", "content": "你是一个有用的助手。"},
+    {"role": "user", "content": "你好！"}
+  ],
+  "temperature": 0.7,
+  "max_tokens": 1000
+}
+```
+
+## `tarko workspace`
+
+**工作区管理**实用程序，用于组织 Agent 项目。
+
+### 命令
+
+```bash
+# 在当前目录初始化新工作区
+tarko workspace --init
+
+# 使用自定义名称初始化
+tarko workspace --init --name my-agent-workspace
+
+# 在 VSCode 中打开工作区
+tarko workspace --open
+
+# 启用全局工作区
+tarko workspace --enable
+
+# 禁用全局工作区
+tarko workspace --disable
+
+# 显示工作区状态和配置
+tarko workspace --status
+
+# 清理工作区（删除临时文件）
+tarko workspace --clean
+```
+
+### 工作区结构
+
+初始化工作区会创建：
+
+```
+my-workspace/
+├── tarko.config.ts          # 主配置
+├── agents/                   # 自定义 Agent
+├── tools/                    # 自定义工具
+├── data/                     # Agent 数据和缓存
+├── logs/                     # 执行日志
+└── .tarko/                   # 内部工作区数据
+```
+
+## 全局选项
+
+这些选项适用于所有命令：
+
+### 配置
+
+```bash
+# 模型配置
+tarko --model.provider openai --model.id gpt-4 --model.apiKey sk-xxx
+
+# 自定义配置文件
+tarko --config ./custom.config.ts
+
+# 自定义工作区
+tarko --workspace ./my-workspace
+```
+
+### 调试
+
+```bash
+# 启用调试日志
+tarko --debug
+
+# 详细输出
+tarko --verbose
+
+# 试运行（显示将要执行的内容）
+tarko --dry-run
+
+# 显示配置并退出
+tarko --show-config
+```
+
+### Tool 和 MCP 过滤
+
+```bash
+# 包含特定工具
+tarko --tool.include "file_*,web_*"
+
+# 排除特定工具
+tarko --tool.exclude "dangerous_*"
+
+# 包含特定 MCP 服务器
+tarko --mcpServer.include "filesystem,browser"
+
+# 排除特定 MCP 服务器
+tarko --mcpServer.exclude "experimental_*"
+```
+
+## 环境变量
+
+CLI 选项的替代方案：
+
+```bash
+# 模型配置
+export OPENAI_API_KEY=your-api-key
+export ANTHROPIC_API_KEY=your-api-key
+
+# 服务器配置
+export TARKO_PORT=3000
+export TARKO_HOST=0.0.0.0
+
+# 调试设置
+export DEBUG=tarko:*
+export TARKO_LOG_LEVEL=debug
+
+# 工作区
+export TARKO_WORKSPACE=./my-workspace
+```
+
+## 退出代码
+
+| 代码 | 描述 |
+|------|------|
+| 0 | 成功 |
+| 1 | 一般错误 |
+| 2 | 配置错误 |
+| 3 | 网络错误 |
+| 4 | 认证错误 |
+| 5 | Agent 执行错误 |
+
+## 示例
+
+### 开发工作流
+
+```bash
+# 1. 初始化工作区
+tarko workspace --init --name my-project
+
+# 2. 启动开发带 UI
+tarko run --dev --open
+
+# 3. 使用无头模式测试
+tarko run --headless --input "测试我的 Agent"
+
+# 4. 部署到生产
+tarko serve --port 3000 --config production.config.ts
+```
+
+### CI/CD 集成
+
+```bash
+# 测试 Agent 功能
+tarko run agent-tars --headless --input "运行测试" --format json > results.json
+
+# 验证配置
+tarko --dry-run --show-config
+
+# 健康检查
+curl -f http://localhost:3000/api/v1/health || exit 1
+```
+
+### 调试
+
+```bash
+# 使用详细日志调试
+DEBUG=tarko:* tarko run --debug --verbose
+
+# 测试直接 LLM 请求
+tarko request --provider openai --model gpt-4 --body '{"messages":[{"role":"user","content":"你好"}]}' --debug
+
+# 检查配置
+tarko --show-config --debug
+```

--- a/multimodal/websites/tarko/docs/zh/guide/cli/commands.mdx
+++ b/multimodal/websites/tarko/docs/zh/guide/cli/commands.mdx
@@ -194,9 +194,6 @@ tarko request --provider openai --model gpt-4 --body request.json --format seman
 # 在当前目录初始化新工作区
 tarko workspace --init
 
-# 使用自定义名称初始化
-tarko workspace --init --name my-agent-workspace
-
 # 在 VSCode 中打开工作区
 tarko workspace --open
 
@@ -208,9 +205,6 @@ tarko workspace --disable
 
 # 显示工作区状态和配置
 tarko workspace --status
-
-# 清理工作区（删除临时文件）
-tarko workspace --clean
 ```
 
 ### 工作区结构

--- a/multimodal/websites/tarko/docs/zh/guide/cli/configuration.mdx
+++ b/multimodal/websites/tarko/docs/zh/guide/cli/configuration.mdx
@@ -1,0 +1,577 @@
+---
+title: CLI 配置
+description: 配置 Tarko CLI 的完整指南
+---
+
+# CLI 配置
+
+Tarko CLI 支持多种配置格式和来源，具有清晰的优先级系统。
+
+## 配置文件
+
+Tarko CLI 按以下顺序自动发现配置文件：
+
+1. `tarko.config.ts` (TypeScript)
+2. `tarko.config.yaml` (YAML)
+3. `tarko.config.json` (JSON)
+
+### TypeScript 配置
+
+```typescript
+// tarko.config.ts
+import { AgentAppConfig } from '@tarko/interface';
+
+const config: AgentAppConfig = {
+  // 模型配置
+  model: {
+    provider: 'openai',
+    id: 'gpt-4',
+    apiKey: process.env.OPENAI_API_KEY,
+    baseURL: 'https://api.openai.com/v1',
+    temperature: 0.7,
+    maxTokens: 4000,
+  },
+  
+  // 工作区设置
+  workspace: './workspace',
+  
+  // 服务器配置
+  server: {
+    port: 8888,
+    host: '0.0.0.0',
+    cors: true,
+  },
+  
+  // Tool 过滤
+  tool: {
+    include: ['file_*', 'web_*'],
+    exclude: ['dangerous_*'],
+  },
+  
+  // MCP Server 过滤
+  mcpServer: {
+    include: ['filesystem', 'browser'],
+    exclude: ['experimental_*'],
+  },
+  
+  // UI 配置
+  ui: {
+    enabled: true,
+    title: 'My Agent',
+    theme: 'default',
+    autoOpen: false,
+  },
+  
+  // 日志配置
+  logging: {
+    level: 'info',
+    format: 'json',
+    output: {
+      console: true,
+      file: {
+        enabled: true,
+        path: './logs/agent.log',
+        maxSize: '10m',
+        maxFiles: 5,
+      },
+    },
+  },
+  
+  // 指标配置
+  metrics: {
+    enabled: true,
+    endpoint: '/metrics',
+    collectors: {
+      requests: true,
+      responses: true,
+      toolCalls: true,
+      errors: true,
+    },
+  },
+};
+
+export default config;
+```
+
+### YAML 配置
+
+```yaml
+# tarko.config.yaml
+model:
+  provider: openai
+  id: gpt-4
+  apiKey: ${OPENAI_API_KEY}
+  baseURL: https://api.openai.com/v1
+  temperature: 0.7
+  maxTokens: 4000
+
+workspace: ./workspace
+
+server:
+  port: 8888
+  host: 0.0.0.0
+  cors: true
+
+tool:
+  include:
+    - 'file_*'
+    - 'web_*'
+  exclude:
+    - 'dangerous_*'
+
+mcpServer:
+  include:
+    - filesystem
+    - browser
+  exclude:
+    - 'experimental_*'
+
+ui:
+  enabled: true
+  title: My Agent
+  theme: default
+  autoOpen: false
+
+logging:
+  level: info
+  format: json
+  output:
+    console: true
+    file:
+      enabled: true
+      path: ./logs/agent.log
+      maxSize: 10m
+      maxFiles: 5
+
+metrics:
+  enabled: true
+  endpoint: /metrics
+  collectors:
+    requests: true
+    responses: true
+    toolCalls: true
+    errors: true
+```
+
+### JSON 配置
+
+```json
+{
+  "model": {
+    "provider": "openai",
+    "id": "gpt-4",
+    "apiKey": "${OPENAI_API_KEY}",
+    "baseURL": "https://api.openai.com/v1",
+    "temperature": 0.7,
+    "maxTokens": 4000
+  },
+  "workspace": "./workspace",
+  "server": {
+    "port": 8888,
+    "host": "0.0.0.0",
+    "cors": true
+  },
+  "tool": {
+    "include": ["file_*", "web_*"],
+    "exclude": ["dangerous_*"]
+  },
+  "mcpServer": {
+    "include": ["filesystem", "browser"],
+    "exclude": ["experimental_*"]
+  },
+  "ui": {
+    "enabled": true,
+    "title": "My Agent",
+    "theme": "default",
+    "autoOpen": false
+  },
+  "logging": {
+    "level": "info",
+    "format": "json",
+    "output": {
+      "console": true,
+      "file": {
+        "enabled": true,
+        "path": "./logs/agent.log",
+        "maxSize": "10m",
+        "maxFiles": 5
+      }
+    }
+  },
+  "metrics": {
+    "enabled": true,
+    "endpoint": "/metrics",
+    "collectors": {
+      "requests": true,
+      "responses": true,
+      "toolCalls": true,
+      "errors": true
+    }
+  }
+}
+```
+
+## 配置优先级
+
+配置按以下优先级顺序解析（最高到最低）：
+
+1. **CLI 参数**（最高优先级）
+2. **工作区配置**
+3. **用户配置文件**（`--config`）
+4. **远程配置 URL**
+5. **默认配置**（最低优先级）
+
+### CLI 参数覆盖
+
+```bash
+# 覆盖模型配置
+tarko --model.provider openai --model.id gpt-4 --model.apiKey sk-xxx
+
+# 覆盖服务器设置
+tarko serve --port 3000 --host 0.0.0.0
+
+# 覆盖工作区
+tarko --workspace ./custom-workspace
+
+# 覆盖工具过滤
+tarko --tool.include "file_*,web_*" --tool.exclude "dangerous_*"
+```
+
+## 环境变量
+
+环境变量提供了配置文件的替代方案：
+
+### 模型配置
+
+```bash
+# API 密钥
+export OPENAI_API_KEY=your-openai-key
+export ANTHROPIC_API_KEY=your-anthropic-key
+export AZURE_OPENAI_API_KEY=your-azure-key
+export GEMINI_API_KEY=your-gemini-key
+
+# 模型设置
+export TARKO_MODEL_PROVIDER=openai
+export TARKO_MODEL_ID=gpt-4
+export TARKO_MODEL_BASE_URL=https://api.openai.com/v1
+export TARKO_MODEL_TEMPERATURE=0.7
+export TARKO_MODEL_MAX_TOKENS=4000
+```
+
+### 服务器配置
+
+```bash
+# 服务器设置
+export TARKO_PORT=3000
+export TARKO_HOST=0.0.0.0
+export TARKO_CORS=true
+
+# 工作区
+export TARKO_WORKSPACE=./my-workspace
+
+# UI 设置
+export TARKO_UI_ENABLED=true
+export TARKO_UI_TITLE="My Agent"
+export TARKO_UI_THEME=default
+export TARKO_UI_AUTO_OPEN=false
+```
+
+### 调试和日志
+
+```bash
+# 调试设置
+export DEBUG=tarko:*
+export TARKO_LOG_LEVEL=debug
+export TARKO_LOG_FORMAT=json
+
+# 指标
+export TARKO_METRICS_ENABLED=true
+export TARKO_METRICS_ENDPOINT=/metrics
+```
+
+## 配置部分
+
+### 模型配置
+
+```typescript
+model: {
+  provider: 'openai' | 'anthropic' | 'azure' | 'ollama' | 'gemini',
+  id: string,              // 模型 ID（例如 'gpt-4', 'claude-3-opus'）
+  apiKey?: string,          // API 密钥（为安全起见使用环境变量）
+  baseURL?: string,         // 自定义 API 端点
+  temperature?: number,     // 创造性（0-1）
+  maxTokens?: number,       // 最大响应令牌
+  topP?: number,            // 核采样
+  frequencyPenalty?: number,// 频率惩罚
+  presencePenalty?: number, // 存在惩罚
+  timeout?: number,         // 请求超时（毫秒）
+  retries?: number,         // 重试次数
+}
+```
+
+### 服务器配置
+
+```typescript
+server: {
+  port?: number,            // 服务器端口（默认：3000）
+  host?: string,            // 服务器主机（默认：'localhost'）
+  cors?: boolean,           // 启用 CORS（默认：true）
+  rateLimit?: {             // 速率限制
+    windowMs: number,       // 时间窗口（毫秒）
+    max: number,            // 每个窗口的最大请求数
+  },
+  ssl?: {                   // SSL 配置
+    enabled: boolean,
+    cert: string,           // 证书路径
+    key: string,            // 私钥路径
+  },
+}
+```
+
+### Tool 过滤
+
+```typescript
+tool: {
+  include?: string[],       // 要包含的工具模式
+  exclude?: string[],       // 要排除的工具模式
+}
+
+// 示例：
+// include: ['file_*', 'web_*'] - 包含所有文件和网络工具
+// exclude: ['dangerous_*'] - 排除危险工具
+// include: ['file_read', 'file_write'] - 包含特定工具
+```
+
+### MCP Server 过滤
+
+```typescript
+mcpServer: {
+  include?: string[],       // 要包含的 MCP 服务器模式
+  exclude?: string[],       // 要排除的 MCP 服务器模式
+}
+
+// 示例：
+// include: ['filesystem', 'browser'] - 包含特定服务器
+// exclude: ['experimental_*'] - 排除实验性服务器
+```
+
+### UI 配置
+
+```typescript
+ui: {
+  enabled?: boolean,        // 启用 Web UI（默认：true）
+  title?: string,           // UI 标题
+  theme?: 'default' | 'dark' | 'light',
+  autoOpen?: boolean,       // 自动打开浏览器（默认：false）
+  customization?: {
+    logo?: string,          // 自定义 logo 路径
+    primaryColor?: string,  // 主色调十六进制
+    layout?: 'sidebar' | 'topbar',
+  },
+}
+```
+
+### 日志配置
+
+```typescript
+logging: {
+  level?: 'debug' | 'info' | 'warn' | 'error',
+  format?: 'json' | 'text',
+  output?: {
+    console?: boolean,      // 输出到控制台
+    file?: {
+      enabled: boolean,
+      path: string,         // 日志文件路径
+      maxSize: string,      // 最大文件大小（例如 '10m'）
+      maxFiles: number,     // 最大文件数
+    },
+    syslog?: {              // Syslog 配置
+      enabled: boolean,
+      host: string,
+      port: number,
+      facility: string,
+    },
+  },
+}
+```
+
+### 指标配置
+
+```typescript
+metrics: {
+  enabled?: boolean,        // 启用指标收集
+  endpoint?: string,        // 指标端点（默认：'/metrics'）
+  collectors?: {
+    requests?: boolean,     // HTTP 请求指标
+    responses?: boolean,    // HTTP 响应指标
+    toolCalls?: boolean,    // 工具调用指标
+    errors?: boolean,       // 错误指标
+    memory?: boolean,       // 内存使用指标
+    cpu?: boolean,          // CPU 使用指标
+  },
+}
+```
+
+## 高级配置
+
+### 远程配置
+
+从远程 URL 加载配置：
+
+```bash
+tarko --config https://example.com/agent-config.json
+```
+
+### 环境特定配置
+
+```typescript
+// tarko.config.ts
+import { AgentAppConfig } from '@tarko/interface';
+
+const baseConfig: AgentAppConfig = {
+  model: {
+    provider: 'openai',
+    id: 'gpt-4',
+  },
+};
+
+const developmentConfig: AgentAppConfig = {
+  ...baseConfig,
+  server: { port: 3000 },
+  logging: { level: 'debug' },
+  ui: { autoOpen: true },
+};
+
+const productionConfig: AgentAppConfig = {
+  ...baseConfig,
+  server: { port: 8080, host: '0.0.0.0' },
+  logging: { level: 'info', format: 'json' },
+  ui: { enabled: false },
+  metrics: { enabled: true },
+};
+
+const config = process.env.NODE_ENV === 'production' 
+  ? productionConfig 
+  : developmentConfig;
+
+export default config;
+```
+
+### 工作区配置
+
+`.tarko/config.ts` 中的工作区特定配置：
+
+```typescript
+// .tarko/config.ts
+import { AgentAppConfig } from '@tarko/interface';
+
+const config: AgentAppConfig = {
+  // 工作区特定设置
+  workspace: '.',
+  tool: {
+    include: ['file_*'], // 此工作区仅使用文件工具
+  },
+};
+
+export default config;
+```
+
+## 配置验证
+
+Tarko CLI 在启动时验证配置：
+
+```bash
+# 不运行即验证配置
+tarko --dry-run --show-config
+
+# 显示解析的配置
+tarko --show-config
+
+# 调试配置解析
+tarko --debug --show-config
+```
+
+## 配置示例
+
+### 开发设置
+
+```typescript
+// tarko.config.ts
+export default {
+  model: {
+    provider: 'openai',
+    id: 'gpt-4',
+    apiKey: process.env.OPENAI_API_KEY,
+  },
+  server: { port: 3000 },
+  ui: { autoOpen: true },
+  logging: { level: 'debug' },
+};
+```
+
+### 生产设置
+
+```typescript
+// tarko.config.ts
+export default {
+  model: {
+    provider: 'openai',
+    id: 'gpt-4',
+    apiKey: process.env.OPENAI_API_KEY,
+  },
+  server: {
+    port: 8080,
+    host: '0.0.0.0',
+    cors: true,
+    rateLimit: {
+      windowMs: 15 * 60 * 1000,
+      max: 100,
+    },
+  },
+  ui: { enabled: false },
+  logging: {
+    level: 'info',
+    format: 'json',
+    output: {
+      console: false,
+      file: {
+        enabled: true,
+        path: './logs/agent.log',
+        maxSize: '100m',
+        maxFiles: 10,
+      },
+    },
+  },
+  metrics: { enabled: true },
+};
+```
+
+### 安全重点设置
+
+```typescript
+// tarko.config.ts
+export default {
+  model: {
+    provider: 'openai',
+    id: 'gpt-4',
+    apiKey: process.env.OPENAI_API_KEY,
+  },
+  tool: {
+    exclude: ['dangerous_*', 'system_*', 'network_*'],
+  },
+  mcpServer: {
+    include: ['filesystem'], // 仅允许文件系统访问
+  },
+  server: {
+    cors: false,
+    rateLimit: {
+      windowMs: 15 * 60 * 1000,
+      max: 50, // 严格的速率限制
+    },
+  },
+  logging: {
+    level: 'info',
+    format: 'json',
+  },
+};
+```

--- a/multimodal/websites/tarko/docs/zh/guide/cli/configuration.mdx
+++ b/multimodal/websites/tarko/docs/zh/guide/cli/configuration.mdx
@@ -1,18 +1,18 @@
 ---
 title: CLI 配置
-description: 配置 Tarko CLI 的完整指南
+description: Tarko CLI 配置完整指南
 ---
 
 # CLI 配置
 
-Tarko CLI 支持多种配置格式和来源，具有清晰的优先级系统。
+Tarko CLI 支持多种配置格式，优先级从高到低：CLI 参数 > 配置文件 > 环境变量。
 
 ## 配置文件
 
-Tarko CLI 按以下顺序自动发现配置文件：
+自动发现配置文件顺序：
 
 1. `tarko.config.ts` (TypeScript)
-2. `tarko.config.yaml` (YAML)
+2. `tarko.config.yaml` (YAML) 
 3. `tarko.config.json` (JSON)
 
 ### TypeScript 配置
@@ -22,24 +22,18 @@ Tarko CLI 按以下顺序自动发现配置文件：
 import { AgentAppConfig } from '@tarko/interface';
 
 const config: AgentAppConfig = {
-  // 模型配置
+  // Model 配置
   model: {
     provider: 'openai',
     id: 'gpt-4',
     apiKey: process.env.OPENAI_API_KEY,
-    baseURL: 'https://api.openai.com/v1',
     temperature: 0.7,
-    maxTokens: 4000,
   },
-  
-  // 工作区设置
-  workspace: './workspace',
   
   // 服务器配置
   server: {
     port: 8888,
-    host: '0.0.0.0',
-    cors: true,
+    exclusive: false, // 独占模式
   },
   
   // Tool 过滤
@@ -54,39 +48,9 @@ const config: AgentAppConfig = {
     exclude: ['experimental_*'],
   },
   
-  // UI 配置
-  ui: {
-    enabled: true,
-    title: 'My Agent',
-    theme: 'default',
-    autoOpen: false,
-  },
-  
-  // 日志配置
-  logging: {
-    level: 'info',
-    format: 'json',
-    output: {
-      console: true,
-      file: {
-        enabled: true,
-        path: './logs/agent.log',
-        maxSize: '10m',
-        maxFiles: 5,
-      },
-    },
-  },
-  
-  // 指标配置
-  metrics: {
-    enabled: true,
-    endpoint: '/metrics',
-    collectors: {
-      requests: true,
-      responses: true,
-      toolCalls: true,
-      errors: true,
-    },
+  // 分享配置
+  share: {
+    provider: 'https://share.example.com',
   },
 };
 
@@ -101,16 +65,11 @@ model:
   provider: openai
   id: gpt-4
   apiKey: ${OPENAI_API_KEY}
-  baseURL: https://api.openai.com/v1
   temperature: 0.7
-  maxTokens: 4000
-
-workspace: ./workspace
 
 server:
   port: 8888
-  host: 0.0.0.0
-  cors: true
+  exclusive: false
 
 tool:
   include:
@@ -126,31 +85,8 @@ mcpServer:
   exclude:
     - 'experimental_*'
 
-ui:
-  enabled: true
-  title: My Agent
-  theme: default
-  autoOpen: false
-
-logging:
-  level: info
-  format: json
-  output:
-    console: true
-    file:
-      enabled: true
-      path: ./logs/agent.log
-      maxSize: 10m
-      maxFiles: 5
-
-metrics:
-  enabled: true
-  endpoint: /metrics
-  collectors:
-    requests: true
-    responses: true
-    toolCalls: true
-    errors: true
+share:
+  provider: https://share.example.com
 ```
 
 ### JSON 配置
@@ -161,15 +97,11 @@ metrics:
     "provider": "openai",
     "id": "gpt-4",
     "apiKey": "${OPENAI_API_KEY}",
-    "baseURL": "https://api.openai.com/v1",
-    "temperature": 0.7,
-    "maxTokens": 4000
+    "temperature": 0.7
   },
-  "workspace": "./workspace",
   "server": {
     "port": 8888,
-    "host": "0.0.0.0",
-    "cors": true
+    "exclusive": false
   },
   "tool": {
     "include": ["file_*", "web_*"],
@@ -179,152 +111,72 @@ metrics:
     "include": ["filesystem", "browser"],
     "exclude": ["experimental_*"]
   },
-  "ui": {
-    "enabled": true,
-    "title": "My Agent",
-    "theme": "default",
-    "autoOpen": false
-  },
-  "logging": {
-    "level": "info",
-    "format": "json",
-    "output": {
-      "console": true,
-      "file": {
-        "enabled": true,
-        "path": "./logs/agent.log",
-        "maxSize": "10m",
-        "maxFiles": 5
-      }
-    }
-  },
-  "metrics": {
-    "enabled": true,
-    "endpoint": "/metrics",
-    "collectors": {
-      "requests": true,
-      "responses": true,
-      "toolCalls": true,
-      "errors": true
-    }
+  "share": {
+    "provider": "https://share.example.com"
   }
 }
 ```
 
 ## 配置优先级
 
-配置按以下优先级顺序解析（最高到最低）：
+配置解析优先级（从高到低）：
 
 1. **CLI 参数**（最高优先级）
 2. **工作区配置**
 3. **用户配置文件**（`--config`）
-4. **远程配置 URL**
-5. **默认配置**（最低优先级）
+4. **默认配置**（最低优先级）
 
 ### CLI 参数覆盖
 
 ```bash
-# 覆盖模型配置
+# 覆盖 Model 配置
 tarko --model.provider openai --model.id gpt-4 --model.apiKey sk-xxx
 
 # 覆盖服务器设置
-tarko serve --port 3000 --host 0.0.0.0
+tarko serve --port 3000
 
 # 覆盖工作区
 tarko --workspace ./custom-workspace
 
-# 覆盖工具过滤
+# 覆盖 Tool 过滤
 tarko --tool.include "file_*,web_*" --tool.exclude "dangerous_*"
 ```
 
 ## 环境变量
 
-环境变量提供了配置文件的替代方案：
-
-### 模型配置
-
 ```bash
-# API 密钥
+# API Keys
 export OPENAI_API_KEY=your-openai-key
 export ANTHROPIC_API_KEY=your-anthropic-key
 export AZURE_OPENAI_API_KEY=your-azure-key
-export GEMINI_API_KEY=your-gemini-key
 
-# 模型设置
-export TARKO_MODEL_PROVIDER=openai
-export TARKO_MODEL_ID=gpt-4
-export TARKO_MODEL_BASE_URL=https://api.openai.com/v1
-export TARKO_MODEL_TEMPERATURE=0.7
-export TARKO_MODEL_MAX_TOKENS=4000
-```
-
-### 服务器配置
-
-```bash
 # 服务器设置
 export TARKO_PORT=3000
-export TARKO_HOST=0.0.0.0
-export TARKO_CORS=true
-
-# 工作区
 export TARKO_WORKSPACE=./my-workspace
 
-# UI 设置
-export TARKO_UI_ENABLED=true
-export TARKO_UI_TITLE="My Agent"
-export TARKO_UI_THEME=default
-export TARKO_UI_AUTO_OPEN=false
-```
-
-### 调试和日志
-
-```bash
 # 调试设置
 export DEBUG=tarko:*
-export TARKO_LOG_LEVEL=debug
-export TARKO_LOG_FORMAT=json
-
-# 指标
-export TARKO_METRICS_ENABLED=true
-export TARKO_METRICS_ENDPOINT=/metrics
 ```
 
-## 配置部分
+## 主要配置选项
 
-### 模型配置
+### Model 配置
 
 ```typescript
 model: {
-  provider: 'openai' | 'anthropic' | 'azure' | 'ollama' | 'gemini',
-  id: string,              // 模型 ID（例如 'gpt-4', 'claude-3-opus'）
-  apiKey?: string,          // API 密钥（为安全起见使用环境变量）
-  baseURL?: string,         // 自定义 API 端点
-  temperature?: number,     // 创造性（0-1）
-  maxTokens?: number,       // 最大响应令牌
-  topP?: number,            // 核采样
-  frequencyPenalty?: number,// 频率惩罚
-  presencePenalty?: number, // 存在惩罚
-  timeout?: number,         // 请求超时（毫秒）
-  retries?: number,         // 重试次数
+  provider: 'openai' | 'anthropic' | 'azure' | 'ollama',
+  id: string,              // Model ID (如 'gpt-4')
+  apiKey?: string,         // API key (建议使用环境变量)
+  temperature?: number,    // 创造性 (0-1)
 }
 ```
 
-### 服务器配置
+### Server 配置
 
 ```typescript
 server: {
-  port?: number,            // 服务器端口（默认：3000）
-  host?: string,            // 服务器主机（默认：'localhost'）
-  cors?: boolean,           // 启用 CORS（默认：true）
-  rateLimit?: {             // 速率限制
-    windowMs: number,       // 时间窗口（毫秒）
-    max: number,            // 每个窗口的最大请求数
-  },
-  ssl?: {                   // SSL 配置
-    enabled: boolean,
-    cert: string,           // 证书路径
-    key: string,            // 私钥路径
-  },
+  port?: number,           // 服务器端口 (默认: 8888)
+  exclusive?: boolean,     // 独占模式 (默认: false)
 }
 ```
 
@@ -332,168 +184,31 @@ server: {
 
 ```typescript
 tool: {
-  include?: string[],       // 要包含的工具模式
-  exclude?: string[],       // 要排除的工具模式
+  include?: string[],      // 包含的 Tool 模式
+  exclude?: string[],      // 排除的 Tool 模式
 }
 
-// 示例：
+// 示例:
 // include: ['file_*', 'web_*'] - 包含所有文件和网络工具
 // exclude: ['dangerous_*'] - 排除危险工具
-// include: ['file_read', 'file_write'] - 包含特定工具
 ```
 
 ### MCP Server 过滤
 
 ```typescript
 mcpServer: {
-  include?: string[],       // 要包含的 MCP 服务器模式
-  exclude?: string[],       // 要排除的 MCP 服务器模式
+  include?: string[],      // 包含的 MCP server 模式
+  exclude?: string[],      // 排除的 MCP server 模式
 }
 
-// 示例：
+// 示例:
 // include: ['filesystem', 'browser'] - 包含特定服务器
 // exclude: ['experimental_*'] - 排除实验性服务器
 ```
 
-### UI 配置
-
-```typescript
-ui: {
-  enabled?: boolean,        // 启用 Web UI（默认：true）
-  title?: string,           // UI 标题
-  theme?: 'default' | 'dark' | 'light',
-  autoOpen?: boolean,       // 自动打开浏览器（默认：false）
-  customization?: {
-    logo?: string,          // 自定义 logo 路径
-    primaryColor?: string,  // 主色调十六进制
-    layout?: 'sidebar' | 'topbar',
-  },
-}
-```
-
-### 日志配置
-
-```typescript
-logging: {
-  level?: 'debug' | 'info' | 'warn' | 'error',
-  format?: 'json' | 'text',
-  output?: {
-    console?: boolean,      // 输出到控制台
-    file?: {
-      enabled: boolean,
-      path: string,         // 日志文件路径
-      maxSize: string,      // 最大文件大小（例如 '10m'）
-      maxFiles: number,     // 最大文件数
-    },
-    syslog?: {              // Syslog 配置
-      enabled: boolean,
-      host: string,
-      port: number,
-      facility: string,
-    },
-  },
-}
-```
-
-### 指标配置
-
-```typescript
-metrics: {
-  enabled?: boolean,        // 启用指标收集
-  endpoint?: string,        // 指标端点（默认：'/metrics'）
-  collectors?: {
-    requests?: boolean,     // HTTP 请求指标
-    responses?: boolean,    // HTTP 响应指标
-    toolCalls?: boolean,    // 工具调用指标
-    errors?: boolean,       // 错误指标
-    memory?: boolean,       // 内存使用指标
-    cpu?: boolean,          // CPU 使用指标
-  },
-}
-```
-
-## 高级配置
-
-### 远程配置
-
-从远程 URL 加载配置：
-
-```bash
-tarko --config https://example.com/agent-config.json
-```
-
-### 环境特定配置
-
-```typescript
-// tarko.config.ts
-import { AgentAppConfig } from '@tarko/interface';
-
-const baseConfig: AgentAppConfig = {
-  model: {
-    provider: 'openai',
-    id: 'gpt-4',
-  },
-};
-
-const developmentConfig: AgentAppConfig = {
-  ...baseConfig,
-  server: { port: 3000 },
-  logging: { level: 'debug' },
-  ui: { autoOpen: true },
-};
-
-const productionConfig: AgentAppConfig = {
-  ...baseConfig,
-  server: { port: 8080, host: '0.0.0.0' },
-  logging: { level: 'info', format: 'json' },
-  ui: { enabled: false },
-  metrics: { enabled: true },
-};
-
-const config = process.env.NODE_ENV === 'production' 
-  ? productionConfig 
-  : developmentConfig;
-
-export default config;
-```
-
-### 工作区配置
-
-`.tarko/config.ts` 中的工作区特定配置：
-
-```typescript
-// .tarko/config.ts
-import { AgentAppConfig } from '@tarko/interface';
-
-const config: AgentAppConfig = {
-  // 工作区特定设置
-  workspace: '.',
-  tool: {
-    include: ['file_*'], // 此工作区仅使用文件工具
-  },
-};
-
-export default config;
-```
-
-## 配置验证
-
-Tarko CLI 在启动时验证配置：
-
-```bash
-# 不运行即验证配置
-tarko --dry-run --show-config
-
-# 显示解析的配置
-tarko --show-config
-
-# 调试配置解析
-tarko --debug --show-config
-```
-
 ## 配置示例
 
-### 开发设置
+### 开发环境
 
 ```typescript
 // tarko.config.ts
@@ -504,12 +219,10 @@ export default {
     apiKey: process.env.OPENAI_API_KEY,
   },
   server: { port: 3000 },
-  ui: { autoOpen: true },
-  logging: { level: 'debug' },
 };
 ```
 
-### 生产设置
+### 生产环境
 
 ```typescript
 // tarko.config.ts
@@ -521,57 +234,15 @@ export default {
   },
   server: {
     port: 8080,
-    host: '0.0.0.0',
-    cors: true,
-    rateLimit: {
-      windowMs: 15 * 60 * 1000,
-      max: 100,
-    },
-  },
-  ui: { enabled: false },
-  logging: {
-    level: 'info',
-    format: 'json',
-    output: {
-      console: false,
-      file: {
-        enabled: true,
-        path: './logs/agent.log',
-        maxSize: '100m',
-        maxFiles: 10,
-      },
-    },
-  },
-  metrics: { enabled: true },
-};
-```
-
-### 安全重点设置
-
-```typescript
-// tarko.config.ts
-export default {
-  model: {
-    provider: 'openai',
-    id: 'gpt-4',
-    apiKey: process.env.OPENAI_API_KEY,
+    exclusive: true,
   },
   tool: {
-    exclude: ['dangerous_*', 'system_*', 'network_*'],
-  },
-  mcpServer: {
-    include: ['filesystem'], // 仅允许文件系统访问
-  },
-  server: {
-    cors: false,
-    rateLimit: {
-      windowMs: 15 * 60 * 1000,
-      max: 50, // 严格的速率限制
-    },
-  },
-  logging: {
-    level: 'info',
-    format: 'json',
+    exclude: ['dangerous_*'],
   },
 };
 ```
+
+## 下一步
+
+- [CLI Commands](/guide/cli/commands) - 完整命令参考
+- [Built-in Agents](/guide/cli/built-in-agents) - 内置 Agent

--- a/multimodal/websites/tarko/docs/zh/guide/cli/overview.mdx
+++ b/multimodal/websites/tarko/docs/zh/guide/cli/overview.mdx
@@ -1,0 +1,144 @@
+---
+title: CLI 概述
+description: Tarko Agent CLI 介绍
+---
+
+# CLI 概述
+
+**Tarko Agent CLI** 是一个基于 **Agent Kernel** ([`@tarko/agent`](https://www.npmjs.com/package/@tarko/agent)) 构建的灵活框架。它提供了一个全面的命令行界面，用于轻松部署和运行 Agent，具有内置的 Web UI 和强大的可扩展性。
+
+## 安装
+
+通过 npm 全局安装：
+
+```bash
+npm install -g @tarko/agent-cli
+```
+
+或使用 npx 进行一次性执行：
+
+```bash
+npx @tarko/agent-cli run my-agent
+```
+
+## 快速开始
+
+```bash
+# 启动交互式 Web UI（默认）
+tarko
+
+# 运行内置 Agent
+tarko run agent-tars  # Agent TARS
+tarko run omni-tars   # Omni-TARS
+tarko run mcp-agent   # MCP Agent
+
+# 运行自定义 Agent
+tarko run ./my-agent.js
+
+# 启动无头 API 服务器
+tarko serve
+
+# 无头模式直接输入
+tarko run --headless --input "分析当前目录结构"
+
+# 管道输入
+echo "总结这段代码" | tarko run --headless
+```
+
+## 核心概念
+
+### 部署模式
+
+- **交互模式** (`tarko run`) - 用于开发和测试的 Web UI
+- **服务器模式** (`tarko serve`) - 用于生产的无头 API 服务器
+- **脚本模式** (`tarko run --headless`) - 用于自动化的静默执行
+
+### 内置 Agent
+
+Tarko CLI 包含几个即用型 Agent：
+
+- **`agent-tars`** - 高级任务自动化和推理系统
+- **`omni-tars`** - 具有综合能力的多模态 Agent
+- **`mcp-agent`** - 用于工具集成的模型上下文协议 Agent
+
+### 配置灵活性
+
+支持多种配置格式，自动发现：
+- `tarko.config.ts` - TypeScript 配置
+- `tarko.config.yaml` - YAML 配置
+- `tarko.config.json` - JSON 配置
+- 环境变量和 CLI 参数
+
+## 主要功能
+
+### 事件驱动架构
+
+基于事件驱动架构监控 Agent 执行：
+
+```typescript
+const eventStream = agent.getEventStream();
+eventStream.subscribe((event) => {
+  console.log('事件:', event.type, event);
+});
+```
+
+### Tool 和 MCP Server 过滤
+
+通过配置过滤可用的工具和 MCP 服务器：
+
+```bash
+tarko --tool.include "file_*,web_*" --tool.exclude "dangerous_*"
+tarko --mcpServer.include "filesystem" --mcpServer.exclude "experimental_*"
+```
+
+### 控制台拦截
+
+在执行期间捕获和处理控制台输出：
+
+```typescript
+import { ConsoleInterceptor } from '@tarko/agent-cli';
+
+const { result, logs } = await ConsoleInterceptor.run(
+  async () => {
+    return await agent.run('input');
+  },
+  { silent: true, capture: true }
+);
+```
+
+## 使用场景
+
+### 开发
+- 使用 Web UI 进行交互式 Agent 开发
+- 实时调试和测试
+- 热重载和开发模式
+
+### 生产
+- 无头 API 服务器部署
+- Docker 和 Kubernetes 集成
+- 负载均衡和扩展
+
+### 自动化
+- CI/CD 流水线集成
+- 批处理和脚本编写
+- 结构化输出的静默执行
+
+### 测试
+- 用于调试的直接 LLM 请求
+- Agent 行为验证
+- 性能测试和基准测试
+
+## 下一步
+
+- [命令参考](/guide/cli/commands) - 详细的命令文档
+- [配置指南](/guide/cli/configuration) - 高级配置选项
+- [内置 Agent](/guide/cli/built-in-agents) - 使用预构建的 Agent
+- [部署指南](/guide/deployment/cli) - 生产部署策略
+
+## API 参考
+
+详细的 TypeScript 定义：
+
+- [`@tarko/agent-interface`](https://www.npmjs.com/package/@tarko/agent-interface) - 核心 Agent 接口
+- [`@tarko/interface`](https://www.npmjs.com/package/@tarko/interface) - 应用层接口
+- [`@tarko/agent-cli`](https://www.npmjs.com/package/@tarko/agent-cli) - CLI 框架接口

--- a/multimodal/websites/tarko/docs/zh/guide/cli/overview.mdx
+++ b/multimodal/websites/tarko/docs/zh/guide/cli/overview.mdx
@@ -71,17 +71,6 @@ Tarko CLI 包含几个即用型 Agent：
 
 ## 主要功能
 
-### 事件驱动架构
-
-基于事件驱动架构监控 Agent 执行：
-
-```typescript
-const eventStream = agent.getEventStream();
-eventStream.subscribe((event) => {
-  console.log('事件:', event.type, event);
-});
-```
-
 ### Tool 和 MCP Server 过滤
 
 通过配置过滤可用的工具和 MCP 服务器：

--- a/multimodal/websites/tarko/docs/zh/guide/cli/overview.mdx
+++ b/multimodal/websites/tarko/docs/zh/guide/cli/overview.mdx
@@ -80,19 +80,16 @@ tarko --tool.include "file_*,web_*" --tool.exclude "dangerous_*"
 tarko --mcpServer.include "filesystem" --mcpServer.exclude "experimental_*"
 ```
 
-### 控制台拦截
+### 调试支持
 
-在执行期间捕获和处理控制台输出：
+通过 `--debug` 参数启用详细日志：
 
-```typescript
-import { ConsoleInterceptor } from '@tarko/agent-cli';
+```bash
+# 启用调试模式
+tarko run --debug
 
-const { result, logs } = await ConsoleInterceptor.run(
-  async () => {
-    return await agent.run('input');
-  },
-  { silent: true, capture: true }
-);
+# 使用环境变量
+DEBUG=tarko:* tarko run
 ```
 
 ## 使用场景

--- a/multimodal/websites/tarko/docs/zh/guide/deployment/cli.mdx
+++ b/multimodal/websites/tarko/docs/zh/guide/deployment/cli.mdx
@@ -1,313 +1,441 @@
 ---
 title: CLI 部署
-description: 使用 CLI 部署 Tarko Agent
+description: 使用 Tarko CLI 的生产部署策略
 ---
 
 # CLI 部署
 
-**Tarko Agent CLI** 提供了一种简单的方式在各种环境中部署和运行基于 Tarko 的 Agent。使用 `tarko run [agent]` 创建无头或有头的 Agent 运行时环境。
+本指南涵盖使用 Tarko CLI 的生产部署策略。有关完整的 CLI 参考和命令，请参阅 [CLI 指南](/guide/cli/overview)。
 
-## 安装
+## 概述
 
-全局安装 Tarko CLI：
+Tarko CLI 提供针对不同环境优化的多种部署模式：
 
-```bash
-npm install -g @tarko/agent-cli
-```
+- **生产服务器** (`tarko serve`) - 用于生产的无头 API 服务器
+- **开发** (`tarko run`) - 用于开发和测试的交互式 UI
+- **自动化** (`tarko run --headless`) - 脚本和 CI/CD 集成
 
-或使用 npx：
+有关详细的命令参考，请参阅 [CLI 命令](/guide/cli/commands)。
 
-```bash
-npx @tarko/agent-cli run my-agent
-```
+## 生产服务器部署
 
-## 基础用法
+### 基本服务器设置
 
-### 运行 Agent
+为生产使用部署无头 API 服务器：
 
 ```bash
-# 在当前目录运行 Agent
-tarko run
+# 启动生产服务器
+tarko serve --port 8080 --host 0.0.0.0
 
-# 运行特定 Agent
-tarko run ./my-agent
+# 使用特定 Agent
+tarko serve agent-tars --port 8080
 
-# 使用自定义配置运行
-tarko run --config ./custom-config.json
+# 使用生产配置
+tarko serve --config production.config.ts --port 8080
 ```
 
-### 开发模式
+服务器在以下地址公开 REST 和 WebSocket API：
+- `GET /api/v1/health` - 健康检查
+- `POST /api/v1/chat` - 聊天端点
+- `GET /api/v1/events` - 事件流（WebSocket）
 
-```bash
-# 在开发模式下运行，支持热重载
-tarko run --dev
+### 生产配置
 
-# 运行时启用调试日志
-tarko run --debug
+创建生产优化配置：
 
-# 运行在特定端口
-tarko run --port 3001
-```
+```typescript
+// production.config.ts
+import { AgentAppConfig } from '@tarko/interface';
 
-## 配置
-
-### CLI 配置文件
-
-创建 `tarko.config.js` 文件：
-
-```javascript
-module.exports = {
-  name: 'MyAgent',
-  description: '一个有用的助手',
-  
-  // 运行时配置
-  runtime: {
-    port: 3000,
-    host: '0.0.0.0',
-    mode: 'production' // 或 'development'
-  },
-  
-  // 模型配置
+const config: AgentAppConfig = {
   model: {
     provider: 'openai',
+    id: 'gpt-4',
     apiKey: process.env.OPENAI_API_KEY,
-    model: 'gpt-4'
   },
   
-  // 工具
-  tools: [
-    '@tarko/tools/file-system',
-    '@tarko/tools/browser',
-    './custom-tools/weather'
-  ],
-  
-  // UI 配置
-  ui: {
-    enabled: true,
-    theme: 'default',
-    title: 'My Agent'
-  }
-};
-```
-
-### 环境变量
-
-```bash
-# 模型配置
-export TARKO_MODEL_PROVIDER=openai
-export TARKO_MODEL_API_KEY=your-api-key
-export TARKO_MODEL_NAME=gpt-4
-
-# 运行时配置
-export TARKO_PORT=3000
-export TARKO_HOST=0.0.0.0
-export TARKO_MODE=production
-
-# UI 配置
-export TARKO_UI_ENABLED=true
-export TARKO_UI_THEME=default
-```
-
-## 部署模式
-
-### 无头模式
-
-运行无 UI，仅提供 API 访问：
-
-```bash
-tarko run --headless
-```
-
-配置：
-
-```javascript
-module.exports = {
-  runtime: {
-    mode: 'headless',
-    api: {
-      enabled: true,
-      cors: true,
-      rateLimit: {
-        windowMs: 15 * 60 * 1000, // 15 分钟
-        max: 100 // 每个 IP 在 windowMs 内限制 100 个请求
-      }
-    }
+  server: {
+    port: 8080,
+    host: '0.0.0.0',
+    cors: true,
+    rateLimit: {
+      windowMs: 15 * 60 * 1000, // 15 分钟
+      max: 100, // 每个窗口的请求数
+    },
   },
+  
   ui: {
-    enabled: false
-  }
-};
-```
-
-### 有头模式
-
-运行带 Web UI：
-
-```bash
-tarko run --ui
-```
-
-配置：
-
-```javascript
-module.exports = {
-  ui: {
+    enabled: false, // 生产环境禁用 UI
+  },
+  
+  logging: {
+    level: 'info',
+    format: 'json',
+    output: {
+      console: false,
+      file: {
+        enabled: true,
+        path: './logs/agent.log',
+        maxSize: '100m',
+        maxFiles: 10,
+      },
+    },
+  },
+  
+  metrics: {
     enabled: true,
-    title: 'My Agent',
-    theme: 'default',
-    customization: {
-      logo: './assets/logo.png',
-      primaryColor: '#007bff',
-      layout: 'sidebar' // 或 'topbar'
-    }
-  }
+    endpoint: '/metrics',
+  },
 };
+
+export default config;
 ```
 
-## 生产部署
+有关完整的配置选项，请参阅 [CLI 配置](/guide/cli/configuration)。
+
+## 容器部署
 
 ### Docker
 
-创建 `Dockerfile`：
+创建生产 Docker 镜像：
 
 ```dockerfile
+# Dockerfile
 FROM node:18-alpine
 
 WORKDIR /app
 
-# 复制包文件
+# 安装依赖
 COPY package*.json ./
 RUN npm ci --only=production
 
-# 复制 Agent 代码
+# 复制应用代码
 COPY . .
 
-# 安装 Tarko CLI
+# 全局安装 Tarko CLI
 RUN npm install -g @tarko/agent-cli
 
-EXPOSE 3000
+# 创建非 root 用户
+RUN addgroup -g 1001 -S tarko && \
+    adduser -S tarko -u 1001
+USER tarko
 
-CMD ["tarko", "run", "--port", "3000", "--host", "0.0.0.0"]
+# 暴露端口
+EXPOSE 8080
+
+# 健康检查
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+  CMD curl -f http://localhost:8080/api/v1/health || exit 1
+
+# 启动服务器
+CMD ["tarko", "serve", "--port", "8080", "--host", "0.0.0.0"]
 ```
 
 构建和运行：
 
 ```bash
-docker build -t my-agent .
-docker run -p 3000:3000 -e OPENAI_API_KEY=your-key my-agent
+# 构建镜像
+docker build -t my-agent:latest .
+
+# 运行容器
+docker run -d \
+  --name my-agent \
+  -p 8080:8080 \
+  -e OPENAI_API_KEY=${OPENAI_API_KEY} \
+  -v $(pwd)/logs:/app/logs \
+  --restart unless-stopped \
+  my-agent:latest
+
+# 检查健康状态
+docker exec my-agent curl -f http://localhost:8080/api/v1/health
 ```
 
 ### Docker Compose
 
+用于多服务部署：
+
 ```yaml
+# docker-compose.yml
 version: '3.8'
 
 services:
   agent:
     build: .
     ports:
-      - "3000:3000"
+      - "8080:8080"
     environment:
-      - TARKO_MODEL_PROVIDER=openai
-      - TARKO_MODEL_API_KEY=${OPENAI_API_KEY}
-      - TARKO_MODEL_NAME=gpt-4
-      - TARKO_MODE=production
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - NODE_ENV=production
     volumes:
-      - ./data:/app/data
+      - ./workspace:/app/workspace
+      - ./logs:/app/logs
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/api/v1/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    depends_on:
+      - redis
 
   redis:
-    image: redis:alpine
+    image: redis:7-alpine
     ports:
       - "6379:6379"
     volumes:
       - redis_data:/data
+    restart: unless-stopped
+    command: redis-server --appendonly yes
+
+  nginx:
+    image: nginx:alpine
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./ssl:/etc/nginx/ssl:ro
+    depends_on:
+      - agent
     restart: unless-stopped
 
 volumes:
   redis_data:
 ```
 
-### 进程管理器 (PM2)
+部署堆栈：
+
+```bash
+# 启动服务
+docker-compose up -d
+
+# 查看日志
+docker-compose logs -f agent
+
+# 扩展 Agent
+docker-compose up -d --scale agent=3
+
+# 健康检查
+curl -f http://localhost:8080/api/v1/health
+```
+
+## Kubernetes 部署
+
+### 基本部署
+
+```yaml
+# k8s/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tarko-agent
+  labels:
+    app: tarko-agent
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: tarko-agent
+  template:
+    metadata:
+      labels:
+        app: tarko-agent
+    spec:
+      containers:
+      - name: agent
+        image: my-agent:latest
+        ports:
+        - containerPort: 8080
+        env:
+        - name: OPENAI_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: api-secrets
+              key: openai-key
+        - name: NODE_ENV
+          value: "production"
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "250m"
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+        livenessProbe:
+          httpGet:
+            path: /api/v1/health
+            port: 8080
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /api/v1/health
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        volumeMounts:
+        - name: workspace
+          mountPath: /app/workspace
+        - name: logs
+          mountPath: /app/logs
+      volumes:
+      - name: workspace
+        persistentVolumeClaim:
+          claimName: agent-workspace
+      - name: logs
+        persistentVolumeClaim:
+          claimName: agent-logs
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tarko-agent-service
+spec:
+  selector:
+    app: tarko-agent
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 8080
+  type: ClusterIP
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: tarko-agent-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+  - host: agent.example.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: tarko-agent-service
+            port:
+              number: 80
+```
+
+部署到 Kubernetes：
+
+```bash
+# 创建密钥
+kubectl create secret generic api-secrets \
+  --from-literal=openai-key=${OPENAI_API_KEY}
+
+# 应用清单
+kubectl apply -f k8s/
+
+# 检查部署
+kubectl get pods -l app=tarko-agent
+kubectl logs -l app=tarko-agent
+
+# 端口转发用于测试
+kubectl port-forward svc/tarko-agent-service 8080:80
+```
+
+## 进程管理
+
+### PM2
+
+用于传统服务器部署：
 
 ```javascript
 // ecosystem.config.js
 module.exports = {
   apps: [{
-    name: 'my-agent',
+    name: 'tarko-agent',
     script: 'tarko',
-    args: 'run --port 3000',
-    instances: 1,
+    args: 'serve --port 8080 --config production.config.ts',
+    instances: 'max', // 使用所有 CPU 核心
+    exec_mode: 'cluster',
     autorestart: true,
     watch: false,
     max_memory_restart: '1G',
     env: {
       NODE_ENV: 'production',
-      TARKO_MODEL_PROVIDER: 'openai',
-      TARKO_MODEL_API_KEY: process.env.OPENAI_API_KEY
-    }
+      OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+    },
+    error_file: './logs/err.log',
+    out_file: './logs/out.log',
+    log_file: './logs/combined.log',
+    time: true,
   }]
 };
 ```
 
-部署：
+使用 PM2 部署：
 
 ```bash
+# 安装 PM2
 npm install -g pm2
+
+# 启动应用
 pm2 start ecosystem.config.js
+
+# 保存 PM2 配置
 pm2 save
+
+# 设置启动脚本
 pm2 startup
+sudo env PATH=$PATH:/usr/bin pm2 startup systemd -u $USER --hp $HOME
+
+# 监控
+pm2 monit
+pm2 logs tarko-agent
+
+# 重启
+pm2 restart tarko-agent
+
+# 停止
+pm2 stop tarko-agent
 ```
 
-## 监控和日志
+### Systemd 服务
 
-### 健康检查
+创建 systemd 服务：
+
+```ini
+# /etc/systemd/system/tarko-agent.service
+[Unit]
+Description=Tarko Agent Server
+After=network.target
+
+[Service]
+Type=simple
+User=tarko
+WorkingDirectory=/opt/tarko-agent
+Environment=NODE_ENV=production
+Environment=OPENAI_API_KEY=your-api-key
+ExecStart=/usr/bin/tarko serve --port 8080 --config production.config.ts
+Restart=always
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+```
+
+管理服务：
 
 ```bash
-# 检查 Agent 状态
-curl http://localhost:3000/health
+# 启用并启动
+sudo systemctl enable tarko-agent
+sudo systemctl start tarko-agent
 
-# 检查详细状态
-curl http://localhost:3000/status
-```
+# 检查状态
+sudo systemctl status tarko-agent
 
-### 日志配置
+# 查看日志
+sudo journalctl -u tarko-agent -f
 
-```javascript
-module.exports = {
-  logging: {
-    level: 'info', // debug, info, warn, error
-    format: 'json', // json, text
-    output: {
-      console: true,
-      file: {
-        enabled: true,
-        path: './logs/agent.log',
-        maxSize: '10m',
-        maxFiles: 5
-      }
-    }
-  }
-};
-```
-
-### 指标
-
-启用指标收集：
-
-```javascript
-module.exports = {
-  metrics: {
-    enabled: true,
-    endpoint: '/metrics',
-    collectors: {
-      requests: true,
-      responses: true,
-      toolCalls: true,
-      errors: true
-    }
-  }
-};
+# 重启
+sudo systemctl restart tarko-agent
 ```
 
 ## 负载均衡
@@ -315,15 +443,36 @@ module.exports = {
 ### Nginx 配置
 
 ```nginx
+# nginx.conf
 upstream tarko_agents {
-    server localhost:3000;
-    server localhost:3001;
-    server localhost:3002;
+    least_conn;
+    server localhost:8080 max_fails=3 fail_timeout=30s;
+    server localhost:8081 max_fails=3 fail_timeout=30s;
+    server localhost:8082 max_fails=3 fail_timeout=30s;
 }
 
 server {
     listen 80;
-    server_name my-agent.example.com;
+    server_name agent.example.com;
+    
+    # 重定向 HTTP 到 HTTPS
+    return 301 https://$server_name$request_uri;
+}
+
+server {
+    listen 443 ssl http2;
+    server_name agent.example.com;
+    
+    # SSL 配置
+    ssl_certificate /etc/nginx/ssl/cert.pem;
+    ssl_certificate_key /etc/nginx/ssl/key.pem;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers HIGH:!aNULL:!MD5;
+    
+    # 安全头
+    add_header X-Frame-Options DENY;
+    add_header X-Content-Type-Options nosniff;
+    add_header X-XSS-Protection "1; mode=block";
     
     location / {
         proxy_pass http://tarko_agents;
@@ -335,7 +484,204 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_cache_bypass $http_upgrade;
+        proxy_read_timeout 86400;
+        
+        # 速率限制
+        limit_req zone=api burst=20 nodelay;
     }
+    
+    # 健康检查端点
+    location /health {
+        access_log off;
+        proxy_pass http://tarko_agents/api/v1/health;
+    }
+    
+    # 指标端点（限制访问）
+    location /metrics {
+        allow 10.0.0.0/8;
+        deny all;
+        proxy_pass http://tarko_agents/metrics;
+    }
+}
+
+# 速率限制
+http {
+    limit_req_zone $binary_remote_addr zone=api:10m rate=10r/s;
+}
+```
+
+## 监控和可观测性
+
+### 健康检查
+
+```bash
+# 基本健康检查
+curl -f http://localhost:8080/api/v1/health
+
+# 详细状态
+curl http://localhost:8080/api/v1/status
+
+# 指标（Prometheus 格式）
+curl http://localhost:8080/metrics
+```
+
+### 日志
+
+为生产配置结构化日志：
+
+```typescript
+// 在 production.config.ts 中
+logging: {
+  level: 'info',
+  format: 'json',
+  output: {
+    console: false,
+    file: {
+      enabled: true,
+      path: './logs/agent.log',
+      maxSize: '100m',
+      maxFiles: 10,
+    },
+  },
+}
+```
+
+使用 ELK 堆栈或类似工具进行日志聚合：
+
+```yaml
+# docker-compose.override.yml
+version: '3.8'
+services:
+  agent:
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+        labels: "service=tarko-agent"
+```
+
+### 指标和告警
+
+启用 Prometheus 指标：
+
+```typescript
+// 在 production.config.ts 中
+metrics: {
+  enabled: true,
+  endpoint: '/metrics',
+  collectors: {
+    requests: true,
+    responses: true,
+    toolCalls: true,
+    errors: true,
+    memory: true,
+    cpu: true,
+  },
+}
+```
+
+## CI/CD 集成
+
+### GitHub Actions
+
+```yaml
+# .github/workflows/deploy.yml
+name: Deploy Agent
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Setup Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: '18'
+        cache: 'npm'
+    
+    - name: Install dependencies
+      run: npm ci
+    
+    - name: Install Tarko CLI
+      run: npm install -g @tarko/agent-cli
+    
+    - name: Test agent
+      run: |
+        tarko run --headless --input "健康检查" --format json
+      env:
+        OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+    
+    - name: Build Docker image
+      run: |
+        docker build -t my-agent:${{ github.sha }} .
+        docker tag my-agent:${{ github.sha }} my-agent:latest
+    
+    - name: Deploy to production
+      run: |
+        # 部署到你的基础设施
+        echo "部署到生产环境..."
+```
+
+### 部署脚本
+
+```bash
+#!/bin/bash
+# deploy.sh
+
+set -e
+
+echo "部署 Tarko Agent..."
+
+# 构建并推送镜像
+docker build -t my-agent:latest .
+docker push my-agent:latest
+
+# 更新 Kubernetes 部署
+kubectl set image deployment/tarko-agent agent=my-agent:latest
+kubectl rollout status deployment/tarko-agent
+
+# 验证部署
+kubectl get pods -l app=tarko-agent
+echo "部署完成！"
+```
+
+## 安全考虑
+
+### 环境变量
+
+```bash
+# 使用安全的环境变量管理
+export OPENAI_API_KEY=$(cat /run/secrets/openai_key)
+export ANTHROPIC_API_KEY=$(cat /run/secrets/anthropic_key)
+
+# 或使用容器密钥
+docker run -d \
+  --secret openai_key \
+  --secret anthropic_key \
+  my-agent:latest
+```
+
+### 网络安全
+
+```typescript
+// 在生产中限制工具访问
+tool: {
+  exclude: ['dangerous_*', 'system_*', 'network_*'],
+},
+
+// 仅为受信任的域启用 CORS
+server: {
+  cors: {
+    origin: ['https://trusted-domain.com'],
+    credentials: true,
+  },
 }
 ```
 
@@ -343,42 +689,49 @@ server {
 
 ### 常见问题
 
-**端口已被使用：**
+**端口冲突：**
 ```bash
-# 查找使用端口的进程
-lsof -i :3000
+# 检查端口使用
+lsof -i :8080
 
-# 终止进程
-kill -9 <PID>
-
-# 或使用不同端口
-tarko run --port 3001
-```
-
-**权限错误：**
-```bash
-# 使用 sudo 运行（不推荐）
-sudo tarko run
-
-# 或更改为非特权端口
-tarko run --port 8080
+# 使用不同端口
+tarko serve --port 8081
 ```
 
 **内存问题：**
 ```bash
-# 增加 Node.js 内存限制
-NODE_OPTIONS="--max-old-space-size=4096" tarko run
+# 增加 Node.js 内存
+NODE_OPTIONS="--max-old-space-size=4096" tarko serve
+
+# 监控内存使用
+top -p $(pgrep -f "tarko serve")
+```
+
+**配置错误：**
+```bash
+# 验证配置
+tarko --show-config --dry-run
+
+# 调试配置加载
+DEBUG=tarko:config tarko serve --debug
 ```
 
 ### 调试模式
 
 ```bash
 # 启用调试日志
-DEBUG=tarko:* tarko run --debug
+DEBUG=tarko:* tarko serve --debug
 
-# 启用 Node.js 检查器
-tarko run --inspect
+# 使用详细输出监控
+tarko serve --debug --verbose
 
-# 启用详细输出
-tarko run --verbose
+# 性能分析
+NODE_OPTIONS="--inspect" tarko serve
 ```
+
+## 下一步
+
+- [CLI 概述](/guide/cli/overview) - 完整的 CLI 参考
+- [CLI 配置](/guide/cli/configuration) - 高级配置
+- [内置 Agent](/guide/cli/built-in-agents) - 使用预构建的 Agent
+- [服务器 API](/guide/deployment/server) - 服务器 API 参考


### PR DESCRIPTION
## Summary

Restructured CLI documentation into proper sections with clear separation of concerns:

**New Structure:**
- `/guide/cli/` - Complete CLI reference aligned with `@tarko/agent-cli` README
- `/guide/deployment/cli.mdx` - Production deployment strategies only


## Checklist

- [ ] Added or updated necessary tests (Optional).
- [x] Updated documentation to align with changes (Optional).
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [ ] My change does not involve the above items.