### PR TITLE
fix(tarko-agent-ui): preserve multimodal content format when navigating from home page

### DIFF
--- a/multimodal/tarko/agent-ui/src/standalone/home/CreatingPage.tsx
+++ b/multimodal/tarko/agent-ui/src/standalone/home/CreatingPage.tsx
@@ -5,9 +5,10 @@ import { useSession } from '@/common/hooks/useSession';
 import { SessionCreatingState } from '@/standalone/chat/components/SessionCreatingState';
 import { globalRuntimeSettingsAtom, resetGlobalRuntimeSettingsAction } from '@/common/state/atoms/globalRuntimeSettings';
 import { createSessionAction } from '@/common/state/actions/sessionActions';
+import { ChatCompletionContentPart } from '@tarko/agent-interface';
 
 interface LocationState {
-  query?: string;
+  query?: string | ChatCompletionContentPart[];
   runtimeSettings?: Record<string, any>; // Persistent settings for the session
   agentOptions?: Record<string, any>; // One-time options for this specific task
 }
@@ -45,7 +46,7 @@ const CreatingPage: React.FC = () => {
         const state = location.state as LocationState | null;
         let runtimeSettings: Record<string, any> = {}; // Persistent session settings
         let agentOptions: Record<string, any> = {}; // One-time task options
-        let query: string | null = null;
+        let query: string | ChatCompletionContentPart[] | null = null;
 
         // Source 1: Router state (highest priority)
         if (state) {

--- a/multimodal/tarko/agent-ui/src/standalone/home/WelcomePage.tsx
+++ b/multimodal/tarko/agent-ui/src/standalone/home/WelcomePage.tsx
@@ -95,7 +95,7 @@ const WelcomePage: React.FC = () => {
       // Navigate to creating page with runtime settings
       navigate('/creating', {
         state: {
-          query: typeof content === 'string' ? content : JSON.stringify(content),
+          query: content, // Keep original format for multimodal content
           runtimeSettings: selectedRuntimeSettings
         }
       });


### PR DESCRIPTION
## Summary

Fixed multimodal content being serialized as text when navigating from home page, preventing context overflow when images are pasted and sent from the Welcome Page.

### Before

<img width="1696" height="628" alt="image" src="https://github.com/user-attachments/assets/af6f2ef6-52bf-40b9-bc61-5b1dd93b2ee7" />

### After

<img width="1698" height="758" alt="image" src="https://github.com/user-attachments/assets/8ddb6a35-cbd6-4b07-ac31-f19110b40d68" />


## Checklist  

- [x] Added or updated necessary tests (Optional).  
- [ ] Updated documentation to align with changes (Optional).  
- [x] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).  
- [ ] My change does not involve the above items.