### PR TITLE
fix(tarko-agent-ui): remove ugly container from ImageRenderer

### DIFF
--- a/multimodal/tarko/agent-ui/src/standalone/workspace/renderers/ImageRenderer.tsx
+++ b/multimodal/tarko/agent-ui/src/standalone/workspace/renderers/ImageRenderer.tsx
@@ -85,17 +85,14 @@ export const ImageRenderer: React.FC<ImageRendererProps> = ({ panelContent, onAc
     <div className="relative group max-w-full">
       <motion.div
         whileHover={{ scale: 1.01 }}
-        className="bg-white dark:bg-gray-800 rounded-xl p-2 border border-gray-200/50 dark:border-gray-700/30 shadow-sm"
+        className="relative"
       >
-        <div className="relative">
-          <img
-            src={src}
-            alt={name || 'Image'}
-            className="md:max-h-[70vh] max-h-60 w-full h-auto object-contain rounded-lg mx-auto"
-          />
-
-          {actionButtons}
-        </div>
+        <img
+          src={src}
+          alt={name || 'Image'}
+          className="md:max-h-[70vh] max-h-60 w-full h-auto object-contain rounded-lg mx-auto"
+        />
+        {actionButtons}
       </motion.div>
     </div>
   );


### PR DESCRIPTION
## Summary

Removed excessive background, padding, border, and shadow styling from `ImageRenderer` container that made it look bulky and ugly. The image now displays cleanly without unnecessary visual noise.

## Checklist  

- [ ] Added or updated necessary tests (Optional).  
- [ ] Updated documentation to align with changes (Optional).  
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).  
- [x] My change does not involve the above items.