### PR TITLE
fix(browser-use): support max_completion_tokens for gpt-5 models

### DIFF
--- a/packages/agent-infra/browser-use/src/agent/helper.ts
+++ b/packages/agent-infra/browser-use/src/agent/helper.ts
@@ -44,8 +44,8 @@ export function createChatModel(
         };
       }
 
-      // O series models have different parameters
-      if (modelName.startsWith('o')) {
+      // O series and gpt-5 models require max_completion_tokens instead of max_tokens
+      if (modelName.startsWith('o') || modelName.startsWith('gpt-5')) {
         args.modelKwargs = {
           max_completion_tokens: maxCompletionTokens,
         };


### PR DESCRIPTION
## Summary

Fixes #1192

GPT-5 models require `max_completion_tokens` instead of `max_tokens`, similar to the existing o-series models (o3, o4-mini, etc.). This PR extends the model name check in `createChatModel` to also match `gpt-5` prefixed models.

**Code change:** `packages/agent-infra/browser-use/src/agent/helper.ts` — added `modelName.startsWith('gpt-5')` to the existing condition.

## Checklist

- [ ] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [x] My change does not involve the above items.