### PR TITLE
ci(tarko-agent-server): add missing `getOptions` method to fix tests

### DIFF
--- a/multimodal/tarko/agent-server/tests/mocks/MockAgent.ts
+++ b/multimodal/tarko/agent-server/tests/mocks/MockAgent.ts
@@ -92,6 +92,10 @@ export class MockAgent implements IAgent {
     return [];
   }
 
+  getOptions(): AgentAppConfig {
+    return this.options;
+  }
+
 
 }
 


### PR DESCRIPTION
## Summary

Fixes `TypeError: wrappedAgent.getOptions is not a function` in `agent-session-restore.test.ts` by implementing missing `IAgent` interface methods in `MockAgent`.

## Checklist  

- [x] Added or updated necessary tests (Optional).  
- [ ] Updated documentation to align with changes (Optional).  
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).  
- [ ] My change does not involve the above items.