### PR TITLE
fix(tarko-agent-ui): code editor light mode highlighting

### DIFF
--- a/multimodal/tarko/ui/src/components/code-editor/CodeEditor.css
+++ b/multimodal/tarko/ui/src/components/code-editor/CodeEditor.css
@@ -133,6 +133,11 @@
   overflow: auto;
 }
 
+.code-editor-code-area .hljs {
+  color: #e1e4e8;
+  background: transparent;
+}
+
 .code-editor-pre {
   margin: 0;
   padding: 12px 16px;


### PR DESCRIPTION
## Summary

Fixed `CodeEditor` light mode syntax highlighting by adding specific `.hljs` color override to ensure proper text visibility.

## Follow-up

TODO: Adopt a more elegant solution instead of override

## Checklist  

- [ ] Added or updated necessary tests (Optional).  
- [ ] Updated documentation to align with changes (Optional).  
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).  
- [x] My change does not involve the above items.