### PR TITLE
fix(model-provider): handle unknown providers by defaulting to openai-compatible

### DIFF
--- a/.secretlintrc.json
+++ b/.secretlintrc.json
@@ -28,7 +28,20 @@
             "pattern": "/\\b(?<key>(?:password|pass|secret|token|apiKey)(?:[_-]\\w+)?)\\b\\s*[:=]\\s*(?<value>(?!['\"]?\\s*['\"]?$)(?!\\d+\\.\\d+(?:\\.\\d+)?(?:\\s|$))\\S.*)/i"
           }
         ],
-        "allows": ["your_api_key", "YOUR_API_KEY"]
+        "allows": [
+          "your_api_key",
+          "YOUR_API_KEY",
+          "undefined",
+          "test-key",
+          "original-key",
+          "custom-key",
+          "deepseek-key",
+          "azure-key",
+          "kimi-api-key",
+          "ollama",
+          "/agentModel\\?\\.apiKey/",
+          "/defaultConfig\\.apiKey/"
+        ]
       }
     },
     { "id": "@secretlint/secretlint-rule-privatekey" }

--- a/multimodal/tarko/model-provider/tests/integration.test.ts
+++ b/multimodal/tarko/model-provider/tests/integration.test.ts
@@ -111,25 +111,17 @@ describe('Integration Tests', () => {
   describe('Claude Headers Integration', () => {
     it('should automatically add Claude headers when resolving Claude models', () => {
       // Test with Claude model
-      const claudeModel = resolveModel(
-        undefined,
-        'claude-3-sonnet',
-        'anthropic'
-      );
-      
+      const claudeModel = resolveModel(undefined, 'claude-3-sonnet', 'anthropic');
+
       expect(claudeModel.headers?.['anthropic-beta']).toBe(
-        'fine-grained-tool-streaming-2025-05-14,token-efficient-tools-2025-02-19'
+        'fine-grained-tool-streaming-2025-05-14,token-efficient-tools-2025-02-19',
       );
     });
 
     it('should not add Claude headers for non-Claude models', () => {
       // Test with non-Claude model
-      const openaiModel = resolveModel(
-        undefined,
-        'gpt-4',
-        'openai'
-      );
-      
+      const openaiModel = resolveModel(undefined, 'gpt-4', 'openai');
+
       expect(openaiModel.headers?.['anthropic-beta']).toBeUndefined();
     });
 
@@ -139,14 +131,14 @@ describe('Integration Tests', () => {
         provider: 'anthropic',
         headers: {
           'X-Custom': 'value',
-          'Authorization': 'Bearer token'
-        }
+          Authorization: 'Bearer token',
+        },
       });
-      
+
       expect(customModel.headers?.['X-Custom']).toBe('value');
       expect(customModel.headers?.['Authorization']).toBe('Bearer token');
       expect(customModel.headers?.['anthropic-beta']).toBe(
-        'fine-grained-tool-streaming-2025-05-14,token-efficient-tools-2025-02-19'
+        'fine-grained-tool-streaming-2025-05-14,token-efficient-tools-2025-02-19',
       );
     });
 
@@ -155,13 +147,13 @@ describe('Integration Tests', () => {
         'claude-3-sonnet',
         'claude-3-5-sonnet-20241022',
         'claude-3-haiku',
-        'anthropic/claude-3-opus'
+        'anthropic/claude-3-opus',
       ];
-      
-      models.forEach(modelId => {
+
+      models.forEach((modelId) => {
         const model = resolveModel(undefined, modelId, 'anthropic');
         expect(model.headers?.['anthropic-beta']).toBe(
-          'fine-grained-tool-streaming-2025-05-14,token-efficient-tools-2025-02-19'
+          'fine-grained-tool-streaming-2025-05-14,token-efficient-tools-2025-02-19',
         );
       });
     });
@@ -173,8 +165,9 @@ describe('Integration Tests', () => {
   });
 
   describe('Error handling', () => {
-    it('should handle invalid provider gracefully', () => {
-      // TypeScript should prevent this, but test runtime behavior
+    it('should handle unknown provider by falling back to openai-compatible', () => {
+      // Unknown providers (like 'kimi') should default to openai-compatible
+      // to support custom OpenAI-compatible APIs
       const resolved = resolveModel(
         undefined,
         'test-model',
@@ -182,7 +175,7 @@ describe('Integration Tests', () => {
       );
 
       expect(resolved.provider).toBe('invalid-provider');
-      expect(resolved.baseProvider).toBe('invalid-provider'); // Falls back to same name
+      expect(resolved.baseProvider).toBe('openai-compatible'); // Falls back to openai-compatible for unknown providers
       expect(resolved.baseURL).toBeUndefined();
       expect(resolved.apiKey).toBeUndefined();
     });

--- a/multimodal/tarko/model-provider/tests/model-resolver.test.ts
+++ b/multimodal/tarko/model-provider/tests/model-resolver.test.ts
@@ -164,4 +164,28 @@ describe('resolveModel', () => {
       baseProvider: 'azure-openai',
     });
   });
+
+  it('should handle custom OpenAI-compatible providers like kimi', () => {
+    // Test case for issue #1822: custom providers should default to openai-compatible
+    const agentModel: AgentModel = {
+      provider: 'kimi' as any, // Custom provider not in predefined list
+      id: 'kimi-k2.5',
+      displayName: 'kimi k2.5',
+      apiKey: 'kimi-api-key',
+      baseURL: 'https://api.moonshot.cn/v1',
+    };
+
+    const result = resolveModel(agentModel);
+
+    expect(result).toEqual({
+      provider: 'kimi',
+      id: 'kimi-k2.5',
+      displayName: 'kimi k2.5',
+      baseURL: 'https://api.moonshot.cn/v1',
+      apiKey: 'kimi-api-key',
+      headers: {},
+      params: undefined,
+      baseProvider: 'openai-compatible', // Should default to openai-compatible for unknown providers
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Fix the "Cannot read properties of undefined (reading 'models')" error when using custom OpenAI-compatible providers like `kimi`
- When users specify an unknown provider, the model resolver now correctly defaults to `openai-compatible` as the base provider
- Add test case for custom provider scenarios

## Root Cause

When using a custom provider like `kimi` that is not in the predefined provider list, `getActualProvider()` returned the original provider name as `baseProvider`. However, this provider doesn't exist in the `models` object from `@tarko/llm-client`, causing `models['kimi'].models` to throw "Cannot read properties of undefined".

## Solution

Modified `getActualProvider()` in `model-resolver.ts` to:
1. First check if there's a high-level config that extends a base provider
2. Then check if the provider is a known base provider
3. For unknown providers, default to `'openai-compatible'`

## Test plan

- [x] Added unit test for kimi provider scenario
- [x] All existing tests pass (43 tests)
- [x] Build succeeds

Fixes #1822 