### PR TITLE
WIP: fix(tarko-agent-ui): add null safety check for toolCall in RawModeRenderer

### DIFF
--- a/multimodal/tarko/agent-ui/src/standalone/workspace/components/RawModeRenderer.tsx
+++ b/multimodal/tarko/agent-ui/src/standalone/workspace/components/RawModeRenderer.tsx
@@ -146,7 +146,24 @@ export const RawModeRenderer: React.FC<RawModeRendererProps> = ({ toolMapping })
   const responseRef = useRef<JSONViewerRef>(null);
   const metadataRef = useRef<JSONViewerRef>(null);
 
-  const hasParameters = toolCall.arguments && Object.keys(toolCall.arguments).length > 0;
+  // Safety check: if toolCall is null or undefined, show error state
+  if (!toolCall) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <div className="text-center">
+          <div className="text-red-400 mb-2">⚠️</div>
+          <p className="text-red-600 dark:text-red-400 font-medium mb-2">
+            Invalid Tool Call Data
+          </p>
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            The tool call data is missing or corrupted.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const hasParameters = toolCall?.arguments && Object.keys(toolCall.arguments).length > 0;
   const hasMetadata = toolResult?._extra && Object.keys(toolResult._extra).length > 0;
 
   return (
@@ -155,7 +172,7 @@ export const RawModeRenderer: React.FC<RawModeRendererProps> = ({ toolMapping })
       <CollapsibleSection
         title="Input"
         icon={<FiPlay size={16} className="text-blue-500" />}
-        timestamp={toolCall.timestamp ? formatTimestamp(toolCall.timestamp, true) : undefined}
+        timestamp={toolCall?.timestamp ? formatTimestamp(toolCall.timestamp, true) : undefined}
         defaultOpen={true}
       >
         <div className="space-y-4">
@@ -166,7 +183,7 @@ export const RawModeRenderer: React.FC<RawModeRendererProps> = ({ toolMapping })
               Tool
             </div>
             <div className="font-mono text-sm bg-white dark:bg-slate-900 text-slate-900 dark:text-slate-100 px-3 py-2 rounded-lg border border-slate-200 dark:border-slate-700">
-              {toolCall.name}
+              {toolCall?.name || 'Unknown Tool'}
             </div>
           </div>
 
@@ -180,7 +197,7 @@ export const RawModeRenderer: React.FC<RawModeRendererProps> = ({ toolMapping })
               <div className="bg-white dark:bg-slate-900 rounded-lg border border-slate-200 dark:border-slate-700 p-3">
                 <JSONViewer
                   ref={parametersRef}
-                  data={toolCall.arguments}
+                  data={toolCall?.arguments || {}}
                   emptyMessage="No parameters"
                 />
               </div>


### PR DESCRIPTION
## Summary

Fixed a `TypeError: Cannot read properties of null (reading 'arguments')` error that occurred when clicking the Raw button in Workspace Tool Renderer. The error was caused by accessing `toolCall.arguments` without null checking when the `toolCall` object was null or undefined.

**Changes made:**
- Added null safety check for `toolCall` before accessing its properties
- Added error state UI when tool call data is missing or corrupted  
- Used optional chaining (`?.`) for safer property access
- Prevents runtime errors when clicking Raw button on invalid tool data

**Error fixed:**
```
VM8:2 Uncaught TypeError: Cannot read properties of null (reading 'arguments')
    at as (VM11:7:9317)
    at ad (VM8:2:58518)
    at i (VM8:2:119386)
    at oO (VM8:2:99063)
    at oF (VM8:2:98933)
    at ox (VM8:2:95704)
    at oC (VM8:2:96093)
    at r8 (VM8:2:44924)
    at VM8:2:93618
```

## Checklist  

- [ ] Added or updated necessary tests (Optional).  
- [ ] Updated documentation to align with changes (Optional).  
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).  
- [x] My change does not involve the above items.