### PR TITLE
fix(tarko-agent-ui): make welcome cards prompt optional

### DIFF
--- a/multimodal/omni-tars/omni-agent/src/index.ts
+++ b/multimodal/omni-tars/omni-agent/src/index.ts
@@ -21,7 +21,7 @@ export default class OmniTARSAgent extends ComposableAgent {
       {
         title: '2048',
         category: 'Game',
-        prompt: `Play this game, your target score is 1024`,
+        // prompt: `Play this game, your target score is 1024`,
         image:
           'https://img.poki-cdn.com/cdn-cgi/image/q=78,scq=50,width=80,height=80,fit=cover,f=auto/cb8c967c-4a78-4ffa-8506-cbac69746f4f/2048.png',
         agentOptions: {

--- a/multimodal/tarko/agent-ui/src/standalone/home/WelcomeCards.tsx
+++ b/multimodal/tarko/agent-ui/src/standalone/home/WelcomeCards.tsx
@@ -48,9 +48,9 @@ const WelcomeCards: React.FC<WelcomeCardsProps> = ({
       // Navigate to creating page with card-specific agent options
       navigate('/creating', {
         state: {
-          query: card.prompt,
-          agentOptions: card.agentOptions || {}
-        }
+          ...(card.prompt && { query: card.prompt }),
+          agentOptions: card.agentOptions || {},
+        },
       });
     } catch (error) {
       console.error('Failed to navigate to creating:', error);

--- a/multimodal/tarko/interface/src/web-ui-implementation.ts
+++ b/multimodal/tarko/interface/src/web-ui-implementation.ts
@@ -138,6 +138,10 @@ export interface WelcomeCard {
    */
   title: string;
   /**
+   * Card category for grouping
+   */
+  category: string;
+  /**
    * Card prompt content
    */
   prompt?: string;
@@ -145,10 +149,6 @@ export interface WelcomeCard {
    * Card background image URL
    */
   image?: string;
-  /**
-   * Card category for grouping
-   */
-  category: string;
   /**
    * Agent options to pass when creating session
    */

--- a/multimodal/tarko/interface/src/web-ui-implementation.ts
+++ b/multimodal/tarko/interface/src/web-ui-implementation.ts
@@ -140,7 +140,7 @@ export interface WelcomeCard {
   /**
    * Card prompt content
    */
-  prompt: string;
+  prompt?: string;
   /**
    * Card background image URL
    */


### PR DESCRIPTION
## Summary

Fixed an issue where clicking `welcomeCards` would always send a user message, even when no `prompt` was configured. Now only sends a message when `card.prompt` exists.

**Before**: All cards triggered message sending regardless of prompt configuration  
**After**: Only cards with configured prompts trigger message sending

## Checklist  

- [ ] Added or updated necessary tests (Optional).  
- [ ] Updated documentation to align with changes (Optional).  
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).  
- [x] My change does not involve the above items.