### PR TITLE
Fix RCE Vuln: Remove `DANGEROUSLY_OMIT_AUTH=true` from dev scripts

### DIFF
--- a/packages/agent-infra/mcp-servers/browser/package.json
+++ b/packages/agent-infra/mcp-servers/browser/package.json
@@ -37,9 +37,9 @@
   ],
   "scripts": {
     "build": "shx rm -rf dist && rslib build && shx chmod +x dist/*.{js,cjs}",
-    "dev": "DANGEROUSLY_OMIT_AUTH=true npx -y @modelcontextprotocol/inspector tsx src/index.ts",
+    "dev": "npx -y @modelcontextprotocol/inspector tsx src/index.ts",
     "dev:server": "tsx --watch src/index.ts --port 3000 --vision",
-    "dev:vision": "DANGEROUSLY_OMIT_AUTH=true npx -y @modelcontextprotocol/inspector tsx src/index.ts --vision",
+    "dev:vision": "npx -y @modelcontextprotocol/inspector tsx src/index.ts --vision",
     "prepare": "npm run build",
     "prepublishOnly": "tsx scripts/update-readme.ts",
     "test": "vitest run --config=./vitest.config.mts",


### PR DESCRIPTION
## Summary

The `DANGEROUSLY_OMIT_AUTH=true` allows any website visited by a developer to maliciously attack the MCP server running locally on the dev machine, achieving remote code execution.

https://www.tenable.com/blog/how-tenable-research-discovered-a-critical-remote-code-execution-vulnerability-on-anthropic

## Checklist  

<!--  Before submitting the pull request, ensure the following items are checked: -->

- [ ] Added or updated necessary tests (Optional).  
- [ ] Updated documentation to align with changes (Optional).  
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).  
- [ ] My change does not involve the above items. 
