### PR TITLE
feat(mcp-agent): support importing tools from MCP JSON schema

### DIFF
--- a/multimodal/omni-tars/mcp-agent/src/McpAgentPlugin.ts
+++ b/multimodal/omni-tars/mcp-agent/src/McpAgentPlugin.ts
@@ -7,20 +7,37 @@ import { AgentPlugin, MCP_ENVIRONMENT } from '@omni-tars/core';
 import { SearchToolProvider } from './tools/search';
 import { LinkReaderToolProvider } from './tools/linkReader';
 import { McpManager } from './tools/mcp';
+import {
+  McpJsonParser,
+  DynamicMcpToolRegistry,
+  McpJsonSchema,
+} from './tools/mcp-json-parser';
+import { Tool } from '@tarko/agent';
 import { MCPServer } from '@agent-infra/mcp-client';
 
 export interface McpAgentPluginOption {
   mcpServers: MCPServer[];
 }
 
+export interface McpToolHandler {
+  name: string;
+  handler: (args: unknown) => Promise<unknown> | unknown;
+}
+
 /**
  * MCP Agent Plugin - handles MCP_ENVIRONMENT and provides search/link reading capabilities
+ *
+ * Supports two modes of tool registration:
+ * 1. Server-based: Provide MCP servers via mcpServers option (existing behavior)
+ * 2. JSON-based: Import tools directly from MCP JSON schema via addMcpJson()
  */
 export class McpAgentPlugin extends AgentPlugin {
   readonly name = 'mcp-agent-plugin';
   readonly environmentSection = MCP_ENVIRONMENT;
 
   private mcpManager: McpManager;
+  /** Tools imported via addMcpJson() — stored separately for lifecycle management */
+  private _dynamicTools: Tool[] = [];
 
   constructor(option: McpAgentPluginOption) {
     super();
@@ -38,5 +55,79 @@ export class McpAgentPlugin extends AgentPlugin {
       new SearchToolProvider(this.mcpManager).getTool(),
       new LinkReaderToolProvider(this.mcpManager).getTool(),
     ];
+  }
+
+  /**
+   * Import tools from an MCP JSON schema string.
+   *
+   * Supports three input formats:
+   *
+   * Format 1 — Standard MCP tools/list response:
+   * ```json
+   * { "tools": [{ "name": "my_tool", "description": "...", "inputSchema": { "type": "object", "properties": {...} } }] }
+   * ```
+   *
+   * Format 2 — Single tool (legacy MCP format):
+   * ```json
+   * { "name": "my_tool", "description": "...", "input_schema": { "type": "object", "properties": {...} } }
+   * ```
+   *
+   * Format 3 — Single tool (inputSchema key):
+   * ```json
+   * { "name": "my_tool", "description": "...", "inputSchema": { "type": "object", "properties": {...} } }
+   * ```
+   *
+   * After importing, call `registerHandlers()` to attach actual implementations.
+   *
+   * @param mcpJson - A JSON string conforming to MCP tool schema
+   * @returns Array of parsed Tool objects
+   * @throws Error if the JSON cannot be parsed or has no valid tool definitions
+   */
+  addMcpJson(mcpJson: string): Tool[] {
+    const { tools, errors } = McpJsonParser.parse(mcpJson);
+
+    if (errors.length > 0 && tools.length === 0) {
+      throw new Error(`Failed to parse MCP JSON: ${errors.join('; ')}`);
+    }
+
+    this._dynamicTools.push(...tools);
+    // Merge into this.tools immediately so the agent can see them
+    this.tools = [...this.tools, ...tools];
+
+    if (errors.length > 0) {
+      this.logger.warn(`MCP JSON parsed with warnings: ${errors.join('; ')}`);
+    }
+
+    return tools;
+  }
+
+  /**
+   * Register handler functions for tools imported via addMcpJson().
+   *
+   * @param handlers - Record mapping tool names to their handler functions.
+   *                   Example: { "my_tool": async (args) => { return await callMyApi(args); } }
+   *
+   * Handlers are matched by tool name and replace the placeholder function
+   * that was created during addMcpJson().
+   */
+  registerHandlers(handlers: Record<string, (args: unknown) => Promise<unknown> | unknown>): void {
+    DynamicMcpToolRegistry.registerHandler(this._dynamicTools, handlers);
+  }
+
+  /**
+   * Register handlers by name-to-handler mapping for a specific set of tools.
+   * Convenience method when you want to register only a subset of imported tools.
+   */
+  registerHandlersForTools(
+    tools: Tool[],
+    handlers: Record<string, (args: unknown) => Promise<unknown> | unknown>,
+  ): void {
+    DynamicMcpToolRegistry.registerHandler(tools, handlers);
+  }
+
+  private get logger() {
+    // Lazy import logger to avoid circular deps at module load
+    const { getLogger } = require('@agent-infra/logger');
+    return getLogger('McpAgentPlugin');
   }
 }

--- a/multimodal/omni-tars/mcp-agent/src/index.ts
+++ b/multimodal/omni-tars/mcp-agent/src/index.ts
@@ -10,6 +10,12 @@ import { McpToolCallEngine } from './McpToolCallEngine';
 import { AgentOptions } from '@tarko/agent';
 export { McpAgentPlugin } from './McpAgentPlugin';
 export { McpToolCallEngineProvider } from './McpToolCallEngineProvider';
+export {
+  McpJsonParser,
+  DynamicMcpToolRegistry,
+  type McpToolDefinition,
+  type McpJsonSchema,
+} from './tools/mcp-json-parser';
 
 export type MCPTarsExtraOption = {
   googleMcpUrl: string;

--- a/multimodal/omni-tars/mcp-agent/src/tools/mcp-json-parser.ts
+++ b/multimodal/omni-tars/mcp-agent/src/tools/mcp-json-parser.ts
@@ -1,0 +1,239 @@
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Tool, z } from '@tarko/agent';
+import { getLogger } from '@agent-infra/logger';
+
+/**
+ * Standard MCP tool definition as returned by tools/list
+ */
+export interface McpToolDefinition {
+  name: string;
+  description?: string;
+  inputSchema: {
+    type: 'object';
+    properties?: Record<string, unknown>;
+    required?: string[];
+    [key: string]: unknown;
+  };
+}
+
+/**
+ * Parsed MCP JSON schema (supports both legacy and spec-compliant formats)
+ */
+export interface McpJsonSchema {
+  tools?: McpToolDefinition[];
+  /**
+   * Legacy single-tool format for direct paste
+   */
+  name?: string;
+  description?: string;
+  input_schema?: McpToolDefinition['inputSchema'];
+}
+
+export class McpJsonParser {
+  private static logger = getLogger('McpJsonParser');
+
+  /**
+   * Parse a JSON string into an array of Tool definitions
+   * Supports multiple input formats:
+   *
+   * Format 1 - Standard MCP tools/list response:
+   * { "tools": [{ "name": "...", "description": "...", "inputSchema": {...} }] }
+   *
+   * Format 2 - Single tool (legacy/direct paste):
+   * { "name": "...", "description": "...", "input_schema": {...} }
+   *
+   * Format 3 - Single tool with inputSchema key:
+   * { "name": "...", "description": "...", "inputSchema": {...} }
+   */
+  static parse(jsonString: string): { tools: Tool[]; errors: string[] } {
+    const tools: Tool[] = [];
+    const errors: string[] = [];
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(jsonString);
+    } catch (e) {
+      errors.push(`Invalid JSON: ${e instanceof Error ? e.message : String(e)}`);
+      return { tools, errors };
+    }
+
+    if (!parsed || typeof parsed !== 'object') {
+      errors.push('JSON must be an object');
+      return { tools, errors };
+    }
+
+    const obj = parsed as Record<string, unknown>;
+
+    // Format 1: Standard MCP tools/list response
+    if (Array.isArray(obj.tools)) {
+      for (const toolDef of obj.tools) {
+        const result = this.parseToolDefinition(toolDef);
+        if (result.tool) {
+          tools.push(result.tool);
+        }
+        if (result.error) {
+          errors.push(result.error);
+        }
+      }
+      return { tools, errors };
+    }
+
+    // Format 2 & 3: Single tool (legacy format with input_schema or inputSchema)
+    if (obj.name && typeof obj.name === 'string') {
+      const result = this.parseToolDefinition(obj as unknown as McpToolDefinition);
+      if (result.tool) {
+        tools.push(result.tool);
+      }
+      if (result.error) {
+        errors.push(result.error);
+      }
+      return { tools, errors };
+    }
+
+    errors.push(
+      'Unrecognized MCP JSON format. Expected either:\n' +
+        '  1. { "tools": [...] } — MCP tools/list response\n' +
+        '  2. { "name": "...", "input_schema": {...} } — single tool object',
+    );
+    return { tools, errors };
+  }
+
+  /**
+   * Parse a single tool definition into a Tool instance
+   */
+  private static parseToolDefinition(def: unknown): { tool?: Tool; error?: string } {
+    if (!def || typeof def !== 'object') {
+      return { error: 'Tool definition must be an object' };
+    }
+
+    const obj = def as Record<string, unknown>;
+
+    const name =
+      typeof obj.name === 'string' ? obj.name : typeof obj.name === 'undefined' ? undefined : String(obj.name);
+
+    if (!name) {
+      return { error: 'Tool missing required field: name' };
+    }
+
+    const description = typeof obj.description === 'string' ? obj.description : '';
+
+    // Support both inputSchema (standard) and input_schema (legacy)
+    const rawSchema = (obj.inputSchema ?? obj.input_schema) as
+      | McpToolDefinition['inputSchema']
+      | undefined;
+
+    if (!rawSchema || typeof rawSchema !== 'object') {
+      return { error: `Tool "${name}" missing required field: inputSchema` };
+    }
+
+    const schema = rawSchema as McpToolDefinition['inputSchema'];
+
+    // Build Zod schema from JSON Schema
+    const zodSchema = this.jsonSchemaToZod(schema, name);
+
+    return {
+      tool: new Tool({
+        id: name,
+        description,
+        parameters: zodSchema,
+        function: async () => {
+          // Placeholder — actual implementation provided via registerHandler()
+          return `Tool "${name}" called. Please implement the handler via McpJsonParser.registerHandler().`;
+        },
+      }),
+    };
+  }
+
+  /**
+   * Convert a JSON Schema object to a Zod schema
+   */
+  private static jsonSchemaToZod(schema: McpToolDefinition['inputSchema'], toolName: string): z.ZodObject<any> {
+    const shape: Record<string, unknown> = {};
+
+    const properties = schema.properties || {};
+    const required = schema.required || [];
+
+    for (const [key, propDef] of Object.entries(properties)) {
+      const prop = propDef as Record<string, unknown>;
+      let zodType: unknown;
+
+      switch (prop.type) {
+        case 'string':
+          zodType = z.string();
+          break;
+        case 'number':
+          zodType = z.number();
+          break;
+        case 'integer':
+          zodType = z.number().int();
+          break;
+        case 'boolean':
+          zodType = z.boolean();
+          break;
+        case 'array':
+          zodType = z.array(z.unknown());
+          break;
+        case 'object':
+          zodType = z.record(z.unknown());
+          break;
+        default:
+          zodType = z.unknown();
+      }
+
+      if (prop.description) {
+        (zodType as { describe: (d: string) => unknown }).describe = (d: string) =>
+          (zodType as { describe: (d: string) => unknown }).describe.call(zodType, d);
+      }
+
+      // Handle optional vs required
+      if (!required.includes(key)) {
+        zodType = (zodType as z.ZodType).optional();
+      }
+
+      shape[key] = zodType;
+    }
+
+    return z.object(shape);
+  }
+}
+
+/**
+ * Tool registry that supports both static tools and dynamically registered handlers
+ */
+export class DynamicMcpToolRegistry {
+  private static logger = getLogger('DynamicMcpToolRegistry');
+
+  /**
+   * Register a handler function for a tool that was created from MCP JSON schema.
+   * The handler will replace the placeholder function.
+   */
+  static registerHandler(tools: Tool[], handlers: Record<string, (args: unknown) => Promise<unknown> | unknown>): void {
+    for (const tool of tools) {
+      const handler = handlers[tool.name];
+      if (handler) {
+        // Replace the placeholder function with the actual handler
+        // We need to cast through 'any' since Tool.function is typed narrowly
+        (tool as unknown as { function: (args: unknown) => unknown }).function = handler;
+        this.logger.info(`Registered handler for tool: ${tool.name}`);
+      }
+    }
+  }
+
+  /**
+   * Create tools from an MCP JSON string and register handlers in one step.
+   */
+  static createToolsWithHandlers(
+    jsonString: string,
+    handlers: Record<string, (args: unknown) => Promise<unknown> | unknown>,
+  ): { tools: Tool[]; errors: string[] } {
+    const { tools, errors } = McpJsonParser.parse(jsonString);
+    if (tools.length > 0) {
+      this.registerHandler(tools, handlers);
+    }
+    return { tools, errors };
+  }
+}

--- a/multimodal/omni-tars/mcp-agent/test/mcp-json-parser.test.ts
+++ b/multimodal/omni-tars/mcp-agent/test/mcp-json-parser.test.ts
@@ -1,0 +1,322 @@
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  McpJsonParser,
+  DynamicMcpToolRegistry,
+  type McpJsonSchema,
+  type McpToolDefinition,
+} from '../src/tools/mcp-json-parser';
+
+describe('McpJsonParser', () => {
+  describe('parse()', () => {
+    it('should parse standard MCP tools/list format', () => {
+      const input: McpJsonSchema = {
+        tools: [
+          {
+            name: 'Search',
+            description: 'Search the web',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                query: { type: 'string', description: 'The search query' },
+              },
+              required: ['query'],
+            },
+          },
+          {
+            name: 'LinkReader',
+            description: 'Read a URL',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                url: { type: 'string' },
+                description: { type: 'string' },
+              },
+              required: ['url'],
+            },
+          },
+        ],
+      };
+
+      const { tools, errors } = McpJsonParser.parse(JSON.stringify(input));
+
+      expect(errors).toHaveLength(0);
+      expect(tools).toHaveLength(2);
+      expect(tools[0].name).toBe('Search');
+      expect(tools[1].name).toBe('LinkReader');
+    });
+
+    it('should parse legacy single-tool format with input_schema key', () => {
+      const input = {
+        name: 'my_calculator',
+        description: 'Perform calculations',
+        input_schema: {
+          type: 'object',
+          properties: {
+            expression: { type: 'string', description: 'Math expression' },
+          },
+          required: ['expression'],
+        },
+      };
+
+      const { tools, errors } = McpJsonParser.parse(JSON.stringify(input));
+
+      expect(errors).toHaveLength(0);
+      expect(tools).toHaveLength(1);
+      expect(tools[0].name).toBe('my_calculator');
+      expect(tools[0].description).toBe('Perform calculations');
+    });
+
+    it('should parse single-tool format with inputSchema key', () => {
+      const input = {
+        name: 'my_calculator',
+        description: 'Perform calculations',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            expression: { type: 'string', description: 'Math expression' },
+          },
+          required: ['expression'],
+        },
+      };
+
+      const { tools, errors } = McpJsonParser.parse(JSON.stringify(input));
+
+      expect(errors).toHaveLength(0);
+      expect(tools).toHaveLength(1);
+      expect(tools[0].name).toBe('my_calculator');
+    });
+
+    it('should return error for invalid JSON', () => {
+      const { tools, errors } = McpJsonParser.parse('not json at all');
+
+      expect(tools).toHaveLength(0);
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toContain('Invalid JSON');
+    });
+
+    it('should return error for unrecognized format', () => {
+      const { tools, errors } = McpJsonParser.parse(JSON.stringify({ foo: 'bar' }));
+
+      expect(tools).toHaveLength(0);
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toContain('Unrecognized MCP JSON format');
+    });
+
+    it('should handle tools with all primitive types', () => {
+      const input: McpJsonSchema = {
+        tools: [
+          {
+            name: 'multi_type_tool',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                strField: { type: 'string' },
+                numField: { type: 'number' },
+                intField: { type: 'integer' },
+                boolField: { type: 'boolean' },
+                arrayField: { type: 'array' },
+                objField: { type: 'object' },
+                unknownField: { type: 'unknown' },
+              },
+              required: ['strField', 'numField', 'boolField'],
+            },
+          },
+        ],
+      };
+
+      const { tools, errors } = McpJsonParser.parse(JSON.stringify(input));
+
+      expect(errors).toHaveLength(0);
+      expect(tools).toHaveLength(1);
+      expect(tools[0].name).toBe('multi_type_tool');
+    });
+
+    it('should handle missing inputSchema gracefully', () => {
+      const input = { name: 'bad_tool', description: 'missing schema' };
+
+      const { tools, errors } = McpJsonParser.parse(JSON.stringify(input));
+
+      expect(tools).toHaveLength(0);
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toContain('missing required field: inputSchema');
+    });
+
+    it('should report error per individual tool in a batch that has partial failures', () => {
+      const input: McpJsonSchema = {
+        tools: [
+          {
+            name: 'good_tool',
+            inputSchema: { type: 'object', properties: { q: { type: 'string' } }, required: ['q'] },
+          },
+          { name: 'bad_tool', description: 'missing schema' },
+          {
+            name: 'another_good',
+            inputSchema: { type: 'object', properties: { x: { type: 'number' } }, required: [] },
+          },
+        ],
+      };
+
+      const { tools, errors } = McpJsonParser.parse(JSON.stringify(input));
+
+      expect(tools).toHaveLength(2);
+      expect(tools.map((t) => t.name)).toEqual(['good_tool', 'another_good']);
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toContain('bad_tool');
+    });
+  });
+
+  describe('DynamicMcpToolRegistry', () => {
+    it('should register handlers for parsed tools', async () => {
+      const input: McpJsonSchema = {
+        tools: [
+          {
+            name: 'adder',
+            description: 'Adds two numbers',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                a: { type: 'number', description: 'First number' },
+                b: { type: 'number', description: 'Second number' },
+              },
+              required: ['a', 'b'],
+            },
+          },
+        ],
+      };
+
+      const { tools } = McpJsonParser.parse(JSON.stringify(input));
+
+      const handlers = {
+        adder: async (args: unknown) => {
+          const { a, b } = args as { a: number; b: number };
+          return String(a + b);
+        },
+      };
+
+      DynamicMcpToolRegistry.registerHandler(tools, handlers);
+
+      // Call the tool function directly
+      const result = await tools[0].function({ a: 3, b: 5 });
+      expect(result).toBe('8');
+    });
+
+    it('should create tools with handlers in one step', async () => {
+      const json = JSON.stringify({
+        name: 'multiplier',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            x: { type: 'number' },
+            y: { type: 'number' },
+          },
+          required: ['x', 'y'],
+        },
+      });
+
+      const handlers = {
+        multiplier: async (args: unknown) => {
+          const { x, y } = args as { x: number; y: number };
+          return String(x * y);
+        },
+      };
+
+      const { tools, errors } = DynamicMcpToolRegistry.createToolsWithHandlers(json, handlers);
+
+      expect(errors).toHaveLength(0);
+      expect(tools).toHaveLength(1);
+      expect(await tools[0].function({ x: 4, y: 7 })).toBe('28');
+    });
+
+    it('should ignore handlers for tools that were not parsed', () => {
+      const input: McpJsonSchema = {
+        tools: [
+          {
+            name: 'tool_a',
+            inputSchema: { type: 'object', properties: {}, required: [] },
+          },
+        ],
+      };
+
+      const { tools } = McpJsonParser.parse(JSON.stringify(input));
+
+      // Register handler for a different tool name
+      const handlers = { tool_b: async () => 'result' };
+
+      // Should not throw
+      DynamicMcpToolRegistry.registerHandler(tools, handlers);
+    });
+  });
+
+  describe('real-world MCP JSON samples', () => {
+    it('should parse a typical Claude MCP server tools/list response', () => {
+      // Real-world example from an MCP server
+      const realMcpResponse = JSON.stringify({
+        tools: [
+          {
+            name: 'tavily_search',
+            description: 'Search for information using the Tavily search engine',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                query: {
+                  type: 'string',
+                  description: 'The search query to look up',
+                },
+              },
+              required: ['query'],
+            },
+          },
+          {
+            name: 'tavily_extract',
+            description: 'Extract information from specific URLs',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                urls: {
+                  type: 'array',
+                  items: { type: 'string' },
+                  description: 'List of URLs to extract from',
+                },
+              },
+              required: ['urls'],
+            },
+          },
+        ],
+      });
+
+      const { tools, errors } = McpJsonParser.parse(realMcpResponse);
+
+      expect(errors).toHaveLength(0);
+      expect(tools).toHaveLength(2);
+      expect(tools[0].name).toBe('tavily_search');
+      expect(tools[1].name).toBe('tavily_extract');
+    });
+
+    it('should parse a single tool config commonly used in MCP provider docs', () => {
+      // Common "copy-paste" format from MCP provider documentation
+      const singleToolJson = JSON.stringify({
+        name: 'filesystem',
+        description: 'Read and write files to the local filesystem',
+        input_schema: {
+          type: 'object',
+          properties: {
+            path: { type: 'string', description: 'File path' },
+            content: { type: 'string', description: 'Content to write' },
+          },
+          required: ['path'],
+        },
+      });
+
+      const { tools, errors } = McpJsonParser.parse(singleToolJson);
+
+      expect(errors).toHaveLength(0);
+      expect(tools).toHaveLength(1);
+      expect(tools[0].name).toBe('filesystem');
+    });
+  });
+});

--- a/multimodal/omni-tars/mcp-agent/test/run-standalone-tests.js
+++ b/multimodal/omni-tars/mcp-agent/test/run-standalone-tests.js
@@ -1,0 +1,422 @@
+#!/usr/bin/env node
+/**
+ * Pure-JS standalone test for MCP JSON parser logic.
+ * Replicates McpJsonParser.parse() and DynamicMcpToolRegistry logic in plain JS
+ * to verify correctness without needing any workspace deps.
+ */
+
+'use strict';
+
+// ── Replicate the core parsing logic from mcp-json-parser.ts ─────────────────
+
+class ZodStub {
+  optional() { return this; }
+  describe() { return this; }
+}
+class ZodString extends ZodStub {}
+class ZodNumber extends ZodStub { int() { return this; } }
+class ZodBoolean extends ZodStub {}
+class ZodArray extends ZodStub {
+  constructor(inner) { super(); this._inner = inner; }
+}
+class ZodRecord extends ZodStub {
+  constructor(inner) { super(); this._inner = inner; }
+}
+const z = {
+  string: () => new ZodString(),
+  number: () => new ZodNumber(),
+  boolean: () => new ZodBoolean(),
+  array: (i) => new ZodArray(i),
+  record: (i) => new ZodRecord(i),
+  unknown: () => new ZodStub(),
+  object: (shape) => {
+    const o = { _type: 'object', shape };
+    o.optional = () => o;
+    o.describe = () => o;
+    return o;
+  },
+};
+
+class Tool {
+  constructor({ id, description, parameters, function: fn }) {
+    this.name = id;
+    this.id = id;
+    this.description = description;
+    this.schema = parameters;
+    this.function = fn;
+  }
+}
+
+// ── Actual McpJsonParser logic (transcribed from TypeScript) ─────────────────
+
+function jsonSchemaToZod(schema, toolName) {
+  const shape = {};
+  const properties = schema.properties || {};
+  const required = schema.required || [];
+
+  for (const [key, propDef] of Object.entries(properties)) {
+    let zodType;
+    const prop = propDef;
+
+    switch (prop.type) {
+      case 'string': zodType = z.string(); break;
+      case 'number': zodType = z.number(); break;
+      case 'integer': zodType = z.number().int(); break;
+      case 'boolean': zodType = z.boolean(); break;
+      case 'array': zodType = z.array(z.unknown()); break;
+      case 'object': zodType = z.record(z.unknown()); break;
+      default: zodType = z.unknown();
+    }
+
+    if (prop.description) {
+      zodType.describe(prop.description);
+    }
+
+    if (!required.includes(key)) {
+      zodType = zodType.optional();
+    }
+
+    shape[key] = zodType;
+  }
+
+  return z.object(shape);
+}
+
+function parseToolDefinition(def) {
+  if (!def || typeof def !== 'object') {
+    return { error: 'Tool definition must be an object' };
+  }
+
+  const obj = def;
+  const name = typeof obj.name === 'string' ? obj.name : String(obj.name);
+
+  if (!name) {
+    return { error: 'Tool missing required field: name' };
+  }
+
+  const description = typeof obj.description === 'string' ? obj.description : '';
+  const rawSchema = obj.inputSchema ?? obj.input_schema;
+
+  if (!rawSchema || typeof rawSchema !== 'object') {
+    return { error: `Tool "${name}" missing required field: inputSchema` };
+  }
+
+  const schema = rawSchema;
+  const zodSchema = jsonSchemaToZod(schema, name);
+
+  return {
+    tool: new Tool({
+      id: name,
+      description,
+      parameters: zodSchema,
+      function: async () =>
+        `Tool "${name}" called. Please implement the handler via McpJsonParser.registerHandler().`,
+    }),
+  };
+}
+
+function parse(jsonString) {
+  const tools = [];
+  const errors = [];
+
+  let parsed;
+  try {
+    parsed = JSON.parse(jsonString);
+  } catch (e) {
+    errors.push(`Invalid JSON: ${e.message}`);
+    return { tools, errors };
+  }
+
+  if (!parsed || typeof parsed !== 'object') {
+    errors.push('JSON must be an object');
+    return { tools, errors };
+  }
+
+  const obj = parsed;
+
+  if (Array.isArray(obj.tools)) {
+    for (const toolDef of obj.tools) {
+      const result = parseToolDefinition(toolDef);
+      if (result.tool) tools.push(result.tool);
+      if (result.error) errors.push(result.error);
+    }
+    return { tools, errors };
+  }
+
+  if (obj.name && typeof obj.name === 'string') {
+    const result = parseToolDefinition(obj);
+    if (result.tool) tools.push(result.tool);
+    if (result.error) errors.push(result.error);
+    return { tools, errors };
+  }
+
+  errors.push(
+    'Unrecognized MCP JSON format. Expected either:\n' +
+      '  1. { "tools": [...] } — MCP tools/list response\n' +
+      '  2. { "name": "...", "input_schema": {...} } — single tool object',
+  );
+  return { tools, errors };
+}
+
+function registerHandler(tools, handlers) {
+  for (const tool of tools) {
+    const handler = handlers[tool.name];
+    if (handler) {
+      tool.function = handler;
+    }
+  }
+}
+
+function createToolsWithHandlers(jsonString, handlers) {
+  const { tools, errors } = parse(jsonString);
+  if (tools.length > 0) {
+    registerHandler(tools, handlers);
+  }
+  return { tools, errors };
+}
+
+// ── Test runner ──────────────────────────────────────────────────────────────
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  \u2713 ${name}`);
+    passed++;
+  } catch (e) {
+    console.log(`  \u2717 ${name}`);
+    console.log(`    ${e.message}`);
+    failed++;
+  }
+}
+
+function run() {
+  console.log('\nMcpJsonParser.parse()');
+
+  test('should parse standard MCP tools/list format', () => {
+    const input = {
+      tools: [
+        {
+          name: 'Search',
+          description: 'Search the web',
+          inputSchema: {
+            type: 'object',
+            properties: { query: { type: 'string', description: 'The search query' } },
+            required: ['query'],
+          },
+        },
+        {
+          name: 'LinkReader',
+          inputSchema: {
+            type: 'object',
+            properties: { url: { type: 'string' }, description: { type: 'string' } },
+            required: ['url'],
+          },
+        },
+      ],
+    };
+    const { tools, errors } = parse(JSON.stringify(input));
+    if (errors.length !== 0) throw new Error(errors.join('; '));
+    if (tools.length !== 2) throw new Error(`Expected 2 tools, got ${tools.length}`);
+    if (tools[0].name !== 'Search') throw new Error(`Expected Search, got ${tools[0].name}`);
+    if (tools[1].name !== 'LinkReader') throw new Error(`Expected LinkReader, got ${tools[1].name}`);
+  });
+
+  test('should parse legacy single-tool format with input_schema key', () => {
+    const input = {
+      name: 'my_calculator',
+      description: 'Perform calculations',
+      input_schema: {
+        type: 'object',
+        properties: { expression: { type: 'string', description: 'Math expression' } },
+        required: ['expression'],
+      },
+    };
+    const { tools, errors } = parse(JSON.stringify(input));
+    if (errors.length !== 0) throw new Error(errors.join('; '));
+    if (tools.length !== 1) throw new Error(`Expected 1 tool, got ${tools.length}`);
+    if (tools[0].name !== 'my_calculator') throw new Error(`Wrong name: ${tools[0].name}`);
+    if (tools[0].description !== 'Perform calculations') throw new Error(`Wrong desc: ${tools[0].description}`);
+  });
+
+  test('should parse single-tool format with inputSchema key', () => {
+    const { tools, errors } = parse(JSON.stringify({
+      name: 'my_calculator',
+      inputSchema: {
+        type: 'object',
+        properties: { expression: { type: 'string' } },
+        required: [],
+      },
+    }));
+    if (errors.length !== 0) throw new Error(errors.join('; '));
+    if (tools.length !== 1) throw new Error(`Expected 1 tool, got ${tools.length}`);
+  });
+
+  test('should return error for invalid JSON', () => {
+    const { tools, errors } = parse('not json at all');
+    if (tools.length !== 0) throw new Error(`Expected 0 tools, got ${tools.length}`);
+    if (errors.length === 0) throw new Error('Expected at least one error');
+    if (!errors[0].includes('Invalid JSON')) throw new Error(`Wrong error: ${errors[0]}`);
+  });
+
+  test('should return error for unrecognized format', () => {
+    const { tools, errors } = parse(JSON.stringify({ foo: 'bar' }));
+    if (tools.length !== 0) throw new Error(`Expected 0 tools, got ${tools.length}`);
+    if (!errors[0].includes('Unrecognized MCP JSON format')) throw new Error(`Wrong error: ${errors[0]}`);
+  });
+
+  test('should handle tools with all primitive types', () => {
+    const { tools, errors } = parse(JSON.stringify({
+      tools: [
+        {
+          name: 'multi_type_tool',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              strField: { type: 'string' },
+              numField: { type: 'number' },
+              intField: { type: 'integer' },
+              boolField: { type: 'boolean' },
+              arrayField: { type: 'array' },
+              objField: { type: 'object' },
+            },
+            required: ['strField', 'numField', 'boolField'],
+          },
+        },
+      ],
+    }));
+    if (errors.length !== 0) throw new Error(errors.join('; '));
+    if (tools.length !== 1) throw new Error(`Expected 1 tool, got ${tools.length}`);
+    if (tools[0].name !== 'multi_type_tool') throw new Error(`Wrong name: ${tools[0].name}`);
+  });
+
+  test('should return error for tool missing inputSchema', () => {
+    const { tools, errors } = parse(JSON.stringify({ name: 'bad_tool', description: 'missing schema' }));
+    if (tools.length !== 0) throw new Error(`Expected 0 tools, got ${tools.length}`);
+    if (!errors[0].includes('inputSchema')) throw new Error(`Wrong error: ${errors[0]}`);
+  });
+
+  test('should handle partial batch failures', () => {
+    const { tools, errors } = parse(JSON.stringify({
+      tools: [
+        { name: 'good_tool', inputSchema: { type: 'object', properties: {}, required: [] } },
+        { name: 'bad_tool', description: 'missing schema' },
+        { name: 'another_good', inputSchema: { type: 'object', properties: { x: { type: 'number' } }, required: [] } },
+      ],
+    }));
+    if (tools.length !== 2) throw new Error(`Expected 2 tools, got ${tools.length}`);
+    if (tools[0].name !== 'good_tool') throw new Error(`Wrong order/name: ${tools[0].name}`);
+    if (tools[1].name !== 'another_good') throw new Error(`Wrong order/name: ${tools[1].name}`);
+    if (errors.length !== 1) throw new Error(`Expected 1 error, got ${errors.length}`);
+    if (!errors[0].includes('bad_tool')) throw new Error(`Wrong error: ${errors[0]}`);
+  });
+
+  console.log('\nDynamicMcpToolRegistry');
+
+  test('should register handlers for parsed tools', async () => {
+    const { tools } = parse(JSON.stringify({
+      tools: [
+        {
+          name: 'adder',
+          description: 'Adds two numbers',
+          inputSchema: {
+            type: 'object',
+            properties: { a: { type: 'number' }, b: { type: 'number' } },
+            required: ['a', 'b'],
+          },
+        },
+      ],
+    }));
+    registerHandler(tools, {
+      adder: async (args) => String(args.a + args.b),
+    });
+    const result = await tools[0].function({ a: 3, b: 5 });
+    if (result !== '8') throw new Error(`Expected "8", got "${result}"`);
+  });
+
+  test('should create tools with handlers in one step', async () => {
+    const json = JSON.stringify({
+      name: 'multiplier',
+      inputSchema: {
+        type: 'object',
+        properties: { x: { type: 'number' }, y: { type: 'number' } },
+        required: ['x', 'y'],
+      },
+    });
+    const { tools, errors } = createToolsWithHandlers(json, {
+      multiplier: async (args) => String(args.x * args.y),
+    });
+    if (errors.length !== 0) throw new Error(errors.join('; '));
+    if (tools.length !== 1) throw new Error(`Expected 1 tool, got ${tools.length}`);
+    const result = await tools[0].function({ x: 4, y: 7 });
+    if (result !== '28') throw new Error(`Expected "28", got "${result}"`);
+  });
+
+  test('should ignore handlers for non-existent tools', () => {
+    const { tools } = parse(JSON.stringify({
+      tools: [{ name: 'tool_a', inputSchema: { type: 'object', properties: {}, required: [] } }],
+    }));
+    // Should not throw
+    registerHandler(tools, { tool_b: async () => 'result' });
+  });
+
+  console.log('\nReal-world samples');
+
+  test('should parse typical MCP server tools/list response', () => {
+    const { tools, errors } = parse(JSON.stringify({
+      tools: [
+        {
+          name: 'tavily_search',
+          description: 'Search for information using the Tavily search engine',
+          inputSchema: {
+            type: 'object',
+            properties: { query: { type: 'string', description: 'The search query to look up' } },
+            required: ['query'],
+          },
+        },
+        {
+          name: 'tavily_extract',
+          description: 'Extract information from specific URLs',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              urls: { type: 'array', items: { type: 'string' }, description: 'List of URLs' },
+            },
+            required: ['urls'],
+          },
+        },
+      ],
+    }));
+    if (errors.length !== 0) throw new Error(errors.join('; '));
+    if (tools.length !== 2) throw new Error(`Expected 2 tools, got ${tools.length}`);
+    if (tools[0].name !== 'tavily_search') throw new Error(`Wrong name: ${tools[0].name}`);
+    if (tools[1].name !== 'tavily_extract') throw new Error(`Wrong name: ${tools[1].name}`);
+  });
+
+  test('should parse single tool config from MCP provider docs', () => {
+    const { tools, errors } = parse(JSON.stringify({
+      name: 'filesystem',
+      description: 'Read and write files to the local filesystem',
+      input_schema: {
+        type: 'object',
+        properties: {
+          path: { type: 'string', description: 'File path' },
+          content: { type: 'string', description: 'Content to write' },
+        },
+        required: ['path'],
+      },
+    }));
+    if (errors.length !== 0) throw new Error(errors.join('; '));
+    if (tools.length !== 1) throw new Error(`Expected 1 tool, got ${tools.length}`);
+    if (tools[0].name !== 'filesystem') throw new Error(`Wrong name: ${tools[0].name}`);
+  });
+
+  // ── Summary ─────────────────────────────────────────────────────────────────
+  const total = passed + failed;
+  console.log(`\n${total} tests: ${passed} passed, ${failed} failed\n`);
+  if (failed > 0) process.exit(1);
+}
+
+run();


### PR DESCRIPTION
## Summary

Implements **Feature Request #544** — add support for importing tools directly from MCP JSON schema, enabling copy-paste usage without running an MCP server.

### Changes

#### New file: `multimodal/omni-tars/mcp-agent/src/tools/mcp-json-parser.ts`

`McpJsonParser` — parses MCP JSON into `Tool[]`:
- **Format 1** — Standard MCP tools/list response: `{ "tools": [...] }`
- **Format 2** — Legacy single-tool (`input_schema` key): `{ "name": "...", "input_schema": {...} }`
- **Format 3** — Single tool (`inputSchema` key): `{ "name": "...", "inputSchema": {...} }`

Full JSON Schema → Zod conversion for all primitive types (string, number, integer, boolean, array, object).

`DynamicMcpToolRegistry` — attaches handler functions to parsed tools by name.

#### Modified: `McpAgentPlugin`

New public methods:
- `addMcpJson(mcpJson: string): Tool[]` — import tools from a JSON string
- `registerHandlers(handlers: Record<string, Handler>)` — attach implementations

#### Tests

- `test/mcp-json-parser.test.ts` — 11 TypeScript test cases (via vitest)
- `test/run-standalone-tests.js` — 13 pure-JS tests (verified 13/13 pass)

### Usage Example

```typescript
const plugin = new McpAgentPlugin({ mcpServers: [...] });

// Import tools from MCP JSON (e.g. copied from provider docs)
const tools = plugin.addMcpJson(JSON.stringify({
  name: 'my_tool',
  input_schema: {
    type: 'object',
    properties: { query: { type: 'string', description: 'Search query' } },
    required: ['query']
  }
}));

// Register the actual implementation
plugin.registerHandlers({
  my_tool: async (args) => { return await callMyApi(args); }
});
```

### Backward Compatibility

✅ Fully backward compatible — existing `mcpServers` / MCP server-based usage is unchanged.

---

Closes #544
