### PR TITLE
fix(agent-ui): display run_script tool arguments in chat

### DIFF
--- a/multimodal/tarko/agent-ui/src/standalone/chat/Message/components/ToolCalls.tsx
+++ b/multimodal/tarko/agent-ui/src/standalone/chat/Message/components/ToolCalls.tsx
@@ -136,6 +136,8 @@ export const ToolCalls: React.FC<ToolCallsProps> = ({
               : '';
         case 'run_command':
           return args.command || (status === 'constructing' ? 'preparing command...' : '');
+        case 'run_script':
+          return args.script || (status === 'constructing' ? 'preparing script...' : '');
         case 'read_file':
         case 'write_file':
         case 'edit_file':
@@ -203,6 +205,8 @@ export const ToolCalls: React.FC<ToolCallsProps> = ({
         return 'List Files';
       case 'run_command':
         return 'Run Command';
+      case 'run_script':
+        return 'Run Script';
       case 'read_file':
         return 'Read File';
       case 'write_file':


### PR DESCRIPTION
## Summary

Add `run_script` case handling to `ToolCalls.tsx` so that the script content is displayed inline in chat tool calls.

### Problem
When the `run_script` tool is called, the chat UI shows the tool call but doesn't display the script content. This is because `getArgumentInfo()` has no `case 'run_script':` — it falls through to the default case which returns an empty string.

### Changes
- Added `case 'run_script':` to `getArgumentInfo()` to display `args.script` inline, consistent with how `run_command` displays `args.command`
- Added `run_script` → `'Run Script'` mapping to `getToolDisplayName()`

Closes #822

## Checklist

- [x] My changes don't break existing behavior
- [ ] I've added tests (N/A — UI display logic, no existing unit tests for this component)
- [ ] I've updated documentation (N/A)
- [x] No breaking changes introduced