### PR TITLE
fix(tarko-agent-ui): show terminal ui for empty execute_bash results

### DIFF
--- a/multimodal/tarko/agent-ui/src/standalone/workspace/renderers/CommandResultRenderer.tsx
+++ b/multimodal/tarko/agent-ui/src/standalone/workspace/renderers/CommandResultRenderer.tsx
@@ -98,21 +98,23 @@ export const CommandResultRenderer: React.FC<CommandResultRendererProps> = ({ pa
   // Extract command data from panelContent
   const commandData = extractCommandData(panelContent);
 
-  if (!commandData) {
-    return <div className="text-gray-500 italic">Command result is empty</div>;
-  }
+  // Always show terminal UI, even for empty results
+  const { command, stdout, stderr, exitCode } = commandData || {
+    command: panelContent.arguments?.command,
+    stdout: undefined,
+    stderr: undefined,
+    exitCode: undefined,
+  };
 
-  const { command, stdout, stderr, exitCode } = commandData;
-
-  // Exit code styling
-  const isError = exitCode !== 0 && exitCode !== undefined;
+  // For empty results, show "Command result is empty" as stdout
+  const displayStdout = stdout || (commandData === null ? 'Command result is empty' : undefined);
 
   return (
     <div className="space-y-4 md:text-base text-sm">
       <div className="md:[&_pre]:text-sm [&_pre]:text-xs md:[&_pre]:p-4 [&_pre]:p-2 md:[&_pre]:max-h-none [&_pre]:overflow-auto">
         <TerminalOutput
           command={command ? highlightCommand(command) : undefined}
-          stdout={stdout}
+          stdout={displayStdout}
           stderr={stderr}
           exitCode={exitCode}
           maxHeight="calc(100vh - 215px)"
@@ -202,6 +204,18 @@ function extractCommandData(panelContent: StandardPanelContent) {
       command: panelContent.arguments?.command,
       stdout: panelContent.source.output,
       exitCode: panelContent.source.returncode,
+    };
+  }
+
+  /**
+   * Handle execute_bash with undefined content
+   */
+  if (panelContent.title === 'execute_bash' && panelContent.source === undefined) {
+    return {
+      command: panelContent.arguments?.command,
+      stdout: undefined,
+      stderr: undefined,
+      exitCode: undefined,
     };
   }
 


### PR DESCRIPTION
## Summary

Fixed issue where `execute_bash` tool results with `undefined` content displayed "Command result is empty" as plain text instead of proper terminal UI. Now always shows terminal interface with the message displayed in the terminal output area.

## Checklist  

- [ ] Added or updated necessary tests (Optional).  
- [ ] Updated documentation to align with changes (Optional).  
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).  
- [x] My change does not involve the above items.