### PR TITLE
fix(browser-operator): add missing win/meta/super key mappings

### DIFF
--- a/packages/ui-tars/operators/browser-operator/src/key-map.ts
+++ b/packages/ui-tars/operators/browser-operator/src/key-map.ts
@@ -41,6 +41,9 @@ export const KEY_MAPPINGS: Record<string, KeyInput> = {
   ctrl: ControlOrMeta,
   cmd: ControlOrMeta,
   command: ControlOrMeta,
+  win: 'Meta',
+  meta: 'Meta',
+  super: 'Meta',
 
   // a-z
   a: 'KeyA',


### PR DESCRIPTION
Fixes #1843

## Problem

When UI-TARS tries to execute a hotkey involving the Windows key (`win`), it throws:

```
Error: Unsupported key: win
    at DefaultBrowserOperator.handleHotkey
```

This is because `win` (the Windows Meta key) was not present in `KEY_MAPPINGS` in `key-map.ts`. Any hotkey combination using `win` (e.g., `win+d` for Show Desktop, `win+r` for Run dialog) would fail with this error.

## Solution

Added the following key aliases to `KEY_MAPPINGS`:

- `win` → `'Meta'` (Windows key on Windows)
- `meta` → `'Meta'` (explicit Meta key reference)
- `super` → `'Meta'` (Linux/Unix convention for the Super/Windows key)

These all map to Puppeteer's `'Meta'` `KeyInput`, which represents the platform meta key (Windows key on Windows, Command key on macOS).

## Testing

The fix can be verified by triggering a hotkey action that uses the `win` key — the error `Unsupported key: win` will no longer be thrown, and the key will be correctly mapped to `Meta` in the browser keyboard event.