### PR TITLE
Fix broken link in Chinese README

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -39,7 +39,7 @@
         <br>
         <br>
         它主要提供
-        <a href="https://github.com/bytedance/UI-TARS-desktop/blob/docs/new-readme/docs/quick-start.md#get-model-and-run" target="_blank">本地</a>计算机以及浏览器操作器。
+        <a href="https://github.com/bytedance/UI-TARS-desktop/blob/main/docs/quick-start.md#get-model-and-run" target="_blank">本地</a>计算机以及浏览器操作器。
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
Corrects broken link path in Chinese README. The link path blob/docs/new-readme/docs/quick-start.md has been fixed to blob/main/docs/quick-start.md.