### PR TITLE
fix: disable source map generation for published packages

### DIFF
--- a/multimodal/agent-tars/core/rslib.config.ts
+++ b/multimodal/agent-tars/core/rslib.config.ts
@@ -35,6 +35,6 @@ export default defineConfig({
   output: {
     target: 'node',
     cleanDistPath: false,
-    sourceMap: true,
+    sourceMap: false,
   },
 });

--- a/multimodal/agent-tars/interface/rslib.config.ts
+++ b/multimodal/agent-tars/interface/rslib.config.ts
@@ -35,6 +35,6 @@ export default defineConfig({
   output: {
     target: 'node',
     cleanDistPath: false,
-    sourceMap: true,
+    sourceMap: false,
   },
 });

--- a/multimodal/tarko/agent-server/rslib.config.ts
+++ b/multimodal/tarko/agent-server/rslib.config.ts
@@ -35,7 +35,7 @@ export default defineConfig({
   output: {
     target: 'node',
     cleanDistPath: true,
-    sourceMap: true,
+    sourceMap: false,
   },
   tools: {
     rspack: {

--- a/multimodal/tarko/agent-ui/rsbuild.config.ts
+++ b/multimodal/tarko/agent-ui/rsbuild.config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
     cleanDistPath: true,
     inlineScripts: true,
     inlineStyles: true,
+    sourceMap: false,
     distPath: {
       root: resolve(__dirname, '../agent-ui-builder/static'),
     },


### PR DESCRIPTION
## Summary

Closes #829

Source maps (`.map` files) were being included in published npm packages, significantly inflating package sizes (some vendor map files were 3-5MB each as shown in the issue).

This PR disables source map generation for packages that are published to npm:

- **`@tarko/agent-server`** — `rslib.config.ts`: `sourceMap: false`
- **`@agent-tars/core`** — `rslib.config.ts`: `sourceMap: false`  
- **`@agent-tars/interface`** — `rslib.config.ts`: `sourceMap: false`
- **`@tarko/agent-ui`** — `rsbuild.config.ts`: `sourceMap: false` (web UI static files bundled into `@tarko/agent-ui-builder/static`)

This aligns with the pattern already used by `@agent-tars/cli` and `@tarko/omni-*` packages which already have `sourceMap: false`.

## Checklist

- [ ] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [x] My change does not involve the above items.