### PR TITLE
fix(agent-ui): add search_files tool rendering support

### DIFF
--- a/multimodal/tarko/agent-ui/src/common/utils/tool-renderers/index.ts
+++ b/multimodal/tarko/agent-ui/src/common/utils/tool-renderers/index.ts
@@ -15,6 +15,7 @@ const TOOL_TO_RENDERER_CONFIG: ToolToRendererCondition[] = [
   { toolName: 'edit_file', renderer: 'diff_result' },
   { toolName: 'run_command', renderer: 'command_result' },
   { toolName: 'run_script', renderer: 'script_result' },
+  { toolName: 'search_files', renderer: 'command_result' },
   { toolName: 'LinkReader', renderer: 'link_reader' },
   { toolName: 'Search', renderer: 'search_result' },
   { toolName: 'execute_bash', renderer: 'command_result' },

--- a/multimodal/tarko/agent-ui/src/standalone/chat/Message/components/ToolCalls.tsx
+++ b/multimodal/tarko/agent-ui/src/standalone/chat/Message/components/ToolCalls.tsx
@@ -136,6 +136,12 @@ export const ToolCalls: React.FC<ToolCallsProps> = ({
               : '';
         case 'run_command':
           return args.command || (status === 'constructing' ? 'preparing command...' : '');
+        case 'search_files':
+          return args.pattern
+            ? `${args.pattern}${args.path ? ` in ${args.path}` : ''}`
+            : status === 'constructing'
+              ? 'preparing search...'
+              : '';
         case 'read_file':
         case 'write_file':
         case 'edit_file':
@@ -201,6 +207,8 @@ export const ToolCalls: React.FC<ToolCallsProps> = ({
         return 'Web Search';
       case 'list_directory':
         return 'List Files';
+      case 'search_files':
+        return 'Search Files';
       case 'run_command':
         return 'Run Command';
       case 'read_file':
@@ -223,6 +231,7 @@ export const ToolCalls: React.FC<ToolCallsProps> = ({
       'write_file',
       'edit_file',
       'list_directory',
+      'search_files',
       'str_replace_editor',
     ];
     return fileTools.includes(toolName);


### PR DESCRIPTION
## Summary

Map `search_files` tool to the `command_result` renderer in the workspace panel and add inline argument display in chat tool calls.

### Problem
The `search_files` tool result falls through to the default JSON renderer, displaying raw JSON structure instead of formatted output.

### Changes
- Added `search_files` → `command_result` mapping in `tool-renderers/index.ts` so workspace panel renders results with the terminal/command output renderer
- Added `case 'search_files':` to `getArgumentInfo()` in `ToolCalls.tsx` to show the search pattern and path inline
- Added `'Search Files'` display name mapping
- Added `search_files` to `isFileRelatedTool()` list

Closes #846

## Checklist

- [x] My changes don't break existing behavior
- [ ] I've added tests (N/A — UI display mapping, no existing unit tests for this component)
- [ ] I've updated documentation (N/A)
- [x] No breaking changes introduced