### PR TITLE
fix(security): MCP HTTP server defaults to localhost + optional Bearer auth

### DIFF
--- a/packages/agent-infra/mcp-http-server/src/startServer.ts
+++ b/packages/agent-infra/mcp-http-server/src/startServer.ts
@@ -18,6 +18,11 @@ import type { AddressInfo } from 'node:net';
 
 export { BaseLogger };
 
+export interface AuthConfig {
+  /** API key for Bearer token authentication. When set, all requests must include Authorization: Bearer <apiKey> header. */
+  apiKey?: string;
+}
+
 export interface RoutesConfig {
   /** Route prefix for all endpoints. Default is '/' */
   prefix?: string;
@@ -53,6 +58,8 @@ interface StartSseAndStreamableHttpMcpServerParams {
   middlewares?: MiddlewareFunction[];
   /** Routes configuration */
   routes?: RoutesConfig;
+  /** Authentication configuration. When provided, requests must include a valid Authorization header. */
+  auth?: AuthConfig;
   logger?: Logger;
   createMcpServer: (req: RequestContext) => Promise<McpServer | Server>;
 }
@@ -67,6 +74,7 @@ export async function startSseAndStreamableHttpMcpServer(
     stateless = true,
     middlewares,
     routes = {},
+    auth,
     logger = new ConsoleLogger(),
   } = params;
 
@@ -96,6 +104,26 @@ export async function startSseAndStreamableHttpMcpServer(
 
   const app = express();
   app.use(express.json());
+
+  // Authentication middleware
+  if (auth?.apiKey) {
+    const apiKey = auth.apiKey;
+    app.use((req: Request, res: Response, next: NextFunction) => {
+      const authHeader = req.headers['authorization'];
+      if (!authHeader || authHeader !== `Bearer ${apiKey}`) {
+        res.status(401).json({
+          jsonrpc: '2.0',
+          error: {
+            code: ErrorCode.InternalError,
+            message: 'Unauthorized: Invalid or missing Authorization header',
+          },
+          id: null,
+        });
+        return;
+      }
+      next();
+    });
+  }
 
   app.use((err: Error, _req: Request, res: Response, next: NextFunction) => {
     if (
@@ -259,7 +287,7 @@ export async function startSseAndStreamableHttpMcpServer(
     },
   );
 
-  const HOST = host || '::';
+  const HOST = host || 'localhost';
   const PORT = Number(port || process.env.PORT || 8080);
 
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
## Security Vulnerability: MCP HTTP Server Exposed on All Interfaces Without Authentication

### Problem

The MCP HTTP server (`packages/agent-infra/mcp-http-server/src/startServer.ts`) has two critical security issues:

1. **Default host is `::` (all interfaces)** — When no host is explicitly configured, the server binds to `::`, which means it listens on **all available network interfaces** (IPv4 and IPv6). Any network peer that can reach the machine can connect to the MCP server.

2. **No authentication mechanism** — There is no way to require authentication for incoming requests. Any client that can reach the server can issue MCP commands without any credentials.

### Impact

- **P0 / Critical**: An MCP server running on a developer machine or CI server could be accessed by anyone on the same network (or potentially the internet if the host is publicly reachable).
- Attackers could issue arbitrary MCP commands, exfiltrate data, or manipulate the agent.

### Fix

1. **Changed default host from `::` to `localhost`** — The server now only accepts local connections by default. Users who need remote access can explicitly set `host: "0.0.0.0"` or `host: "::"`.

2. **Added optional `auth` configuration** — New `AuthConfig` interface with an `apiKey` field:
   ```typescript
   interface AuthConfig {
     apiKey?: string;
   }
   ```

3. **Added authentication middleware** — When `auth.apiKey` is set, all requests must include a valid `Authorization: Bearer <apiKey>` header. Requests without valid credentials receive a `401 Unauthorized` response.

4. **Backward compatible** — If no `auth` config is provided, the server behaves exactly as before (no auth required), but is now safely bound to localhost.

### Files Changed

- `packages/agent-infra/mcp-http-server/src/startServer.ts`

### Testing

- Verified the server starts correctly on localhost with and without auth config
- Verified that requests without proper auth header are rejected with 401 when auth is configured
- Verified backward compatibility (no auth = existing behavior)