### PR TITLE
fix(browser-operator): use model-specified scroll amount instead of hard-coded 500

### DIFF
--- a/packages/ui-tars/operators/browser-operator/src/browser-operator.ts
+++ b/packages/ui-tars/operators/browser-operator/src/browser-operator.ts
@@ -531,7 +531,8 @@ export class BrowserOperator extends Operator {
     const page = await this.getActivePage();
 
     const { direction } = inputs;
-    const scrollAmount = 500;
+    const scrollAmount =
+      inputs.amount !== undefined ? Number(inputs.amount) || 500 : 500;
 
     this.logger.info(`Scrolling ${direction} by ${scrollAmount}px`);
 
@@ -541,6 +542,12 @@ export class BrowserOperator extends Operator {
         break;
       case 'down':
         await page.mouse.wheel({ deltaY: scrollAmount });
+        break;
+      case 'left':
+        await page.mouse.wheel({ deltaX: -scrollAmount });
+        break;
+      case 'right':
+        await page.mouse.wheel({ deltaX: scrollAmount });
         break;
       default:
         this.logger.warn(`Unsupported scroll direction: ${direction}`);


### PR DESCRIPTION
## Summary

Fixes #903

The `handleScroll` method in `browser-operator.ts` hard-coded `scrollAmount = 500`, ignoring the `amount` parameter from the model output (e.g. `scroll(direction='down', amount=200)`). The action parser correctly extracts `amount` into `inputs.amount`, but it was never used.

**Changes:**
- Use `inputs.amount` (with fallback to 500) for scroll distance
- Add support for `left` and `right` scroll directions (previously only `up`/`down` were handled)

## Checklist

- [ ] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [ ] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [x] My change does not involve the above items.