### PR TITLE
fix(tarko-agent-ui): restore container and navbar in replay mode

### DIFF
--- a/multimodal/tarko/agent-ui/src/standalone/app/App.tsx
+++ b/multimodal/tarko/agent-ui/src/standalone/app/App.tsx
@@ -42,7 +42,15 @@ export const App: React.FC = () => {
 
   if (isReplayMode) {
     console.log('[ReplayMode] Rendering replay layout directly');
-    return <Layout isReplayMode={true} />;
+    return (
+      <div className="flex h-screen bg-[#F2F3F5] dark:bg-gray-900 text-gray-900 dark:text-gray-100 overflow-hidden">
+        <Sidebar />
+        <div className="flex-1 flex flex-col overflow-hidden">
+          <Navbar />
+          <Layout isReplayMode={true} />
+        </div>
+      </div>
+    );
   }
 
   return (


### PR DESCRIPTION
## Summary

Fixed height control issue in Agent UI's Replay mode by restoring the missing container with proper styling and the Navbar component.

**Problem**: In replay mode, the UI was missing the outer container with `flex h-screen bg-[#F2F3F5] dark:bg-gray-900 text-gray-900 dark:text-gray-100 overflow-hidden` classes and the Navbar component, causing layout issues where the UI didn't fill the screen properly.

**Root Cause**: PR #1553 moved the layout structure but replay mode bypassed the normal routing and rendered `<Layout>` directly without the necessary container wrapper.

**Solution**: Wrapped the replay mode layout with the same container structure used for normal sessions, including the Sidebar, Navbar, and proper CSS classes.

## Checklist

- [ ] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [x] My change does not involve the above items.