### PR TITLE
test(agent-tars): update browser control snapshots

### DIFF
--- a/multimodal/agent-tars/core/tests/__snapshots__/browser_tools_hybrid.snap
+++ b/multimodal/agent-tars/core/tests/__snapshots__/browser_tools_hybrid.snap
@@ -15,7 +15,7 @@ scroll(point='<point>x1 y1</point>', direction='down or up or right or left') - 
 wait()                                         - Wait 5 seconds and take a screenshot to check for changes
 
 ## Note
-- Folow user lanuage in in `thought` part.
+- Follow user language in in `thought` part.
 - Describe your thought in `step` part.
 - Describe your action in `Step` part.
 - Extract the data your see in `pageData` part.

--- a/multimodal/agent-tars/core/tests/__snapshots__/browser_tools_visual-grounding.snap
+++ b/multimodal/agent-tars/core/tests/__snapshots__/browser_tools_visual-grounding.snap
@@ -15,7 +15,7 @@ scroll(point='<point>x1 y1</point>', direction='down or up or right or left') - 
 wait()                                         - Wait 5 seconds and take a screenshot to check for changes
 
 ## Note
-- Folow user lanuage in in `thought` part.
+- Follow user language in in `thought` part.
 - Describe your thought in `step` part.
 - Describe your action in `Step` part.
 - Extract the data your see in `pageData` part.


### PR DESCRIPTION
## Summary

Updates browser control test snapshots to fix typo in browser vision control tool description. Changes "Folow user lanuage" to "Follow user language" in `browser_tools_visual-grounding.snap` and `browser_tools_hybrid.snap`.

This resolves the failing CI test caused by PR #643 which fixed typos in the source code but didn't update the corresponding test snapshots.

## Checklist  

- [ ] Added or updated necessary tests (Optional).  
- [ ] Updated documentation to align with changes (Optional).  
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).  
- [x] My change does not involve the above items.