### PR TITLE
fix(security): prevent shell injection in ADB operator

### DIFF
--- a/multimodal/gui-agent/operator-adb/src/AdbOperator.ts
+++ b/multimodal/gui-agent/operator-adb/src/AdbOperator.ts
@@ -5,7 +5,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-import { exec } from 'node:child_process';
+import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 
 import {
@@ -27,6 +27,14 @@ const yadbCommand =
   'app_process -Djava.class.path=/data/local/tmp/yadb /data/local/tmp com.ysbing.yadb.Main';
 const screenshotPathOnAndroid = '/data/local/tmp/ui_tars_screenshot.png';
 const screenshotPathOnLocal = path.join(os.homedir(), 'Downloads', 'ui_tars_screenshot.png');
+
+/**
+ * Escapes a string for safe inclusion in a shell command argument.
+ * Wraps the value in single quotes and escapes any existing single quotes.
+ */
+function shellEscape(str: string): string {
+  return "'" + str.replace(/'/g, "'\\''") + "'";
+}
 
 export class AdbOperator extends Operator {
   private logger: ConsoleLogger;
@@ -188,9 +196,9 @@ export class AdbOperator extends Operator {
    * @throws Error when unable to retrieve device list
    */
   private async getConnectedDevices(): Promise<string> {
-    const execPromise = promisify(exec);
+    const execFilePromise = promisify(execFile);
     try {
-      const { stdout } = await execPromise('adb devices');
+      const { stdout } = await execFilePromise('adb', ['devices']);
       const devices = stdout
         .split('\n')
         .slice(1) // Skip the first line "List of devices attached"
@@ -267,7 +275,7 @@ export class AdbOperator extends Operator {
         this.logger.debug('screenshotWithFallback result of screencap:', result);
       } catch (error) {
         // screenshot which is forbidden by app
-        await this.executeWithYadb(`-screenshot ${screenshotPathOnAndroid}`);
+        await this.executeWithYadb(['-screenshot', screenshotPathOnAndroid]);
       }
       await this._adb!.pull(screenshotPathOnAndroid, screenshotPathOnLocal);
       screenshotBuffer = await fs.promises.readFile(screenshotPathOnLocal);
@@ -280,8 +288,12 @@ export class AdbOperator extends Operator {
   }
 
   private async handleClick(x: number, y: number): Promise<void> {
-    // Use adjusted coordinates
-    await this._adb!.shell(`input tap ${x} ${y}`);
+    // Use adjusted coordinates - validate numeric values to prevent injection
+    if (!Number.isFinite(x) || !Number.isFinite(y)) {
+      throw new Error(`Invalid click coordinates: x=${x}, y=${y}`);
+    }
+    // Math.round ensures integer output; Number.isFinite ensures no injection via NaN/Infinity
+    await this._adb!.shell(`input tap ${Math.round(x)} ${Math.round(y)}`);
   }
 
   private async handleType(text: string): Promise<void> {
@@ -296,7 +308,8 @@ export class AdbOperator extends Operator {
       return;
     }
     // for non-ASCII characters, use yadb
-    await this.executeWithYadb(`-keyboard "${text}"`);
+    // Pass text as separate argument to avoid shell injection via string interpolation
+    await this.executeWithYadb(['-keyboard', text]);
   }
 
   private async handleHotkey(keyStr: string) {
@@ -340,7 +353,13 @@ export class AdbOperator extends Operator {
     to: { x: number; y: number },
     duration: number, // ms
   ): Promise<void> {
-    await this._adb!.shell(`input swipe ${from.x} ${from.y} ${to.x} ${to.y} ${duration}`);
+    // Validate numeric values to prevent injection
+    if (!Number.isFinite(from.x) || !Number.isFinite(from.y) ||
+        !Number.isFinite(to.x) || !Number.isFinite(to.y) ||
+        !Number.isFinite(duration)) {
+      throw new Error(`Invalid swipe parameters: from=${JSON.stringify(from)}, to=${JSON.stringify(to)}, duration=${duration}`);
+    }
+    await this._adb!.shell(`input swipe ${Math.round(from.x)} ${Math.round(from.y)} ${Math.round(to.x)} ${Math.round(to.y)} ${Math.round(duration)}`);
   }
 
   private async handleScroll(direction: string, point?: Coordinates) {
@@ -374,16 +393,19 @@ export class AdbOperator extends Operator {
   }
 
   /**
-   * @param subCommand, such as:
-   * -keyboard "${keyboardContent}
+   * Execute a command via yadb. Uses proper shell escaping to prevent
+   * shell injection through user-controlled text.
+   * @param args - Command arguments as an array of strings
    */
-  private async executeWithYadb(subCommand: string): Promise<void> {
+  private async executeWithYadb(args: string[]): Promise<void> {
     if (!this._hasPushedYadb) {
       // the size of yadb just 12kB, just adb push it every time initailied
       const yadbBin = path.join(__dirname, '../bin/yadb');
       await this._adb!.push(yadbBin, '/data/local/tmp');
       this._hasPushedYadb = true;
     }
-    await this._adb!.shell(`${yadbCommand} ${subCommand}`);
+    // Escape each argument to prevent shell injection
+    const escapedArgs = args.map(shellEscape).join(' ');
+    await this._adb!.shell(`${yadbCommand} ${escapedArgs}`);
   }
 }


### PR DESCRIPTION
## Security Vulnerability: Shell Injection in ADB Operator

### Problem

The ADB operator (`multimodal/gui-agent/operator-adb/src/AdbOperator.ts`) contains multiple shell injection vulnerabilities:

1. **`exec()` with string command** — `getConnectedDevices()` uses `exec('adb devices')` with Node.js `exec()`, which spawns a shell. While this specific call has no user input, it sets an unsafe pattern.

2. **`handleType()` text injection (Critical)** — User-controlled text content is directly interpolated into a shell command:
   ```typescript
   await this.executeWithYadb(`-keyboard "${text}"`);
   ```
   An attacker controlling the agent's type action could inject arbitrary commands by crafting text like: `foo"; rm -rf /; echo "`

3. **`handleClick()` / `handleSwipe()` coordinate injection** — While coordinates are typed as `number`, no validation ensures they are actually finite numbers. A value like `NaN` or `Infinity` could produce unexpected shell behavior.

4. **`executeWithYadb()` raw string subCommands** — The method accepts raw string arguments that are directly concatenated into shell commands without escaping.

### Impact

- **P0 / Critical**: The `handleType()` path allows arbitrary command execution on the Android device through shell injection when processing non-ASCII text input (Chinese characters, etc.).
- **P1**: Lack of input validation in coordinate/duration parameters could lead to unexpected behavior.

### Fix

1. **Replace `exec()` with `execFile()`** — Uses argument arrays instead of shell string commands for the `adb devices` call.

2. **Add `shellEscape()` utility** — Properly escapes strings for safe inclusion in shell commands by wrapping in single quotes and escaping existing single quotes.

3. **Refactor `executeWithYadb()` to accept `string[]`** — Arguments are now passed as an array and each is individually shell-escaped before being joined into the command string.

4. **Add `Number.isFinite()` validation** — All numeric parameters (coordinates, duration) are validated before being interpolated into commands.

5. **Use `Math.round()` for numeric values** — Ensures clean integer output in generated shell commands.

### Files Changed

- `multimodal/gui-agent/operator-adb/src/AdbOperator.ts`

### Testing

- Verified shell escaping handles special characters correctly (quotes, backticks, dollar signs, semicolons)
- Verified Number.isFinite() rejects NaN, Infinity, and non-numeric values
- Backward compatible: all existing functionality preserved with added safety
