### PR TITLE
feat(cli): add auto-learn feature for Android app UI mapping

### DIFF
--- a/packages/ui-tars/cli/src/auto-learn/__tests__/app-launcher.test.ts
+++ b/packages/ui-tars/cli/src/auto-learn/__tests__/app-launcher.test.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { describe, it, expect } from 'vitest';
+import { launchApp, adbClick, adbBack, adbHome, adbWake } from '../app-launcher';
+
+describe('app-launcher argument sanitization', () => {
+  describe('launchApp', () => {
+    it('should reject deviceId with shell injection characters', () => {
+      expect(() => launchApp('device1; rm -rf /', 'com.example.app')).toThrow();
+    });
+
+    it('should reject pkg with shell injection characters', () => {
+      expect(() => launchApp('device1', 'com.example.app; rm -rf /')).toThrow();
+    });
+
+    it('should accept valid package names', () => {
+      // This will fail at ADB level (no device), but should NOT throw sanitization error
+      try {
+        launchApp('emulator-5554', 'com.example.app');
+      } catch (err: any) {
+        // ADB error is expected, but NOT sanitization error
+        expect(err.message).not.toContain('Invalid argument');
+      }
+    });
+
+    it('should accept valid device IDs with dots and hyphens', () => {
+      try {
+        launchApp('192.168.1.1:5555', 'com.app');
+      } catch (err: any) {
+        expect(err.message).not.toContain('Invalid argument');
+      }
+    });
+
+    it('should reject pkg with spaces', () => {
+      expect(() => launchApp('device1', 'com.example app')).toThrow('Invalid argument');
+    });
+  });
+
+  describe('adbClick', () => {
+    it('should reject deviceId with injection characters', () => {
+      expect(() => adbClick('device; evil', 100, 200)).toThrow('Invalid argument');
+    });
+  });
+
+  describe('adbBack', () => {
+    it('should reject deviceId with injection characters', () => {
+      expect(() => adbBack('device; evil')).toThrow('Invalid argument');
+    });
+  });
+
+  describe('adbHome', () => {
+    it('should reject deviceId with injection characters', () => {
+      expect(() => adbHome('device; evil')).toThrow('Invalid argument');
+    });
+  });
+
+  describe('adbWake', () => {
+    it('should reject deviceId with injection characters', () => {
+      expect(() => adbWake('device; evil')).toThrow('Invalid argument');
+    });
+  });
+});

--- a/packages/ui-tars/cli/src/auto-learn/__tests__/page-signatures.test.ts
+++ b/packages/ui-tars/cli/src/auto-learn/__tests__/page-signatures.test.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  matchPageSignature,
+  getLayoutType,
+  isSecondaryPage,
+} from '../page-signatures';
+
+describe('matchPageSignature', () => {
+  it('should match home page features', () => {
+    expect(matchPageSignature('推荐卡片和banner轮播')).toBe('首页');
+    expect(matchPageSignature('banner推荐内容')).toBe('首页');
+  });
+
+  it('should match theater page features', () => {
+    expect(matchPageSignature('左侧分类筛选列表')).toBe('剧场');
+    expect(matchPageSignature('剧目卡片和分类筛选')).toBe('剧场');
+  });
+
+  it('should match messages page features', () => {
+    expect(matchPageSignature('消息列表聊天记录')).toBe('消息');
+  });
+
+  it('should match profile page features', () => {
+    expect(matchPageSignature('用户头像和钻石余额')).toBe('我的');
+    expect(matchPageSignature('个人中心设置')).toBe('我的');
+  });
+
+  it('should match secondary pages based on parent context', () => {
+    expect(matchPageSignature('剧目封面播放按钮', '剧场')).toBe('剧目详情');
+    expect(matchPageSignature('搜索框搜索结果', '首页')).toBe('搜索页');
+    expect(matchPageSignature('播放器全屏', '剧目详情')).toBe('播放页');
+  });
+
+  it('should return Unknown for unrecognized pages', () => {
+    expect(matchPageSignature('随机未知页面')).toBe('Unknown');
+  });
+
+  it('should use notFeatures to reduce false positives', () => {
+    // "推荐" would match 首页, but "左侧筛选" is a notFeature for 首页
+    // So this should match 剧场 instead
+    const result = matchPageSignature('左侧筛选和剧目列表');
+    expect(result).toBe('剧场');
+  });
+});
+
+describe('getLayoutType', () => {
+  it('should return correct layout for known pages', () => {
+    expect(getLayoutType('首页')).toBe('scrollable-feed');
+    expect(getLayoutType('剧场')).toBe('split-view');
+    expect(getLayoutType('消息')).toBe('list');
+    expect(getLayoutType('我的')).toBe('form');
+  });
+
+  it('should return unknown for pages without layout definition', () => {
+    expect(getLayoutType('AI伴侣')).toBe('unknown');
+    expect(getLayoutType('Unknown')).toBe('unknown');
+  });
+});
+
+describe('isSecondaryPage', () => {
+  it('should return true for secondary pages', () => {
+    expect(isSecondaryPage('剧目详情')).toBe(true);
+    expect(isSecondaryPage('搜索页')).toBe(true);
+    expect(isSecondaryPage('播放页')).toBe(true);
+    expect(isSecondaryPage('设置页')).toBe(true);
+  });
+
+  it('should return false for primary pages', () => {
+    expect(isSecondaryPage('首页')).toBe(false);
+    expect(isSecondaryPage('剧场')).toBe(false);
+    expect(isSecondaryPage('AI伴侣')).toBe(false);
+    expect(isSecondaryPage('消息')).toBe(false);
+    expect(isSecondaryPage('我的')).toBe(false);
+  });
+
+  it('should return false for unknown pages', () => {
+    expect(isSecondaryPage('Unknown')).toBe(false);
+  });
+});

--- a/packages/ui-tars/cli/src/auto-learn/__tests__/recording-operator.test.ts
+++ b/packages/ui-tars/cli/src/auto-learn/__tests__/recording-operator.test.ts
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { RecordingOperator } from '../recording-operator';
+import type { Operator, ScreenshotOutput, ExecuteParams, ExecuteOutput } from '@ui-tars/sdk/core';
+
+describe('RecordingOperator', () => {
+  let mockBaseOp: Operator;
+  let recordingOp: RecordingOperator;
+
+  const createScreenshotOutput = (base64 = 'mock-screenshot'): ScreenshotOutput => ({
+    base64,
+    scaleFactor: 2,
+  });
+
+  const createExecuteParams = (
+    actionType = 'click',
+    coords = [100, 200],
+    thought = '我要点击【按钮】',
+  ): ExecuteParams =>
+    ({
+      parsedPrediction: {
+        action_type: actionType,
+        action_inputs: { start_coords: coords },
+        thought,
+      },
+    }) as unknown as ExecuteParams;
+
+  beforeEach(() => {
+    mockBaseOp = {
+      screenshot: vi.fn().mockResolvedValue(createScreenshotOutput()),
+      execute: vi.fn().mockResolvedValue({} as ExecuteOutput),
+    } as unknown as Operator;
+
+    recordingOp = new RecordingOperator(mockBaseOp);
+  });
+
+  describe('screenshot', () => {
+    it('should delegate to base operator and cache last screenshot', async () => {
+      const result = await recordingOp.screenshot();
+
+      expect(mockBaseOp.screenshot).toHaveBeenCalled();
+      expect(result.base64).toBe('mock-screenshot');
+      expect(recordingOp.getLastScreenshot()).toBe('mock-screenshot');
+    });
+  });
+
+  describe('execute', () => {
+    it('should delegate to base operator', async () => {
+      const params = createExecuteParams();
+      await recordingOp.execute(params);
+
+      expect(mockBaseOp.execute).toHaveBeenCalledWith(params);
+    });
+
+    it('should record click actions with screenshot before', async () => {
+      await recordingOp.screenshot(); // Set last screenshot
+      await recordingOp.execute(createExecuteParams('click', [100, 200]));
+
+      const actions = recordingOp.getActions();
+      expect(actions).toHaveLength(1);
+      expect(actions[0].type).toBe('click');
+      expect(actions[0].inputs).toEqual({ start_coords: [100, 200] });
+      expect(actions[0].thought).toBe('我要点击【按钮】');
+      expect(actions[0].screenshotBefore).toBe('mock-screenshot');
+    });
+
+    it('should record non-click actions', async () => {
+      await recordingOp.execute(createExecuteParams('scroll', [200, 300], '向上滚动'));
+
+      const actions = recordingOp.getActions();
+      expect(actions[0].type).toBe('scroll');
+    });
+
+    it('should auto-finish after repeated clicks at same position', async () => {
+      // Click same position 4 times
+      for (let i = 0; i < 4; i++) {
+        await recordingOp.execute(createExecuteParams('click', [100, 200]));
+      }
+
+      const actions = recordingOp.getActions();
+      const finishedAction = actions.find((a) => a.type === 'finished');
+      expect(finishedAction).toBeDefined();
+      expect(finishedAction?.thought).toBe(
+        'Auto-finished due to repeated clicks at same position',
+      );
+    });
+
+    it('should not auto-finish for different click positions', async () => {
+      const positions = [
+        [100, 200],
+        [200, 300],
+        [300, 400],
+        [400, 500],
+      ];
+      for (const pos of positions) {
+        await recordingOp.execute(createExecuteParams('click', pos));
+      }
+
+      const actions = recordingOp.getActions();
+      expect(actions.find((a) => a.type === 'finished')).toBeUndefined();
+    });
+
+    it('should take after-screenshot for click actions', async () => {
+      await recordingOp.execute(createExecuteParams('click', [100, 200]));
+
+      // Should have called screenshot again for after-screenshot
+      expect(mockBaseOp.screenshot).toHaveBeenCalledTimes(1);
+      const immediateScreenshots = recordingOp.getImmediateScreenshots();
+      expect(immediateScreenshots).toHaveLength(1);
+      expect(immediateScreenshots[0].actionIndex).toBe(0);
+    });
+  });
+
+  describe('getActions', () => {
+    it('should return all recorded actions', async () => {
+      await recordingOp.execute(createExecuteParams('click', [100, 200]));
+      await recordingOp.execute(createExecuteParams('scroll', [200, 300]));
+      await recordingOp.execute(createExecuteParams('type'));
+
+      expect(recordingOp.getActions()).toHaveLength(3);
+    });
+
+    it('should return empty array initially', () => {
+      expect(recordingOp.getActions()).toEqual([]);
+    });
+  });
+});

--- a/packages/ui-tars/cli/src/auto-learn/__tests__/utils.test.ts
+++ b/packages/ui-tars/cli/src/auto-learn/__tests__/utils.test.ts
@@ -1,0 +1,270 @@
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  extractCoords,
+  parseBbox,
+  guessElementType,
+  guessActionType,
+  extractElementName,
+  generateElementId,
+  generateTabName,
+  isSameElement,
+  deduplicateTabs,
+  deduplicateElements,
+  mapFile,
+  saveScreenshot,
+  DEDUP_THRESHOLD,
+} from '../utils';
+
+describe('extractCoords', () => {
+  it('should extract start_coords from action inputs', () => {
+    const inputs = { start_coords: [100, 200] };
+    expect(extractCoords(inputs)).toEqual([100, 200]);
+  });
+
+  it('should return empty array when start_coords is missing', () => {
+    expect(extractCoords({})).toEqual([]);
+  });
+
+  it('should return empty array when start_coords has less than 2 elements', () => {
+    expect(extractCoords({ start_coords: [100] })).toEqual([]);
+  });
+
+  it('should return empty array when start_coords is not an array', () => {
+    expect(extractCoords({ start_coords: 'invalid' })).toEqual([]);
+  });
+});
+
+describe('parseBbox', () => {
+  it('should parse bbox string to number array', () => {
+    expect(parseBbox('[10, 20, 30, 40]')).toEqual([10, 20, 30, 40]);
+  });
+
+  it('should return empty array for invalid input', () => {
+    expect(parseBbox('')).toEqual([]);
+    expect(parseBbox('invalid')).toEqual([]);
+  });
+});
+
+describe('guessElementType', () => {
+  it('should recognize button type', () => {
+    expect(guessElementType('我要点击【按钮】')).toBe('button');
+    expect(guessElementType('click the button')).toBe('button');
+  });
+
+  it('should recognize card type', () => {
+    expect(guessElementType('点击【推荐卡片】')).toBe('card');
+    expect(guessElementType('click card')).toBe('card');
+  });
+
+  it('should recognize list-item type', () => {
+    expect(guessElementType('点击列表项')).toBe('list-item');
+    expect(guessElementType('click list item')).toBe('list-item');
+  });
+
+  it('should recognize input type', () => {
+    expect(guessElementType('输入框')).toBe('input');
+    expect(guessElementType('type input')).toBe('input');
+  });
+
+  it('should recognize icon type', () => {
+    expect(guessElementType('点击图标')).toBe('icon');
+    expect(guessElementType('click icon')).toBe('icon');
+  });
+
+  it('should recognize tab/button for navigation', () => {
+    expect(guessElementType('点击tab导航')).toBe('button');
+    expect(guessElementType('点击导航栏')).toBe('button');
+  });
+
+  it('should return unknown for unrecognized types', () => {
+    expect(guessElementType('some random text')).toBe('unknown');
+  });
+});
+
+describe('guessActionType', () => {
+  it('should return navigate when page changed', () => {
+    expect(guessActionType('click something', true)).toBe('navigate');
+  });
+
+  it('should recognize filter action', () => {
+    expect(guessActionType('筛选内容', false)).toBe('filter');
+    expect(guessActionType('apply filter', false)).toBe('filter');
+  });
+
+  it('should recognize toggle action', () => {
+    expect(guessActionType('切换状态', false)).toBe('toggle');
+    expect(guessActionType('toggle option', false)).toBe('toggle');
+  });
+
+  it('should recognize input action', () => {
+    expect(guessActionType('输入文字', false)).toBe('input');
+    expect(guessActionType('type text', false)).toBe('input');
+  });
+
+  it('should return click for unknown actions', () => {
+    expect(guessActionType('click here', false)).toBe('click');
+  });
+});
+
+describe('extractElementName', () => {
+  it('should extract name from 【name】 pattern', () => {
+    expect(extractElementName('我要点击【首页】')).toBe('首页');
+    expect(extractElementName('Thought: 我要点击【推荐卡片】')).toBe('推荐卡片');
+  });
+
+  it('should extract name from "name" pattern', () => {
+    expect(extractElementName('click "button"')).toBe('button');
+  });
+
+  it('should return "unknown" for empty thought', () => {
+    expect(extractElementName('')).toBe('unknown');
+  });
+
+  it('should extract name from keyword-based pattern', () => {
+    expect(extractElementName('点击推荐卡片查看详情')).toBe('点击推荐卡片');
+    // Keyword-based extraction returns prefix + keyword
+    expect(extractElementName('点击按钮确认')).toBe('点击按钮');
+  });
+
+  it('should return "element" when no pattern matches', () => {
+    expect(extractElementName('some random action')).toBe('element');
+  });
+
+  it('should accept names from 【name】 pattern within length limit (<=20)', () => {
+    // The 【name】 pattern checks for min length > 1 AND max length <= 20
+    const longName = '这是一个非常非常长的名称超过限制';
+    expect(extractElementName(`【${longName}】`)).toBe(longName);
+  });
+});
+
+describe('generateElementId', () => {
+  it('should generate element ID with page name and element name', () => {
+    const id = generateElementId('Page_0', '推荐卡片', 1, 'card', 0);
+    expect(id).toContain('Page_0');
+    expect(id).toContain('推荐卡片');
+    expect(id).toContain('_card');
+  });
+
+  it('should handle unknown element type', () => {
+    const id = generateElementId('Page_0', '元素', 1, 'unknown', 0);
+    expect(id).not.toContain('_unknown');
+  });
+
+  it('should add count suffix for duplicate names', () => {
+    const id = generateElementId('Page_0', '按钮', 1, 'button', 2);
+    expect(id).toContain('_3');
+  });
+
+  it('should sanitize special characters in element name', () => {
+    const id = generateElementId('Page_0', '特殊@字符#', 1, 'unknown', 0);
+    expect(id).not.toContain('@');
+    expect(id).not.toContain('#');
+  });
+});
+
+describe('generateTabName', () => {
+  it('should extract tab name from 【name】 pattern', () => {
+    expect(generateTabName('我要点击【首页】', 1)).toBe('首页');
+    expect(generateTabName('点击【剧场】tab', 2)).toBe('剧场');
+  });
+
+  it('should recognize common tab patterns', () => {
+    expect(generateTabName('navigate to 首页', 1)).toBe('首页');
+    expect(generateTabName('click 我的 tab', 2)).toBe('我的');
+  });
+
+  it('should fallback to Tab_N when no pattern matches', () => {
+    expect(generateTabName('random text', 3)).toBe('Tab_3');
+  });
+});
+
+describe('isSameElement', () => {
+  it('should return true for coordinates within threshold', () => {
+    expect(isSameElement([100, 200], [110, 210], 50)).toBe(true);
+  });
+
+  it('should return false for coordinates outside threshold', () => {
+    expect(isSameElement([100, 200], [200, 300], 50)).toBe(false);
+  });
+
+  it('should return false for invalid coordinates', () => {
+    expect(isSameElement([], [100, 200])).toBe(false);
+    expect(isSameElement([100], [100, 200])).toBe(false);
+    expect(isSameElement(null as any, [100, 200])).toBe(false);
+  });
+
+  it('should use custom threshold', () => {
+    // dx=30, dy=30, threshold=50: 30 < 50 && 30 < 50 -> true
+    expect(isSameElement([100, 200], [130, 230], 50)).toBe(true);
+    // dx=60, dy=60, threshold=50: 60 >= 50 -> false
+    expect(isSameElement([100, 200], [160, 260], 50)).toBe(false);
+    // dx=60, dy=60, threshold=100: 60 < 100 -> true
+    expect(isSameElement([100, 200], [160, 260], 100)).toBe(true);
+  });
+});
+
+describe('deduplicateTabs', () => {
+  it('should remove tabs with similar coordinates', () => {
+    const tabs = [
+      { coords: [100, 200], name: 'Tab1' },
+      { coords: [105, 205], name: 'Tab2' },
+      { coords: [300, 200], name: 'Tab3' },
+    ];
+    const result = deduplicateTabs(tabs, 20);
+    expect(result).toHaveLength(2);
+    expect(result[0].name).toBe('Tab1');
+    expect(result[1].name).toBe('Tab3');
+  });
+
+  it('should keep all tabs when coordinates are distinct', () => {
+    const tabs = [
+      { coords: [100, 200], name: 'Tab1' },
+      { coords: [300, 200], name: 'Tab2' },
+      { coords: [500, 200], name: 'Tab3' },
+    ];
+    expect(deduplicateTabs(tabs, 50)).toHaveLength(3);
+  });
+});
+
+describe('deduplicateElements', () => {
+  it('should remove elements with similar coordinates', () => {
+    const elements = [
+      { coords: [100, 200] },
+      { coords: [110, 210] },
+      { coords: [300, 200] },
+    ];
+    expect(deduplicateElements(elements, 20)).toHaveLength(2);
+  });
+});
+
+describe('mapFile', () => {
+  it('should sanitize package name for filename', () => {
+    expect(mapFile('com.example.app')).toBe('com.example.app.json');
+    expect(mapFile('com.example/my-app')).toBe('com.example_my-app.json');
+    expect(mapFile('com.app@v2.0')).toBe('com.app_v2.0.json');
+  });
+});
+
+describe('DEDUP_THRESHOLD', () => {
+  it('should have tab threshold of 80', () => {
+    expect(DEDUP_THRESHOLD.TAB).toBe(80);
+  });
+
+  it('should have element threshold of 60', () => {
+    expect(DEDUP_THRESHOLD.ELEMENT).toBe(60);
+  });
+
+  it('should use ELEMENT threshold as default in deduplicateElements', () => {
+    // Default threshold should be 60 (DEDUP_THRESHOLD.ELEMENT)
+    const elements = [
+      { coords: [100, 200] },
+      { coords: [155, 255] }, // dx=55, dy=55 -> same at 60, different at 50
+    ];
+    expect(deduplicateElements(elements)).toHaveLength(1);
+    expect(deduplicateElements(elements, 50)).toHaveLength(2);
+  });
+});

--- a/packages/ui-tars/cli/src/auto-learn/app-launcher.ts
+++ b/packages/ui-tars/cli/src/auto-learn/app-launcher.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { execSync } from 'node:child_process';
+
+/**
+ * Sanitize an argument string for shell command safety.
+ * Only allows alphanumeric characters, dots, underscores, and hyphens.
+ */
+function sanitizeArg(arg: string): string {
+  if (!/^[a-zA-Z0-9._:-]+$/.test(arg)) {
+    throw new Error(`Invalid argument: "${arg}" - only alphanumeric, ".", "_", "-", ":" are allowed`);
+  }
+  return arg;
+}
+
+/**
+ * Launch an Android app using ADB monkey command
+ */
+export function launchApp(deviceId: string, pkg: string): void {
+  const safeDeviceId = sanitizeArg(deviceId);
+  const safePkg = sanitizeArg(pkg);
+  execSync(`adb -s ${safeDeviceId} shell am force-stop ${safePkg}`, { stdio: 'pipe' });
+  execSync(
+    `adb -s ${safeDeviceId} shell monkey -p ${safePkg} -c android.intent.category.LAUNCHER 1`,
+    { stdio: 'pipe' },
+  );
+}
+
+/**
+ * Tap at coordinates on the device
+ */
+export function adbClick(deviceId: string, x: number, y: number): void {
+  const safeDeviceId = sanitizeArg(deviceId);
+  execSync(`adb -s ${safeDeviceId} shell input tap ${x} ${y}`, { stdio: 'pipe' });
+}
+
+/**
+ * Send back key event
+ */
+export function adbBack(deviceId: string): void {
+  const safeDeviceId = sanitizeArg(deviceId);
+  execSync(`adb -s ${safeDeviceId} shell input keyevent KEYCODE_BACK`, { stdio: 'pipe' });
+}
+
+/**
+ * Send home key event
+ */
+export function adbHome(deviceId: string): void {
+  const safeDeviceId = sanitizeArg(deviceId);
+  execSync(`adb -s ${safeDeviceId} shell input keyevent KEYCODE_HOME`, { stdio: 'pipe' });
+}
+
+/**
+ * Wake up the device
+ */
+export function adbWake(deviceId: string): void {
+  const safeDeviceId = sanitizeArg(deviceId);
+  execSync(`adb -s ${safeDeviceId} shell input keyevent KEYCODE_WAKEUP`, { stdio: 'pipe' });
+}
+
+/**
+ * Query the physical screen size of the device
+ */
+export function adbScreenSize(deviceId: string): { width: number; height: number } | null {
+  const safeDeviceId = sanitizeArg(deviceId);
+  try {
+    const output = execSync(`adb -s ${safeDeviceId} shell wm size`, {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const match = output.match(/Physical size:\s*(\d+)x(\d+)/i);
+    if (match) {
+      return { width: parseInt(match[1], 10), height: parseInt(match[2], 10) };
+    }
+  } catch {
+    // ignore
+  }
+  return null;
+}
+
+/**
+ * Sleep for specified milliseconds
+ */
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Run a promise with a timeout, rejecting if it exceeds the limit
+ */
+export function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  label = 'operation',
+): Promise<T> {
+  return Promise.race([
+    promise,
+    sleep(ms).then(() => {
+      throw new Error(`${label} timed out after ${ms}ms`);
+    }),
+  ]);
+}

--- a/packages/ui-tars/cli/src/auto-learn/index.ts
+++ b/packages/ui-tars/cli/src/auto-learn/index.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+export { autoLearnAndRun } from './manager';
+export type { AutoLearnConfig } from './manager';
+export type { AppMap } from './types';

--- a/packages/ui-tars/cli/src/auto-learn/manager.ts
+++ b/packages/ui-tars/cli/src/auto-learn/manager.ts
@@ -1,0 +1,250 @@
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { AdbOperator } from '@ui-tars/operator-adb';
+import { loadMap, saveMap, SS_DIR } from './map-storage';
+import { AppMap, JumpTarget } from './types';
+import { launchApp, adbClick, adbWake, adbHome, adbBack, adbScreenSize, sleep } from './app-launcher';
+import { learnTabs } from './tab-learner';
+import { learnPageElements } from './page-learner';
+import { saveScreenshot } from './utils';
+
+export interface AutoLearnConfig {
+  /** Android app package name */
+  pkg: string;
+  /** ADB device ID */
+  deviceId: string;
+  /** VLM model configuration */
+  modelConfig: {
+    baseURL: string;
+    apiKey: string;
+    model: string;
+    useResponsesApi?: boolean;
+  };
+  /** Force re-learning even if a cached map exists */
+  forceRelearn?: boolean;
+  /** Screen physical width (default 1080) */
+  screenWidth?: number;
+  /** Screen physical height (default 2400) */
+  screenHeight?: number;
+  /** Maximum number of tabs to learn (default 3) */
+  maxTabs?: number;
+}
+
+/**
+ * Main orchestrator for the auto-learn feature.
+ * 1. Checks cache (unless forceRelearn)
+ * 2. Launches app, learns tabs, learns elements on each tab
+ * 3. Saves the resulting AppMap
+ */
+export async function autoLearnAndRun(config: AutoLearnConfig): Promise<AppMap | null> {
+  const { pkg, deviceId, modelConfig, forceRelearn } = config;
+  const screenWidth = config.screenWidth || 1080;
+  const screenHeight = config.screenHeight || 2400;
+  const maxTabs = config.maxTabs ?? 3;
+
+  // Check cache first
+  if (!forceRelearn) {
+    const cached = loadMap(pkg);
+    if (cached) {
+      console.log(`\n[Auto-Learn] Using cached app map for: ${pkg}`);
+      console.log(`  Tabs: ${cached.navigation.tabs.length}`);
+      console.log(`  Pages: ${Object.keys(cached.pages).length}`);
+      return cached;
+    }
+  } else {
+    console.log(`\n[Auto-Learn] Force re-learning enabled, ignoring cache for: ${pkg}`);
+  }
+
+  console.log('\n========================================');
+  console.log('DEEP APP LEARNING');
+  console.log(`Package: ${pkg}`);
+  console.log(`Device: ${deviceId}`);
+  console.log('========================================');
+
+  const startTime = Date.now();
+
+  // Wake device, go home, launch app
+  try {
+    adbWake(deviceId);
+  } catch {
+    // ignore - device may already be awake
+  }
+
+  try {
+    adbHome(deviceId);
+  } catch (err) {
+    console.error('[Error] Failed to send home:', err);
+    return null;
+  }
+  await sleep(1000);
+
+  try {
+    launchApp(deviceId, pkg);
+  } catch (err) {
+    console.error('[Error] Failed to launch app:', err);
+    return null;
+  }
+  await sleep(3000);
+
+  // Create ADB operator
+  const op = new AdbOperator(deviceId);
+
+  // Verify app launched with a screenshot
+  let initialSS;
+  try {
+    initialSS = await op.screenshot();
+  } catch {
+    console.log('ERROR: App failed to launch or screenshot');
+    return null;
+  }
+
+  if (!initialSS?.base64) {
+    console.log('ERROR: App failed to launch (empty screenshot)');
+    return null;
+  }
+
+  // Query actual screen dimensions, fallback to config defaults
+  const actualSize = adbScreenSize(deviceId);
+  const actualWidth = actualSize?.width || screenWidth;
+  const actualHeight = actualSize?.height || screenHeight;
+  console.log(`App launched: ${actualWidth}x${actualHeight}`);
+  saveScreenshot(initialSS.base64, 'launch', SS_DIR);
+
+  // Initialize empty map structure
+  const map: AppMap = {
+    meta: {
+      appName: 'Unknown',
+      package: pkg,
+      screenWidth: actualWidth,
+      screenHeight: actualHeight,
+      learnTime: 0,
+      learnDate: new Date().toISOString(),
+      device: deviceId,
+    },
+    navigation: { tabs: [], topButtons: [] },
+    pages: {},
+    secondaryPages: {},
+    navigationGraph: {},
+  };
+
+  // Phase 1: Learn tabs
+  try {
+    const tabs = await learnTabs(op, modelConfig);
+    if (tabs.length === 0) {
+      console.log('[Phase 1 Error] No tabs discovered, aborting learning');
+      return null;
+    }
+    map.navigation.tabs = tabs;
+    saveMap(pkg, map);
+    console.log(`[Phase 1 Complete] ${tabs.length} tabs discovered`);
+  } catch (err) {
+    console.error('[Phase 1 Error] Failed to learn tabs:', err);
+    return null;
+  }
+
+  // Restart app to ensure we're in the target app
+  console.log('\nRestarting app to ensure we are in target app...');
+  try {
+    launchApp(deviceId, pkg);
+  } catch (err) {
+    console.error('[Error] Failed to restart app:', err);
+    return null;
+  }
+  await sleep(3000);
+
+  // Phase 2: Learn elements on each tab
+  for (let t = 0; t < map.navigation.tabs.length; t++) {
+    const tab = map.navigation.tabs[t];
+    if (tab.coords.length < 2) continue;
+
+    console.log(`\nNavigating to Tab ${tab.index}`);
+    const clickX = Math.round(tab.coords[0]);
+    const clickY = Math.round(tab.coords[1]);
+
+    try {
+      adbClick(deviceId, clickX, clickY);
+      await sleep(500);
+
+      const pageSS = await op.screenshot();
+      if (pageSS?.base64) {
+        saveScreenshot(pageSS.base64, `tab_${tab.index}_page`, SS_DIR);
+      }
+
+      const pageName = `Page_${tab.index}`;
+      tab.name = pageName;
+
+      const pageResult = await learnPageElements(
+        op,
+        modelConfig,
+        pageName,
+        1,
+        map,
+        pkg,
+        10,
+        actualWidth,
+        actualHeight,
+        (partialMap) => saveMap(pkg, partialMap),
+      );
+
+      map.pages[pageName] = pageResult.pageMap;
+
+      // Handle jump targets (secondary pages)
+      if (pageResult.jumpTargets.length > 0) {
+        map.navigationGraph[pageName] = pageResult.jumpTargets.map(
+          (j: JumpTarget) => `SecondaryPage_from_${pageName}`,
+        );
+
+        // Explore the first secondary page
+        const firstJump = pageResult.jumpTargets[0];
+        if (firstJump?.coords) {
+          console.log(`\n[Phase 3] Exploring Secondary Page from ${pageName}`);
+          adbClick(deviceId, Math.round(firstJump.coords[0]), Math.round(firstJump.coords[1]));
+          await sleep(2000);
+
+          const enterSS = await op.screenshot();
+          if (enterSS?.base64) {
+            saveScreenshot(enterSS.base64, `SecondaryPage_from_${pageName}_enter`, SS_DIR);
+          }
+
+          // Go back
+          adbBack(deviceId);
+          await sleep(500);
+        }
+      }
+
+      // Incremental save after each page
+      saveMap(pkg, map);
+      console.log(`[Incremental save] Map saved after completing page: ${pageName}`);
+
+      await sleep(300);
+
+      // Limit to configured maxTabs
+      if (t >= maxTabs - 1) {
+        if (maxTabs < map.navigation.tabs.length) {
+          console.log(`[Limit] Only processing first ${maxTabs} tabs for faster learning`);
+        }
+        break;
+      }
+    } catch (err) {
+      console.error(`[Error learning tab ${t}]`, err);
+      continue;
+    }
+  }
+
+  const endTime = Date.now();
+  map.meta.learnTime = endTime - startTime;
+
+  // Final save
+  saveMap(pkg, map);
+
+  console.log('\n========================================');
+  console.log('LEARNING COMPLETE');
+  console.log(`Time: ${((endTime - startTime) / 1000).toFixed(1)}s`);
+  console.log(`Tabs: ${map.navigation.tabs.length}`);
+  console.log(`Pages: ${Object.keys(map.pages).length}`);
+  console.log('========================================');
+
+  return map;
+}

--- a/packages/ui-tars/cli/src/auto-learn/map-storage.ts
+++ b/packages/ui-tars/cli/src/auto-learn/map-storage.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { AppMap } from './types';
+import { mapFile, mkdirSafe } from './utils';
+
+export const MAP_DIR = path.join(process.cwd(), '.ui-tars', 'app-maps');
+export const SS_DIR = path.join(process.cwd(), '.ui-tars', 'screenshots');
+
+// Ensure directories exist
+mkdirSafe(MAP_DIR);
+mkdirSafe(SS_DIR);
+
+/**
+ * Load a cached app map for the given package
+ */
+export function loadMap(pkg: string): AppMap | null {
+  const fp = path.join(MAP_DIR, mapFile(pkg));
+  if (!fs.existsSync(fp)) return null;
+  return JSON.parse(fs.readFileSync(fp, 'utf8')) as AppMap;
+}
+
+/**
+ * Save an app map to JSON file
+ */
+export function saveMap(pkg: string, map: AppMap): string {
+  const fp = path.join(MAP_DIR, mapFile(pkg));
+  fs.writeFileSync(fp, JSON.stringify(map, null, 2));
+  console.log(`App map saved: ${fp}`);
+  return fp;
+}

--- a/packages/ui-tars/cli/src/auto-learn/page-learner.ts
+++ b/packages/ui-tars/cli/src/auto-learn/page-learner.ts
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { GUIAgent } from '@ui-tars/sdk';
+import { Operator } from '@ui-tars/sdk/core';
+import { RecordingOperator } from './recording-operator';
+import { AppMap, JumpTarget, PageMap, Region, Element } from './types';
+import { withTimeout } from './app-launcher';
+import {
+  extractCoords,
+  extractElementName,
+  guessElementType,
+  guessActionType,
+  generateElementId,
+  deduplicateElements,
+  saveScreenshot,
+} from './utils';
+import { SS_DIR } from './map-storage';
+import { getLayoutType } from './page-signatures';
+
+/**
+ * Phase 2: Learn page elements by instructing the agent to explore interactive elements.
+ */
+export async function learnPageElements(
+  op: Operator,
+  modelConfig: { baseURL: string; apiKey: string; model: string; useResponsesApi?: boolean },
+  pageName: string,
+  depth: number,
+  map: AppMap,
+  pkg: string,
+  maxLoops = 10,
+  screenWidth = 1080,
+  screenHeight = 2400,
+  onIncrementalSave?: (partialMap: AppMap) => void,
+): Promise<{ pageMap: PageMap; jumpTargets: JumpTarget[] }> {
+  console.log(`\n[Phase 2] Learning Page: ${pageName} (depth=${depth})`);
+
+  const recordingOp = new RecordingOperator(op);
+
+  // Incremental save callback: trigger every 5 clicks
+  let lastSaveCount = 0;
+  const checkAndSave = async () => {
+    const currentClicks = recordingOp.getActions().filter((a) => a.type === 'click');
+    if (currentClicks.length >= lastSaveCount + 5) {
+      lastSaveCount = currentClicks.length;
+      if (!map.pages[pageName]) {
+        map.pages[pageName] = {
+          name: pageName,
+          depth,
+          layout: getLayoutType(pageName),
+          regions: [],
+          backAction: { type: 'hotkey', key: 'back' },
+        };
+      }
+      onIncrementalSave?.(map);
+      console.log(`[Incremental save] Map saved after ${currentClicks.length} clicks on ${pageName}`);
+    }
+  };
+
+  // Wrap execute to call checkAndSave
+  const originalExecute = recordingOp.execute.bind(recordingOp);
+  recordingOp.execute = async (params) => {
+    const res = await originalExecute(params);
+    await checkAndSave();
+    return res;
+  };
+
+  const agent = new GUIAgent({
+    operator: recordingOp,
+    model: modelConfig,
+    logger: console,
+    maxLoopCount: maxLoops,
+    loopIntervalInMs: 0,
+  });
+
+  await withTimeout(
+    agent.run(
+      '探索当前页面的可交互元素。\n\n' +
+        '**【绝对禁止】点击屏幕顶部 1/8 区域（y坐标小于屏幕高度的 1/8）！**\n' +
+        '这个区域通常是Logo、品牌名称、导航栏，不可交互。\n' +
+        '你必须从屏幕中间或下半部分开始探索。\n\n' +
+        '**重要：在Thought中用【元素名称】标注你点击的是什么！**\n' +
+        '例如：Thought: 我要点击【推荐卡片】来查看详情。Action: click(...)\n\n' +
+        '**探索规则：**\n' +
+        '1. 首先观察屏幕下半部分的卡片、按钮、列表\n' +
+        '2. 点击第一个看起来有功能的元素（如推荐卡片、角色列表项）\n' +
+        '3. 用【名称】标注元素，如【推荐卡片】【签到按钮】【角色卡片】\n' +
+        '4. 点击后如果进入新页面，立即hotkey(key="back")返回\n' +
+        '5. 如果出现弹窗，关闭后换下一个元素\n' +
+        '6. 向上滚动探索更多内容\n' +
+        '7. 探索完 5-8 个主要元素后执行 finished()\n\n' +
+        '**记住：目标是发现有功能的交互元素！从屏幕中间开始，不要点击顶部！**',
+      [],
+      {},
+    ),
+    600_000, // 10 minutes
+    'learnPageElements',
+  );
+
+  const actions = recordingOp.getActions();
+  const clicks = actions.filter((a) => a.type === 'click');
+  const scrolls = actions.filter((a) => a.type === 'scroll');
+  const backs = actions.filter((a) => a.type === 'hotkey' && a.inputs.key === 'back');
+
+  const elements: Array<{
+    id: string;
+    name: string;
+    description: string;
+    coords: number[];
+    bbox: number[];
+    type: string;
+    action: string;
+    status: 'reliable' | 'unreliable';
+    retryCount: number;
+    target?: string;
+  }> = [];
+  const jumpTargets: JumpTarget[] = [];
+  let jumpIdx = 0;
+  let filteredCount = 0;
+  const TOP_REGION_THRESHOLD = Math.floor(screenHeight / 8);
+
+  for (const click of clicks) {
+    const coords = extractCoords(click.inputs);
+
+    // Filter clicks in the top region (likely nav bar/logo)
+    if (coords.length >= 2 && coords[1] < TOP_REGION_THRESHOLD) {
+      filteredCount++;
+      continue;
+    }
+
+    const elementName = extractElementName(click.thought);
+    const elemType = guessElementType(click.thought);
+
+    const sameNameCount = elements.filter((e) => e.name === elementName).length;
+    const elemId = generateElementId(
+      pageName,
+      elementName,
+      elements.length + 1,
+      elemType,
+      sameNameCount,
+    );
+
+    const pageChanged = backs.some(
+      (b) => b.loopIndex > click.loopIndex && b.loopIndex < click.loopIndex + 5,
+    );
+
+    const yPos = coords.length >= 2 ? Math.round(coords[1]) : 0;
+    const positionDesc =
+      yPos < 800 ? '上部区域' : yPos < 1600 ? '中部区域' : '下部区域';
+
+    const elem: {
+      id: string;
+      name: string;
+      description: string;
+      coords: number[];
+      bbox: number[];
+      type: string;
+      action: string;
+      status: 'reliable' | 'unreliable';
+      retryCount: number;
+      target?: string;
+    } = {
+      id: elemId,
+      name: elementName,
+      description: `${elementName} - 位于${positionDesc}，${click.thought.substring(0, 80)}`,
+      coords,
+      bbox: [],
+      type: elemType,
+      action: guessActionType(click.thought, pageChanged),
+      status: 'reliable' as const,
+      retryCount: 0,
+    };
+
+    if (pageChanged && elem.action === 'navigate') {
+      elem.target = `SecondaryPage_${jumpIdx + 1}`;
+      jumpTargets.push({
+        elementId: elem.id,
+        coords,
+        screenshotBefore: click.screenshotBefore,
+      });
+      jumpIdx++;
+    }
+
+    elements.push(elem);
+
+    if (click.screenshotBefore) {
+      saveScreenshot(click.screenshotBefore, `${elemId}_click`, SS_DIR);
+    }
+  }
+
+  if (filteredCount > 0) {
+    console.log(
+      `[Filter] Filtered out ${filteredCount} clicks in top region (y < ${TOP_REGION_THRESHOLD})`,
+    );
+  }
+
+  const uniqueElements = deduplicateElements(elements, 60);
+  console.log(`[Dedup] After deduplication: ${uniqueElements.length} unique elements`);
+
+  const regions: Region[] = [];
+  if (uniqueElements.length > 0) {
+    regions.push({
+      id: `${pageName}_main`,
+      position: 'full',
+      bbox: [0, 0, screenWidth, screenHeight],
+      type: scrolls.length > 0 ? 'scrollable-grid' : 'static',
+      scrollable: scrolls.length > 0,
+      elements: uniqueElements as Element[],
+      description: 'Main content area',
+    });
+  }
+
+  const pageMap: PageMap = {
+    name: pageName,
+    depth,
+    layout: getLayoutType(pageName),
+    regions,
+    backAction: { type: 'hotkey', key: 'back' },
+  };
+
+  console.log(`Found ${uniqueElements.length} elements, ${jumpTargets.length} jump targets`);
+  return { pageMap, jumpTargets };
+}

--- a/packages/ui-tars/cli/src/auto-learn/page-signatures.ts
+++ b/packages/ui-tars/cli/src/auto-learn/page-signatures.ts
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { LayoutType } from './types';
+
+interface PageSignatureData {
+  name: string;
+  features: string[];
+  notFeatures?: string[];
+  layout?: string;
+  parentTypes?: string[];
+}
+
+export const PAGE_SIGNATURES: PageSignatureData[] = [
+  {
+    name: '首页',
+    features: ['横幅轮播', '推荐卡片', 'banner', '推荐内容'],
+    notFeatures: ['左侧筛选', '分类列表'],
+    layout: 'scrollable-feed',
+  },
+  {
+    name: '剧场',
+    features: ['左侧分类', '筛选列表', '剧目卡片', '剧目列表', '分类筛选'],
+    layout: 'split-view',
+  },
+  {
+    name: 'AI伴侣',
+    features: ['伴侣头像', '对话界面', 'AI', '伴侣', '聊天'],
+    layout: 'unknown',
+  },
+  {
+    name: '消息',
+    features: ['消息列表', '聊天记录', '消息卡片', '对话'],
+    notFeatures: ['推荐', '剧目'],
+    layout: 'list',
+  },
+  {
+    name: '我的',
+    features: ['用户头像', '钻石余额', '角色清单', '个人中心', '设置', '我的'],
+    layout: 'form',
+  },
+  {
+    name: '剧目详情',
+    features: ['剧目封面', '播放按钮', '剧情简介', '详情页'],
+    parentTypes: ['剧场', '首页'],
+    layout: 'unknown',
+  },
+  {
+    name: '搜索页',
+    features: ['搜索框', '搜索结果', '搜索'],
+    parentTypes: ['首页', '剧场'],
+    layout: 'list',
+  },
+  {
+    name: '播放页',
+    features: ['播放器', '视频', '全屏'],
+    parentTypes: ['剧目详情'],
+    layout: 'unknown',
+  },
+  {
+    name: '设置页',
+    features: ['设置选项', '设置列表', '开关'],
+    parentTypes: ['我的'],
+    layout: 'list',
+  },
+];
+
+export function matchPageSignature(
+  description: string,
+  parentPage?: string,
+): string {
+  const lowerDesc = description.toLowerCase();
+
+  let bestMatch: PageSignatureData | null = null;
+  let bestScore = 0;
+
+  for (const sig of PAGE_SIGNATURES) {
+    let score = 0;
+
+    for (const feature of sig.features) {
+      if (lowerDesc.includes(feature.toLowerCase())) {
+        score += 2;
+      }
+    }
+
+    if (sig.notFeatures) {
+      for (const notFeature of sig.notFeatures) {
+        if (lowerDesc.includes(notFeature.toLowerCase())) {
+          score -= 3;
+        }
+      }
+    }
+
+    if (parentPage && sig.parentTypes && sig.parentTypes.includes(parentPage)) {
+      score += 1;
+    }
+
+    if (score > bestScore) {
+      bestScore = score;
+      bestMatch = sig;
+    }
+  }
+
+  if (bestMatch && bestScore > 0) {
+    return bestMatch.name;
+  }
+
+  return 'Unknown';
+}
+
+export function getLayoutType(pageName: string): LayoutType {
+  const sig = PAGE_SIGNATURES.find((s) => s.name === pageName);
+  return (sig?.layout as LayoutType) || 'unknown';
+}
+
+export function isSecondaryPage(pageName: string): boolean {
+  const sig = PAGE_SIGNATURES.find((s) => s.name === pageName);
+  return sig?.parentTypes !== undefined && sig.parentTypes.length > 0;
+}

--- a/packages/ui-tars/cli/src/auto-learn/recording-operator.ts
+++ b/packages/ui-tars/cli/src/auto-learn/recording-operator.ts
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { Operator, type ScreenshotOutput, type ExecuteOutput, type ExecuteParams } from '@ui-tars/sdk/core';
+import { sleep } from './app-launcher';
+import { extractCoords } from './utils';
+import type { ActionRecord } from './types';
+
+/**
+ * A decorator Operator that wraps a base operator and records all actions + screenshots.
+ * Used during the learning phase to capture element positions and page structure.
+ */
+export class RecordingOperator extends Operator {
+  static MANUAL = {
+    ACTION_SPACES: [
+      `click(start_box='[x1, y1, x2, y2]')`,
+      `type(content='')`,
+      `swipe(start_box='[x1, y1, x2, y2]', end_box='[x3, y3, x4, y4]')`,
+      `scroll(start_box='[x1, y1, x2, y2]', direction='down or up or right or left')`,
+      `hotkey(key='')`,
+      `wait()`,
+      `finished()`,
+      `call_user()`,
+    ],
+  };
+
+  actions: ActionRecord[] = [];
+  lastScreenshot: string | null = null;
+  immediateScreenshots: { actionIndex: number; screenshotAfter: string }[] = [];
+  recentClicks: string[] = [];
+
+  constructor(private baseOp: Operator) {
+    super();
+  }
+
+  override async screenshot(): Promise<ScreenshotOutput> {
+    const ss = await this.baseOp.screenshot();
+    this.lastScreenshot = ss.base64;
+    return ss;
+  }
+
+  override async execute(params: ExecuteParams): Promise<ExecuteOutput> {
+    const result = await this.baseOp.execute(params);
+
+    if (params.parsedPrediction?.action_type) {
+      const { action_type, action_inputs } = params.parsedPrediction;
+      const coords = extractCoords(action_inputs);
+      const clickPos =
+        coords.length >= 2
+          ? `${Math.round(coords[0])},${Math.round(coords[1])}`
+          : 'none';
+
+      // Detect repeated clicks at same position (4+ times -> auto-finish)
+      if (action_type === 'click') {
+        this.recentClicks.push(clickPos);
+        if (this.recentClicks.length > 8) {
+          this.recentClicks.shift();
+        }
+
+        const sameClickCount = this.recentClicks.filter((p) => p === clickPos).length;
+        if (sameClickCount >= 4) {
+          console.log(
+            `[RecordingOperator] WARNING: Same position clicked 4+ times: ${clickPos}. Auto-finishing.`,
+          );
+          this.actions.push({
+            type: 'finished',
+            inputs: {},
+            thought: 'Auto-finished due to repeated clicks at same position',
+            screenshotBefore: this.lastScreenshot || undefined,
+            time: Date.now(),
+            loopIndex: this.actions.length,
+          });
+          return result;
+        }
+      }
+
+      // Record the action
+      this.actions.push({
+        type: action_type,
+        inputs: action_inputs,
+        thought: params.parsedPrediction.thought || '',
+        screenshotBefore: this.lastScreenshot || undefined,
+        time: Date.now(),
+        loopIndex: this.actions.length,
+      });
+
+      // Take immediate after-screenshot for click actions
+      if (action_type === 'click') {
+        await sleep(300);
+        try {
+          const afterSS = await this.baseOp.screenshot();
+          this.immediateScreenshots.push({
+            actionIndex: this.actions.length - 1,
+            screenshotAfter: afterSS.base64,
+          });
+          this.lastScreenshot = afterSS.base64;
+        } catch {
+          // If after-screenshot fails, continue without it
+        }
+      }
+    } else if (result) {
+      // Log when parsedPrediction is missing but execute returned a result
+      console.debug(
+        '[RecordingOperator] parsedPrediction missing, action not recorded',
+      );
+    }
+
+    return result;
+  }
+
+  getActions(): ActionRecord[] {
+    return this.actions;
+  }
+
+  getImmediateScreenshots(): { actionIndex: number; screenshotAfter: string }[] {
+    return this.immediateScreenshots;
+  }
+
+  getLastScreenshot(): string | null {
+    return this.lastScreenshot;
+  }
+}

--- a/packages/ui-tars/cli/src/auto-learn/tab-learner.ts
+++ b/packages/ui-tars/cli/src/auto-learn/tab-learner.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { GUIAgent } from '@ui-tars/sdk';
+import { Operator } from '@ui-tars/sdk/core';
+import { RecordingOperator } from './recording-operator';
+import { TabElement } from './types';
+import { extractCoords, generateTabName, DEDUP_THRESHOLD } from './utils';
+import { withTimeout } from './app-launcher';
+
+/**
+ * Phase 1: Learn navigation tabs by instructing the agent to click all bottom nav tabs.
+ */
+export async function learnTabs(
+  op: Operator,
+  modelConfig: { baseURL: string; apiKey: string; model: string; useResponsesApi?: boolean },
+  maxLoops = 8,
+  timeoutMs = 300_000, // 5 minutes
+): Promise<TabElement[]> {
+  console.log('\n[Phase 1] Learning Navigation Tabs');
+
+  const recordingOp = new RecordingOperator(op);
+  const agent = new GUIAgent({
+    operator: recordingOp,
+    model: modelConfig,
+    logger: console,
+    maxLoopCount: maxLoops,
+    loopIntervalInMs: 0,
+  });
+
+  await withTimeout(
+    agent.run(
+      '依次点击底部导航栏所有tab，从左到右。\n\n' +
+        '**重要：在Thought中用【tab名称】标注你点击的tab！**\n' +
+        '例如：Thought: 我要点击【首页】tab。Action: click(...)\n' +
+        '例如：Thought: 我要点击【剧场】tab。Action: click(...)\n\n' +
+        '点击完所有tab后回到第一个，然后执行finished()',
+      [],
+      {},
+    ),
+    timeoutMs,
+    'learnTabs',
+  );
+
+  const actions = recordingOp.getActions();
+  const clicks = actions.filter((a) => a.type === 'click');
+
+  const tabs: TabElement[] = [];
+  clicks.forEach((click, idx) => {
+    const coords = extractCoords(click.inputs);
+    const tabName = generateTabName(click.thought, idx + 1);
+
+    tabs.push({
+      index: idx + 1,
+      name: tabName,
+      coords,
+      bbox: [],
+      status: 'reliable',
+    });
+  });
+
+  // Deduplicate by coordinate proximity, preserving full TabElement structure
+  const seenCoords: number[][] = [];
+  const uniqueTabs = tabs.filter((tab) => {
+    const isDup = seenCoords.some(
+      (c) =>
+        tab.coords.length >= 2 &&
+        c.length >= 2 &&
+        Math.abs(tab.coords[0] - c[0]) < DEDUP_THRESHOLD.TAB &&
+        Math.abs(tab.coords[1] - c[1]) < DEDUP_THRESHOLD.TAB,
+    );
+    if (isDup) return false;
+    seenCoords.push(tab.coords);
+    return true;
+  });
+  console.log(`Found ${uniqueTabs.length} unique tabs (after deduplication)`);
+  return uniqueTabs;
+}

--- a/packages/ui-tars/cli/src/auto-learn/types.ts
+++ b/packages/ui-tars/cli/src/auto-learn/types.ts
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export interface AppMapMeta {
+  appName: string;
+  package: string;
+  screenWidth: number;
+  screenHeight: number;
+  learnTime: number;
+  learnDate: string;
+  device: string;
+}
+
+export interface TabElement {
+  index: number;
+  name: string;
+  coords: number[];
+  bbox: number[];
+  icon?: string;
+  status: 'reliable' | 'unreliable';
+}
+
+export interface TopButtonElement {
+  name: string;
+  coords: number[];
+  bbox: number[];
+  position?: string;
+  status: 'reliable' | 'unreliable';
+}
+
+export interface NavigationMap {
+  tabs: TabElement[];
+  topButtons: TopButtonElement[];
+}
+
+export interface ElementPattern {
+  type: 'list' | 'grid' | 'carousel';
+  itemWidth?: number;
+  itemHeight: number;
+  marginX?: number;
+  marginY?: number;
+  cols?: number;
+  estimatedCount: number;
+}
+
+export interface Element {
+  id: string;
+  coords: number[];
+  bbox: number[];
+  type: 'button' | 'card' | 'list-item' | 'icon' | 'input' | 'unknown';
+  name?: string;
+  description?: string;
+  text?: string;
+  action: 'navigate' | 'filter' | 'toggle' | 'input' | 'unknown';
+  target?: string;
+  status: 'reliable' | 'unreliable';
+  retryCount: number;
+  lastError?: string;
+  screenshotBefore?: string;
+  screenshotAfter?: string;
+}
+
+export interface Region {
+  id: string;
+  position: 'left' | 'right' | 'top' | 'bottom' | 'center' | 'full';
+  bbox: number[];
+  type:
+    | 'scrollable-list'
+    | 'scrollable-grid'
+    | 'static'
+    | 'carousel'
+    | 'dynamic';
+  scrollable: boolean;
+  elements: Element[];
+  pattern?: ElementPattern;
+  description?: string;
+}
+
+export interface ScrollInfo {
+  regionId: string;
+  direction: 'up' | 'down' | 'left' | 'right';
+  totalCount?: number;
+  hasMore: boolean;
+}
+
+export interface BackAction {
+  type: 'click' | 'hotkey' | 'tab';
+  coords?: number[];
+  bbox?: number[];
+  key?: string;
+  targetTab?: number;
+}
+
+export type LayoutType =
+  | 'scrollable-feed'
+  | 'split-view'
+  | 'card-grid'
+  | 'list'
+  | 'form'
+  | 'unknown';
+
+export interface PageMap {
+  name: string;
+  depth: number;
+  parent?: string;
+  entryElement?: string;
+  layout: LayoutType;
+  regions: Region[];
+  scrollInfo?: ScrollInfo[];
+  backAction?: BackAction;
+  unreliableElements?: string[];
+}
+
+export interface NavigationGraph {
+  [source: string]: string[];
+}
+
+export interface AppMap {
+  meta: AppMapMeta;
+  navigation: NavigationMap;
+  pages: Record<string, PageMap>;
+  secondaryPages?: Record<string, PageMap>;
+  navigationGraph: NavigationGraph;
+}
+
+export interface ActionRecord {
+  type: string;
+  inputs: {
+    start_coords?: number[];
+    start_box?: string;
+    end_coords?: number[];
+    end_box?: string;
+    content?: string;
+    key?: string;
+    direction?: string;
+  };
+  thought: string;
+  screenshotBefore?: string;
+  screenshotAfter?: string;
+  time: number;
+  loopIndex: number;
+}
+
+export interface LearningResult {
+  actions: ActionRecord[];
+  screenshots: string[];
+  finalScreenshot?: string;
+}
+
+export interface PageSignature {
+  name: string;
+  features: string[];
+  notFeatures?: string[];
+  layout?: LayoutType;
+  parentTypes?: string[];
+}
+
+export interface JumpTarget {
+  elementId: string;
+  coords: number[];
+  screenshotBefore?: string;
+}

--- a/packages/ui-tars/cli/src/auto-learn/utils.ts
+++ b/packages/ui-tars/cli/src/auto-learn/utils.ts
@@ -1,0 +1,242 @@
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+/** Deduplication thresholds */
+export const DEDUP_THRESHOLD = {
+  TAB: 80,
+  ELEMENT: 60,
+};
+
+/**
+ * Extract [x, y] coordinates from action inputs
+ */
+export function extractCoords(
+  inputs: Record<string, unknown>,
+): number[] {
+  if (inputs.start_coords && Array.isArray(inputs.start_coords) && inputs.start_coords.length >= 2) {
+    return inputs.start_coords as number[];
+  }
+  return [];
+}
+
+/**
+ * Parse bbox string like "[x1, y1, x2, y2]" to number array
+ */
+export function parseBbox(bboxStr: string): number[] {
+  if (!bboxStr) return [];
+  const match = bboxStr.match(/\[([0-9., ]+)\]/);
+  if (!match) return [];
+  return match[1].split(',').map((s) => parseFloat(s.trim()));
+}
+
+/**
+ * Guess element type from VLM thought string
+ */
+export function guessElementType(
+  thought: string,
+): 'button' | 'card' | 'list-item' | 'icon' | 'input' | 'unknown' {
+  const lower = thought.toLowerCase();
+  if (lower.includes('按钮') || lower.includes('button')) return 'button';
+  if (lower.includes('卡片') || lower.includes('card')) return 'card';
+  if (lower.includes('列表') || lower.includes('list') || lower.includes('item')) return 'list-item';
+  if (lower.includes('输入') || lower.includes('input') || lower.includes('框')) return 'input';
+  if (lower.includes('图标') || lower.includes('icon')) return 'icon';
+  if (lower.includes('tab') || lower.includes('导航')) return 'button';
+  if (lower.includes('弹窗') || lower.includes('dialog')) return 'button';
+  if (lower.includes('链接') || lower.includes('link')) return 'button';
+  return 'unknown';
+}
+
+/**
+ * Guess action type from thought and whether page changed
+ */
+export function guessActionType(thought: string, pageChanged: boolean): string {
+  const lower = thought.toLowerCase();
+  if (pageChanged) return 'navigate';
+  if (lower.includes('筛选') || lower.includes('过滤') || lower.includes('filter')) return 'filter';
+  if (lower.includes('切换') || lower.includes('toggle')) return 'toggle';
+  if (lower.includes('输入') || lower.includes('type')) return 'input';
+  if (lower.includes('关闭') || lower.includes('close')) return 'close';
+  if (lower.includes('确认') || lower.includes('confirm')) return 'confirm';
+  return 'click';
+}
+
+/**
+ * Extract element name from VLM thought (supports 【name】 and "name" patterns)
+ */
+export function extractElementName(thought: string): string {
+  if (!thought) return 'unknown';
+
+  // Try 【name】 pattern
+  const start = thought.indexOf('【');
+  const end = thought.indexOf('】');
+  if (start >= 0 && end > start) {
+    const name = thought.substring(start + 1, end).trim();
+    if (name.length > 1 && name.length <= 20) return name;
+  }
+
+  // Try "name" pattern
+  const q1 = thought.indexOf('"');
+  const q2 = thought.lastIndexOf('"');
+  if (q1 >= 0 && q2 > q1) {
+    const name = thought.substring(q1 + 1, q2).trim();
+    if (name.length > 1 && name.length <= 20) return name;
+  }
+
+  // Keyword-based extraction
+  const keywords = ['按钮', '卡片', '头像', '菜单', '返回', '图标', '标签', '列表', '输入框', '图片', '弹窗', '横幅', '选项', '聊天'];
+  for (const kw of keywords) {
+    const kwIdx = thought.indexOf(kw);
+    if (kwIdx >= 0) {
+      const before = thought.substring(0, kwIdx);
+      let lastStop = -1;
+      for (let j = before.length - 1; j >= 0; j--) {
+        if (' ,，。！？（）"\''.indexOf(before[j]) >= 0) {
+          lastStop = j;
+          break;
+        }
+      }
+      const prefix = lastStop >= 0 ? before.substring(lastStop + 1).trim() : before.trim();
+      if (prefix.length > 0 && prefix.length <= 8) return prefix + kw;
+      return kw;
+    }
+  }
+
+  // Try "点击XXX" pattern
+  const clickIdx = thought.indexOf('点击');
+  if (clickIdx >= 0) {
+    const afterClick = thought.substring(clickIdx + 2).trim();
+    const stopChars = ' ,，。！？；;\n（）';
+    let cutIdx = afterClick.length;
+    for (let i = 0; i < afterClick.length && i < 12; i++) {
+      if (stopChars.indexOf(afterClick[i]) >= 0) {
+        cutIdx = i;
+        break;
+      }
+    }
+    const name = afterClick.substring(0, cutIdx).trim();
+    if (name.length > 1 && name.length <= 12) return name;
+  }
+
+  return 'element';
+}
+
+/**
+ * Generate unique element ID
+ */
+export function generateElementId(
+  pageName: string,
+  elementName: string,
+  idx: number,
+  elemType: string,
+  sameNameCount: number,
+): string {
+  const safeName = elementName.replace(/[^\w\u4e00-\u9fff]/g, '_');
+  const finalName = safeName.length < 2 || safeName === 'element' ? `elem_${idx}` : safeName;
+  const typeSuffix = elemType && elemType !== 'unknown' ? `_${elemType}` : '';
+  const countSuffix = sameNameCount > 0 ? `_${sameNameCount + 1}` : '';
+  return `${pageName}_${finalName}${typeSuffix}${countSuffix}`;
+}
+
+/**
+ * Generate tab name from VLM thought
+ */
+export function generateTabName(thought: string, idx: number): string {
+  const bracketMatch = thought.match(/【([^】]+)】/);
+  if (bracketMatch && bracketMatch[1]) {
+    const name = bracketMatch[1].trim();
+    if (name.length > 1 && name.length <= 10) return name;
+  }
+
+  const tabPatterns = ['首页', '剧场', 'AI伴侣', '消息', '我的', '设置', '个人'];
+  for (const pattern of tabPatterns) {
+    if (thought.includes(pattern)) return pattern;
+  }
+
+  return `Tab_${idx}`;
+}
+
+/**
+ * Check if two coordinates represent the same element (within threshold)
+ */
+export function isSameElement(
+  coords1: number[],
+  coords2: number[],
+  threshold = 50,
+): boolean {
+  if (!coords1 || !coords2 || coords1.length < 2 || coords2.length < 2) return false;
+  const dx = Math.abs(coords1[0] - coords2[0]);
+  const dy = Math.abs(coords1[1] - coords2[1]);
+  return dx < threshold && dy < threshold;
+}
+
+/**
+ * Deduplicate tabs by coordinate proximity
+ */
+export function deduplicateTabs(
+  tabs: Array<{ coords: number[]; name: string }>,
+  threshold = 80,
+): typeof tabs {
+  const unique: typeof tabs = [];
+  for (const tab of tabs) {
+    const isDuplicate = unique.some(
+      (u) => isSameElement(tab.coords, u.coords, threshold),
+    );
+    if (!isDuplicate) {
+      unique.push(tab);
+    }
+  }
+  return unique;
+}
+
+/**
+ * Deduplicate elements by coordinate proximity
+ */
+export function deduplicateElements(
+  elements: Array<{ coords: number[] }>,
+  threshold = DEDUP_THRESHOLD.ELEMENT,
+): typeof elements {
+  const unique: typeof elements = [];
+  const seenCoords: number[][] = [];
+  for (const elem of elements) {
+    const isDuplicate = seenCoords.some(
+      (c) => isSameElement(elem.coords, c, threshold),
+    );
+    if (!isDuplicate) {
+      unique.push(elem);
+      seenCoords.push(elem.coords);
+    }
+  }
+  return unique;
+}
+
+/**
+ * Sanitize package name for use as filename
+ */
+export function mapFile(pkg: string): string {
+  return pkg.replace(/[^a-zA-Z0-9._-]/g, '_') + '.json';
+}
+
+/**
+ * Safe directory creation
+ */
+export function mkdirSafe(dir: string): void {
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * Save base64 screenshot to file
+ */
+export function saveScreenshot(b64: string, name: string, dir: string): string {
+  const p = path.join(dir, name + '.png');
+  fs.writeFileSync(p, Buffer.from(b64, 'base64'));
+  return p;
+}

--- a/packages/ui-tars/cli/src/cli/commands.ts
+++ b/packages/ui-tars/cli/src/cli/commands.ts
@@ -16,6 +16,9 @@ export const run = () => {
     .option('-p, --presets <url>', 'Model Config Presets')
     .option('-t, --target <target>', 'The target operator')
     .option('-q, --query <query>', "Use's query")
+    .option('-l, --auto-learn', 'Automatically learn the app map before running (requires --target adb and --package)')
+    .option('-r, --force-relearn', 'Force regenerating the app map even if cached')
+    .option('--package <pkg>', 'Android app package name (required with --auto-learn)')
     .action(async (options: CliOptions) => {
       try {
         await start(options);

--- a/packages/ui-tars/cli/src/cli/start.ts
+++ b/packages/ui-tars/cli/src/cli/start.ts
@@ -13,11 +13,22 @@ import yaml from 'js-yaml';
 
 import { NutJSOperator } from '@ui-tars/operator-nut-js';
 import { getAndroidDeviceId, AdbOperator } from '@ui-tars/operator-adb';
+import { autoLearnAndRun } from '../auto-learn';
+
+interface PresetConfig {
+  vlmApiKey?: string;
+  vlmBaseUrl?: string;
+  vlmModelName?: string;
+  useResponsesApi?: boolean;
+}
 
 export interface CliOptions {
   presets?: string;
   target?: string;
   query?: string;
+  autoLearn?: boolean;
+  forceRelearn?: boolean;
+  package?: string;
 }
 export const start = async (options: CliOptions) => {
   const CONFIG_PATH = path.join(os.homedir(), '.ui-tars-cli.json');
@@ -37,11 +48,11 @@ export const start = async (options: CliOptions) => {
     }
 
     const yamlText = await response.text();
-    const preset = yaml.load(yamlText) as any;
+    const preset = yaml.load(yamlText) as PresetConfig;
 
-    config.apiKey = preset?.vlmApiKey;
-    config.baseURL = preset?.vlmBaseUrl;
-    config.model = preset?.vlmModelName;
+    config.apiKey = preset?.vlmApiKey ?? '';
+    config.baseURL = preset?.vlmBaseUrl ?? '';
+    config.model = preset?.vlmModelName ?? '';
     config.useResponsesApi = preset?.useResponsesApi ?? false;
   } else if (fs.existsSync(CONFIG_PATH)) {
     try {
@@ -79,6 +90,34 @@ export const start = async (options: CliOptions) => {
   }
 
   let targetOperator = null;
+
+  // Auto-learn phase (only for ADB target)
+  if (options.autoLearn && options.target === 'adb') {
+    if (!options.package) {
+      console.error('--package is required when using --auto-learn with --target adb');
+      process.exit(1);
+    }
+
+    const deviceId = await getAndroidDeviceId();
+    if (deviceId == null) {
+      console.error('No Android devices found. Please connect a device and try again.');
+      process.exit(0);
+    }
+
+    const map = await autoLearnAndRun({
+      pkg: options.package,
+      deviceId,
+      modelConfig: config,
+      forceRelearn: options.forceRelearn,
+    });
+
+    if (map) {
+      console.log(
+        `\n[Auto-Learn] App map ready: ${map.meta.package} (${Object.keys(map.pages).length} pages, ${map.navigation.tabs.length} tabs)`,
+      );
+    }
+  }
+
   const targetType =
     options.target ||
     ((await p.select({

--- a/packages/ui-tars/cli/vitest.config.mts
+++ b/packages/ui-tars/cli/vitest.config.mts
@@ -14,14 +14,14 @@ export default defineProject({
   root: './',
   test: {
     globals: true,
-    setupFiles: [resolve(__dirname, '../../scripts/vitest-setup.ts')],
+    setupFiles: [resolve(__dirname, '../../../scripts/vitest-setup.ts')],
     environment: 'node',
-    includeSource: [resolve(__dirname, '.')],
+    include: ['src/**/*.test.ts', 'src/**/*.spec.ts'],
   },
 
   plugins: [
     tsconfigPath({
-      projects: ['../../tsconfig.node.json'],
+      projects: ['../tsconfig.node.json'],
     }),
   ],
 });


### PR DESCRIPTION
Add --auto-learn flag to automatically discover and map Android app UI structure (navigation tabs, interactive elements, page layouts, jump targets) using VLM-guided agents. Includes code review fixes for security (argument sanitization), error handling, type safety, and timeout protection.

<!--------------------------------------------------------------------------------
    Thank you for submitting a pull request!

    We appreciate the time and effort you have invested in making these changes. Please 
    ensure that you provide enough information to allow others to review your pull request 
    effectively, so please DO NOT delete this template.

    If you're new to contributing, learn more about contributing here:
    https://github.com/bytedance/UI-TARS-desktop/blob/main/CONTRIBUTING.md.  
---------------------------------------------------------------------------------->

## Summary

<!--------------------------------------------------------------------------------
    Can you explain the reasoning behind implementing this change?  
    What problem or issue does this pull request resolve?  

    It would be helpful to include relevant context, such as GitHub issues 
    (e.g., Close: #xxx) or related discussions.

    If updating the UI, please include a **before/after screenshot** for visibility.
    Thank you for reading. Next, start describing your Summary on the next line
    after the comment ends. 👇🏻
---------------------------------------------------------------------------------->



## Checklist  

<!--  Before submitting the pull request, ensure the following items are checked: -->

- [x] Added or updated necessary tests (Optional).  
- [ ] Updated documentation to align with changes (Optional).  
- [x] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).  
- [ ] My change does not involve the above items. 
