### PR TITLE
fix(ui-tars): add HTTP status check in fetchPresetFromUrl and handle unknown operator type

### DIFF
--- a/apps/ui-tars/src/main/services/runAgent.ts
+++ b/apps/ui-tars/src/main/services/runAgent.ts
@@ -161,7 +161,7 @@ export const runAgent = async (
       operatorType = 'browser';
       break;
     default:
-      break;
+      throw new Error(`Unsupported operator type: ${settings.operator}`);
   }
 
   let modelVersion = getModelVersion(settings.vlmProvider);

--- a/apps/ui-tars/src/main/store/setting.ts
+++ b/apps/ui-tars/src/main/store/setting.ts
@@ -132,6 +132,9 @@ export class SettingStore {
   public static async fetchPresetFromUrl(url: string): Promise<LocalStore> {
     try {
       const response = await fetch(url);
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
       const yamlContent = await response.text();
       return await this.importPresetFromText(yamlContent);
     } catch (error) {


### PR DESCRIPTION
## Summary

Two bug fixes in the main process:

### 1. Missing HTTP status check in `fetchPresetFromUrl()` (`setting.ts:134`)

`fetch()` does not throw on HTTP errors (4xx/5xx). Without checking `response.ok`, the YAML parser receives an error HTML page instead of YAML content, producing confusing parse errors.

**Fix:** Add `if (!response.ok)` check before parsing the response body.

### 2. Uninitialized `operator` on unknown enum value (`runAgent.ts:163`)

The `switch` statement over `settings.operator` silently falls through on unknown values (`default: break`), leaving the `operator` variable uninitialized. It is later accessed via non-null assertion (`operator!` at line 202), causing a runtime TypeError.

**Fix:** Throw an explicit error in the `default` branch.

## Checklist

- [x] Changes are focused and minimal
- [x] No unrelated changes included