### PR TITLE
fix(agent-tars): skip browser_vision_control screenshot on empty pages

### DIFF
--- a/multimodal/agent-tars/core/src/environments/local/browser/browser-gui-agent.ts
+++ b/multimodal/agent-tars/core/src/environments/local/browser/browser-gui-agent.ts
@@ -281,6 +281,26 @@ wait()                                         - Wait 5 seconds and take a scree
       const { originalSize, screenshotTime, compressedSize, compressedBase64, currentUrl } =
         await this.screenshot();
 
+      // Skip sending screenshot for empty pages — the agent should navigate first
+      if (!currentUrl || currentUrl === 'about:blank') {
+        this.logger.info('Page is empty (about:blank), skipping screenshot');
+        const emptyPageEvent = eventStream.createEvent('environment_input', {
+          content: [
+            {
+              type: 'text',
+              text: 'Browser is open but no page is loaded (about:blank). Use browser_navigate to open a URL before using browser_vision_control.',
+            },
+          ],
+          description: 'Browser Status',
+          metadata: {
+            type: 'screenshot',
+            url: currentUrl || 'about:blank',
+          },
+        });
+        eventStream.sendEvent(emptyPageEvent);
+        return;
+      }
+
       this.currentScreenshot = compressedBase64;
 
       // Calculate compression ratio and percentage


### PR DESCRIPTION
## Summary

Fixes #902

When the browser page is `about:blank` (no URL loaded), the agent would take a screenshot and send it to the LLM, which then uselessly invoked `browser_vision_control` on the empty page. This wasted resources and confused users.

**Changes:**
- In `onEachAgentLoopStart()`, detect when the current URL is `about:blank` or empty
- Instead of sending a screenshot, send a text-only `environment_input` event instructing the agent to navigate to a URL first before attempting visual browser control

## Checklist

- [ ] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [x] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [ ] My change does not involve the above items.