### PR TITLE
feat(tarko-agent-ui): add `webui.layout.enableSidebar` config

### DIFF
--- a/multimodal/tarko/agent-ui/src/config/web-ui-config.ts
+++ b/multimodal/tarko/agent-ui/src/config/web-ui-config.ts
@@ -67,6 +67,7 @@ export function getLayoutConfig() {
     getWebUIConfig().layout || {
       defaultLayout: 'default',
       enableLayoutSwitchButton: false,
+      enableSidebar: true,
     }
   );
 }
@@ -83,4 +84,11 @@ export function isLayoutSwitchButtonEnabled(): boolean {
  */
 export function getDefaultLayoutMode() {
   return getLayoutConfig().defaultLayout || 'default';
+}
+
+/**
+ * Check if sidebar is enabled
+ */
+export function isSidebarEnabled(): boolean {
+  return getLayoutConfig().enableSidebar ?? true;
 }

--- a/multimodal/tarko/agent-ui/src/standalone/app/App.tsx
+++ b/multimodal/tarko/agent-ui/src/standalone/app/App.tsx
@@ -7,11 +7,13 @@ import { useReplayMode } from '@/common/hooks/useReplayMode';
 import { SessionRouter } from './Router/SessionRouter';
 import { Sidebar } from '@/standalone/sidebar';
 import { Navbar } from '@/standalone/navbar';
+import { isSidebarEnabled } from '@/config/web-ui-config';
 
 export const App: React.FC = () => {
   const { initConnectionMonitoring, loadSessions, connectionStatus, activeSessionId } =
     useSession();
   const { isReplayMode } = useReplayMode();
+  const sidebarEnabled = isSidebarEnabled();
 
   useEffect(() => {
     if (isReplayMode) {
@@ -44,7 +46,7 @@ export const App: React.FC = () => {
     console.log('[ReplayMode] Rendering replay layout directly');
     return (
       <div className="flex h-screen bg-[#F2F3F5] dark:bg-gray-900 text-gray-900 dark:text-gray-100 overflow-hidden">
-        <Sidebar />
+        {sidebarEnabled && <Sidebar />}
         <div className="flex-1 flex flex-col overflow-hidden">
           <Navbar />
           <Layout isReplayMode={true} />
@@ -59,7 +61,7 @@ export const App: React.FC = () => {
         path="/"
         element={
           <div className="flex h-screen bg-[#F2F3F5] dark:bg-gray-900 text-gray-900 dark:text-gray-100 overflow-hidden">
-            <Sidebar />
+            {sidebarEnabled && <Sidebar />}
             <div className="flex-1 flex flex-col overflow-hidden">
               <HomePage />
             </div>
@@ -70,7 +72,7 @@ export const App: React.FC = () => {
         path="/:sessionId"
         element={
           <div className="flex h-screen bg-[#F2F3F5] dark:bg-gray-900 text-gray-900 dark:text-gray-100 overflow-hidden">
-            <Sidebar />
+            {sidebarEnabled && <Sidebar />}
             <div className="flex-1 flex flex-col overflow-hidden">
               <Navbar />
               <SessionRouter>

--- a/multimodal/tarko/interface/src/web-ui-implementation.ts
+++ b/multimodal/tarko/interface/src/web-ui-implementation.ts
@@ -61,6 +61,11 @@ export interface LayoutConfig {
    * @defaultValue false
    */
   enableLayoutSwitchButton?: boolean;
+  /**
+   * Enable sidebar display
+   * @defaultValue true
+   */
+  enableSidebar?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds `webui.layout.enableSidebar` configuration option to control sidebar visibility in the web UI. When set to `false`, the sidebar will be hidden across all views (home, session, and replay mode).

## Checklist

- [ ] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [x] My change does not involve the above items.