### PR TITLE
feat(tarko-agent-ui): add `webui.layout.enableHome` config

### DIFF
--- a/multimodal/tarko/agent-ui/src/config/web-ui-config.ts
+++ b/multimodal/tarko/agent-ui/src/config/web-ui-config.ts
@@ -68,6 +68,7 @@ export function getLayoutConfig() {
       defaultLayout: 'default',
       enableLayoutSwitchButton: false,
       enableSidebar: true,
+      enableHome: true,
     }
   );
 }
@@ -91,4 +92,11 @@ export function getDefaultLayoutMode() {
  */
 export function isSidebarEnabled(): boolean {
   return getLayoutConfig().enableSidebar ?? true;
+}
+
+/**
+ * Check if home route is enabled
+ */
+export function isHomeEnabled(): boolean {
+  return getLayoutConfig().enableHome ?? true;
 }

--- a/multimodal/tarko/agent-ui/src/standalone/app/App.tsx
+++ b/multimodal/tarko/agent-ui/src/standalone/app/App.tsx
@@ -7,13 +7,14 @@ import { useReplayMode } from '@/common/hooks/useReplayMode';
 import { SessionRouter } from './Router/SessionRouter';
 import { Sidebar } from '@/standalone/sidebar';
 import { Navbar } from '@/standalone/navbar';
-import { isSidebarEnabled } from '@/config/web-ui-config';
+import { isSidebarEnabled, isHomeEnabled } from '@/config/web-ui-config';
 
 export const App: React.FC = () => {
   const { initConnectionMonitoring, loadSessions, connectionStatus, activeSessionId } =
     useSession();
   const { isReplayMode } = useReplayMode();
   const sidebarEnabled = isSidebarEnabled();
+  const homeEnabled = isHomeEnabled();
 
   useEffect(() => {
     if (isReplayMode) {
@@ -57,17 +58,19 @@ export const App: React.FC = () => {
 
   return (
     <Routes>
-      <Route
-        path="/"
-        element={
-          <div className="flex h-screen bg-[#F2F3F5] dark:bg-gray-900 text-gray-900 dark:text-gray-100 overflow-hidden">
-            {sidebarEnabled && <Sidebar />}
-            <div className="flex-1 flex flex-col overflow-hidden">
-              <HomePage />
+      {homeEnabled && (
+        <Route
+          path="/"
+          element={
+            <div className="flex h-screen bg-[#F2F3F5] dark:bg-gray-900 text-gray-900 dark:text-gray-100 overflow-hidden">
+              {sidebarEnabled && <Sidebar />}
+              <div className="flex-1 flex flex-col overflow-hidden">
+                <HomePage />
+              </div>
             </div>
-          </div>
-        }
-      />
+          }
+        />
+      )}
       <Route
         path="/:sessionId"
         element={

--- a/multimodal/tarko/interface/src/web-ui-implementation.ts
+++ b/multimodal/tarko/interface/src/web-ui-implementation.ts
@@ -66,6 +66,11 @@ export interface LayoutConfig {
    * @defaultValue true
    */
   enableSidebar?: boolean;
+  /**
+   * Enable home route registration
+   * @defaultValue true
+   */
+  enableHome?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

Add `webui.layout.enableHome` configuration option to control home route registration. When set to `false`, the home route "/" will not be registered, allowing for custom routing behavior.

## Checklist  

- [ ] Added or updated necessary tests (Optional).  
- [ ] Updated documentation to align with changes (Optional).  
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).  
- [x] My change does not involve the above items.