### PR TITLE
fix: align prediction marker on scaled displays

### DIFF
--- a/apps/ui-tars/src/main/window/ScreenMarker.ts
+++ b/apps/ui-tars/src/main/window/ScreenMarker.ts
@@ -206,6 +206,7 @@ class ScreenMarker {
     });
 
     const { scaleFactor = 1 } = screenshotContext;
+    const { bounds } = screen.getPrimaryDisplay();
 
     // loop predictions
     for (let i = 0; i < overlays.length; i++) {
@@ -229,9 +230,9 @@ class ScreenMarker {
           webPreferences: { nodeIntegration: true, contextIsolation: false },
           ...(overlay.xPos &&
             overlay.yPos && {
-              // logical pixels
-              x: (overlay.xPos + overlay.offsetX) * scaleFactor,
-              y: (overlay.yPos + overlay.offsetY) * scaleFactor,
+              // Convert screenshot pixels into Electron's global logical pixels.
+              x: bounds.x + overlay.xPos / scaleFactor + overlay.offsetX,
+              y: bounds.y + overlay.yPos / scaleFactor + overlay.offsetY,
             }),
         });
 


### PR DESCRIPTION
## Summary
- align prediction marker overlay coordinates with Electron global logical coordinates
- account for display bounds and screenshot scale factor when positioning the marker window

## Why
On macOS Tahoe 26 / Retina-style displays, the red prediction marker can appear offset from where the cursor actually moves. The marker overlay was positioned in a different coordinate space than the execution path, which makes the visual feedback misleading for both users and the VLM's next screenshot context.

Fixes #1876

## Validation
- pnpm --filter ui-tars-desktop run typecheck:node
- pnpm --filter ui-tars-desktop run typecheck:web