### PR TITLE
feat(agent-tars): disable contextual selector by default

### DIFF
--- a/multimodal/agent-tars/core/src/agent-tars.ts
+++ b/multimodal/agent-tars/core/src/agent-tars.ts
@@ -45,7 +45,7 @@ export class AgentTARS<T extends AgentTARSOptions = AgentTARSOptions> extends MC
       'Tell me the top 5 most popular projects on ProductHunt today',
       'Please book me the earliest flight from Hangzhou to Shenzhen on 10.1',
     ],
-    enableContextualSelector: true,
+    enableContextualSelector: false,
     guiAgent: {
       defaultScreenshotRenderStrategy: 'beforeAction',
       enableScreenshotRenderStrategySwitch: true,


### PR DESCRIPTION
## Summary

Disabled `enableContextualSelector` in Agent TARS by default.

## Checklist  

- [ ] Added or updated necessary tests (Optional).  
- [ ] Updated documentation to align with changes (Optional).  
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).  
- [x] My change does not involve the above items.