### PR TITLE
fix: remove debug console.logs and fix typos

### DIFF
--- a/multimodal/tarko/agent-server/src/utils/agent-resolver.ts
+++ b/multimodal/tarko/agent-server/src/utils/agent-resolver.ts
@@ -21,23 +21,23 @@ interface AgentResolutionOptions {
 }
 
 export async function resolveAgentImplementation(
-  implementaion?: AgentImplementation,
+  implementation?: AgentImplementation,
   options?: AgentResolutionOptions,
 ): Promise<AgentResolutionResult> {
-  if (!implementaion) {
-    throw new Error(`Missing agent implmentation`);
+  if (!implementation) {
+    throw new Error(`Missing agent implementation`);
   }
 
-  if (isAgentImplementationType(implementaion, 'module')) {
+  if (isAgentImplementationType(implementation, 'module')) {
     return {
-      agentName: implementaion.label ?? implementaion.constructor.label ?? 'Anonymous',
-      agentConstructor: implementaion.constructor,
-      agioProviderConstructor: implementaion.agio,
+      agentName: implementation.label ?? implementation.constructor.label ?? 'Anonymous',
+      agentConstructor: implementation.constructor,
+      agioProviderConstructor: implementation.agio,
     };
   }
 
-  if (isAgentImplementationType(implementaion, 'modulePath')) {
-    const agentModulePathIdentifier = implementaion.value;
+  if (isAgentImplementationType(implementation, 'modulePath')) {
+    const agentModulePathIdentifier = implementation.value;
 
     try {
       // Build resolve options with workspace path if provided
@@ -74,9 +74,9 @@ export async function resolveAgentImplementation(
       }
 
       return {
-        agentName: implementaion.label ?? agentConstructor.label ?? 'Anonymous',
+        agentName: implementation.label ?? agentConstructor.label ?? 'Anonymous',
         agentConstructor,
-        agioProviderConstructor: implementaion.agio,
+        agioProviderConstructor: implementation.agio,
       };
     } catch (error) {
       throw new Error(
@@ -85,5 +85,5 @@ export async function resolveAgentImplementation(
     }
   }
 
-  throw new Error(`Non-supported agent type: ${implementaion.type}`);
+  throw new Error(`Non-supported agent type: ${implementation.type}`);
 }

--- a/packages/ui-tars/visualizer/src/component/detail-panel.tsx
+++ b/packages/ui-tars/visualizer/src/component/detail-panel.tsx
@@ -170,8 +170,6 @@ const DetailPanel = (): JSX.Element => {
           (nextTask.timing.start - activeTask.timing.start) / playbackSpeed;
       }
 
-      console.log('nextIndex', nextIndex, nextTask);
-
       timeoutId = setTimeout(() => {
         setActiveTask(nextTask);
       }, delay);
@@ -227,8 +225,6 @@ const DetailPanel = (): JSX.Element => {
       value: type,
     };
   });
-
-  console.log('startReplay', startReplay);
 
   return (
     <div className="detail-panel">


### PR DESCRIPTION
## Description

Remove debug console.log statements and fix variable name typos.

## Changes

### packages/ui-tars/visualizer/src/component/detail-panel.tsx
- Remove debug `console.log('nextIndex', nextIndex, nextTask);` (line 173)
- Remove debug `console.log('startReplay', startReplay);` (line 231)

### multimodal/tarko/agent-server/src/utils/agent-resolver.ts
- Fix typo: `implementaion` → `implementation` (parameter name)
- Fix typo: `implmentation` → `implementation` (error message)
- Update all references throughout the function

## Benefits

- Cleaner console output in production
- Correct variable naming improves code readability
- Reduces confusion from misspelled identifiers

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>