### PR TITLE
fix: prevent tray click event listener from being added multiple times

### DIFF
--- a/apps/ui-tars/src/main/tray.ts
+++ b/apps/ui-tars/src/main/tray.ts
@@ -42,6 +42,7 @@ export async function createTray() {
       // 根据状态添加或移除点击事件监听
       if (state.status === StatusEnum.RUNNING) {
         tray?.setImage(pauseIcon);
+        tray?.removeListener('click', handleTrayClick);
         tray?.on('click', handleTrayClick);
       } else {
         tray?.setImage(normalIcon);


### PR DESCRIPTION
### Description (描述)
```markdown
## 🐛 Problem

The tray click event listener is added every time the app state transitions to `RUNNING`, but the old listener may not be removed first. This can cause:

- ❌ **Memory leak**: Listeners accumulate with each state transition
- ❌ **Duplicate execution**: Each tray click triggers `stopRun()` multiple times
- ❌ **Performance degradation**: More listeners = slower response over time

**Current behavior**:
```typescript
if (state.status === StatusEnum.RUNNING) {
  tray?.on('click', handleTrayClick);  // ⚠️ Adds listener without removing old one
}
```

**Issue**:
- State change #1: 1 listener ✅
- State change #2: 2 listeners ⚠️
- State change #3: 3 listeners ⚠️⚠️
- Click tray → `stopRun()` called 3 times 🐛

---

## ✅ Solution

Use **defensive programming**: always remove the listener before adding it to ensure exactly one instance.

**Fixed behavior**:
```typescript
if (state.status === StatusEnum.RUNNING) {
  tray?.removeListener('click', handleTrayClick);  // Remove old listener
  tray?.on('click', handleTrayClick);               // Add new listener
}
```

**Result**:
- State change #1: 1 listener ✅
- State change #2: 1 listener ✅
- State change #3: 1 listener ✅
- Click tray → `stopRun()` called exactly once ✅

---

## 📝 Changes

**File**: `apps/ui-tars/src/main/tray.ts`

**Modification**:
- Added `removeListener` call before `on` to prevent listener accumulation
- Ensures exactly one click listener is active at any time
- No changes to functionality, only improves reliability

**Code diff**:
```diff
  if (state.status === StatusEnum.RUNNING) {
    tray?.setImage(pauseIcon);
+   tray?.removeListener('click', handleTrayClick);
    tray?.on('click', handleTrayClick);
  } else {
    tray?.setImage(normalIcon);
    tray?.removeListener('click', handleTrayClick);
  }
```

**Statistics**:
- Files changed: 1
- Lines added: 1
- Lines removed: 0
- Net change: +1 line

---

## 🧪 Testing

- ✅ **TypeScript compilation**: Passes (`npm run typecheck`)
- ✅ **Code quality**: Follows project conventions
- ✅ **Logic verification**: Defensive programming ensures correctness

**Expected behavior**:
- Tray click always triggers exactly one `stopRun()` call
- No listener accumulation regardless of state transition frequency
- No memory leak from repeated state changes

---

## 📊 Severity & Impact

**Severity**: **Medium-High (6-7/10)**  
**Type**: Memory leak / Event listener management

**Impact**:
- ✅ **Prevents memory leak** - No listener accumulation
- ✅ **Ensures correct behavior** - One click = one action
- ✅ **Improves long-term stability** - No performance degradation
- ✅ **Defensive programming** - Works regardless of Electron's internal behavior

**Risk**: **Extremely Low**  
- Only adds one line before existing code
- `removeListener` is a no-op if listener doesn't exist
- No changes to normal execution flow
- No breaking changes

---

## 🔍 Related Issues

Fixes potential memory leak and duplicate event handling in tray click listener management.

---

**Testing scenarios**:
1. Start app, transition to RUNNING multiple times → Only 1 listener active
2. Click tray in RUNNING state → `stopRun()` called exactly once
3. Rapid state transitions → No memory growth
4. Long-running app with many transitions → Stable performance
```
