### PR TITLE
fix(agent): await endExecution in onAgentLoopEnd to ensure cleanup completes

### DIFF
--- a/multimodal/tarko/agent/src/agent/agent.ts
+++ b/multimodal/tarko/agent/src/agent/agent.ts
@@ -616,9 +616,11 @@ Provide concise and accurate responses.`;
 
     // End execution if not already ended
     if (this.executionController.isExecuting()) {
-      this.executionController.endExecution(AgentStatus.IDLE).catch((err) => {
+      try {
+        await this.executionController.endExecution(AgentStatus.IDLE);
+      } catch (err) {
         this.logger.error(`Error ending execution: ${err}`);
-      });
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes #1061

In streaming mode, `onAgentLoopEnd` called `endExecution()` with `.catch()` (fire-and-forget) instead of `await`. This meant cleanup handlers—including the one that sends the `agent_run_end` event—could complete after the method returned, causing the stream adapter to never receive the completion signal.

**Changes:**
- Changed `endExecution().catch(...)` to `try { await endExecution() } catch`
- This ensures cleanup (including `agent_run_end` event emission) completes before `onAgentLoopEnd` returns

## Checklist

- [ ] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [x] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [ ] My change does not involve the above items.