### PR TITLE
fix(llm-client): handle empty string arguments in Anthropic convertMessages

### DIFF
--- a/multimodal/tarko/llm-client/src/handlers/anthropic.ts
+++ b/multimodal/tarko/llm-client/src/handlers/anthropic.ts
@@ -413,7 +413,8 @@ export const convertMessages = async (
       };
       currentParams.push(toolResult);
     } else if (message.role === 'assistant') {
-      if (typeof message.content === 'string') {
+      // Anthropic rejects empty text content blocks; skip when content is "".
+      if (typeof message.content === 'string' && message.content) {
         currentParams.push({
           text: message.content,
           type: 'text',
@@ -424,7 +425,9 @@ export const convertMessages = async (
         const convertedContent: Array<ToolUseBlockParam> = message.tool_calls.map((toolCall) => {
           return {
             id: toolCall.id,
-            input: JSON.parse(toolCall.function.arguments),
+            // Anthropic streaming emits "" for arguments when the tool input is
+            // an empty object; JSON.parse("") throws — fall back to "{}".
+            input: JSON.parse(toolCall.function.arguments || '{}'),
             name: toolCall.function.name,
             type: 'tool_use',
           };


### PR DESCRIPTION
## Problem

When running the CLI with `--provider anthropic` against any prompt that triggers more than ~3 tool-call iterations, the agent crashes with:

```
SyntaxError: Unexpected end of JSON input
```

The error originates in `convertMessages` inside `multimodal/tarko/llm-client/src/handlers/anthropic.ts`.

## Root cause

The Anthropic streaming API emits a `content_block_start` event for tool calls whose input is an empty object `{}`. The streaming accumulator in `createCompletionResponseStreaming` (line ~130) stores the arguments as `""` (empty string) rather than `"{}"` when the input block is empty:

```ts
arguments: isEmptyObject(chunk.content_block.input) ? '' : JSON.stringify(chunk.content_block.input),
```

On the **next** loop iteration, `convertMessages` replays the full message history and hits:

```ts
input: JSON.parse(toolCall.function.arguments),  // JSON.parse("") → throws
```

A second issue in the same block: when an assistant message has `content: ""` alongside `tool_calls`, the code pushes `{ type: 'text', text: '' }` into the Anthropic request, which the API rejects with a 400 `messages: text content blocks must be non-empty`.

## Fix

Two one-line guards in the `assistant` branch of `convertMessages`:

```ts
// 1. fall back to "{}" when arguments is an empty string
input: JSON.parse(toolCall.function.arguments || '{}'),

// 2. skip the text block when content is an empty string
if (typeof message.content === 'string' && message.content) {
```

The `|| '{}'` fallback is already applied by the downstream callers in `tool-processor.ts` — this brings `convertMessages` in line with them.

## Reproducer

```bash
npx @agent-tars/cli@latest \
  --provider anthropic \
  --model claude-sonnet-4-5 \
  --apiKey $ANTHROPIC_API_KEY \
  --headless \
  --input "what is ui tars"
```

With the fix applied the agent completes successfully and returns a full answer.