### PR TITLE
fix(browser): add timeout and validation to CDP endpoint fetch in RemoteBrowser

### DIFF
--- a/packages/agent-infra/browser/src/remote-browser.ts
+++ b/packages/agent-infra/browser/src/remote-browser.ts
@@ -60,8 +60,20 @@ export class RemoteBrowser extends BaseBrowser {
     if (!browserWSEndpoint) {
       const cdpEndpoint =
         this.options?.cdpEndpoint || `http://127.0.0.1:9222/json/version`;
-      const response = await fetch(cdpEndpoint);
+      const response = await fetch(cdpEndpoint, {
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (!response.ok) {
+        throw new Error(
+          `Failed to fetch CDP endpoint ${cdpEndpoint}: ${response.status} ${response.statusText}`,
+        );
+      }
       const { webSocketDebuggerUrl } = await response.json();
+      if (!webSocketDebuggerUrl) {
+        throw new Error(
+          `CDP endpoint ${cdpEndpoint} did not return a webSocketDebuggerUrl`,
+        );
+      }
       browserWSEndpoint = webSocketDebuggerUrl;
     }
 


### PR DESCRIPTION
## Summary

The `fetch()` call in `RemoteBrowser.launch()` to discover the WebSocket debugger URL has three issues:

1. **No timeout** — hangs indefinitely if the CDP server is unresponsive
2. **No HTTP status check** — calls `response.json()` on error responses (e.g. 500), producing confusing errors
3. **No null check** — if `webSocketDebuggerUrl` is missing from the response, puppeteer fails later with an unclear error

## Changes

- Add `AbortSignal.timeout(10_000)` to fail fast on unresponsive servers
- Validate `response.ok` before parsing JSON
- Check that `webSocketDebuggerUrl` is present before using it

All three errors now throw with clear messages identifying what went wrong.