### PR TITLE
fix(security): use DEFAULT_SAFE_SCHEMA for all yaml.load() calls

### DIFF
--- a/apps/ui-tars/src/main/store/setting.ts
+++ b/apps/ui-tars/src/main/store/setting.ts
@@ -97,7 +97,7 @@ export class SettingStore {
       }
 
       const yamlText = await response.text();
-      const preset = yaml.load(yamlText);
+      const preset = yaml.load(yamlText, { schema: yaml.DEFAULT_SAFE_SCHEMA });
       const validatedPreset = validatePreset(preset);
 
       SettingStore.setStore({
@@ -142,7 +142,7 @@ export class SettingStore {
 }
 
 async function parsePresetYaml(yamlContent: string): Promise<LocalStore> {
-  const preset = yaml.load(yamlContent);
+  const preset = yaml.load(yamlContent, { schema: yaml.DEFAULT_SAFE_SCHEMA });
   const validatedPreset = validatePreset(preset);
   return validatedPreset;
 }

--- a/infra/pdk/src/utils/workspace.ts
+++ b/infra/pdk/src/utils/workspace.ts
@@ -49,7 +49,7 @@ export function readWorkspacePatterns(cwd = process.cwd()): string[] {
     }
 
     const content = readFileSync(workspacePath, 'utf-8');
-    const parsed = yaml.load(content) as { packages?: string[] };
+    const parsed = yaml.load(content, { schema: yaml.DEFAULT_SAFE_SCHEMA }) as { packages?: string[] };
     return parsed?.packages || [];
   } catch (error) {
     console.error('Failed to read pnpm-workspace.yaml:', error);

--- a/multimodal/gui-agent/cli/src/cli/start.ts
+++ b/multimodal/gui-agent/cli/src/cli/start.ts
@@ -44,7 +44,7 @@ export const start = async (options: CliOptions) => {
     }
 
     const yamlText = await response.text();
-    const preset = yaml.load(yamlText) as any;
+    const preset = yaml.load(yamlText, { schema: yaml.DEFAULT_SAFE_SCHEMA }) as any;
 
     config.apiKey = preset?.vlmApiKey;
     config.baseURL = preset?.vlmBaseUrl;

--- a/multimodal/tarko/config-loader/src/index.ts
+++ b/multimodal/tarko/config-loader/src/index.ts
@@ -127,7 +127,7 @@ export async function loadConfig<T extends Record<string, any> = Record<string, 
     try {
       const { default: yaml } = await import('js-yaml');
       const content = await fs.promises.readFile(configFilePath, 'utf-8');
-      configExport = yaml.load(content);
+      configExport = yaml.load(content, { schema: yaml.DEFAULT_SAFE_SCHEMA });
     } catch (err) {
       console.error(`Failed to load YAML file: ${configFilePath}`);
       throw err;

--- a/packages/ui-tars/cli/src/cli/start.ts
+++ b/packages/ui-tars/cli/src/cli/start.ts
@@ -37,7 +37,7 @@ export const start = async (options: CliOptions) => {
     }
 
     const yamlText = await response.text();
-    const preset = yaml.load(yamlText) as any;
+    const preset = yaml.load(yamlText, { schema: yaml.DEFAULT_SAFE_SCHEMA }) as any;
 
     config.apiKey = preset?.vlmApiKey;
     config.baseURL = preset?.vlmBaseUrl;

--- a/scripts/merge-yml/merge-yml.ts
+++ b/scripts/merge-yml/merge-yml.ts
@@ -22,8 +22,8 @@ interface YamlData {
   releaseDate?: string;
 }
 
-const x64Data = yaml.load(x64Content) as YamlData;
-const arm64Data = yaml.load(arm64Content) as YamlData;
+const x64Data = yaml.load(x64Content, { schema: yaml.DEFAULT_SAFE_SCHEMA }) as YamlData;
+const arm64Data = yaml.load(arm64Content, { schema: yaml.DEFAULT_SAFE_SCHEMA }) as YamlData;
 
 // Merge files field from both x64 and arm64
 const mergedFiles = [...(x64Data.files || []), ...(arm64Data.files || [])];


### PR DESCRIPTION
## Security Hardening: Use DEFAULT_SAFE_SCHEMA for all yaml.load() calls

### Problem

Multiple files across the codebase call `yaml.load()` without explicitly specifying a safe schema:

- `apps/ui-tars/src/main/store/setting.ts` (2 occurrences) — loads YAML from remote URLs and user-provided text
- `multimodal/gui-agent/cli/src/cli/start.ts` — loads YAML presets from remote URLs
- `packages/ui-tars/cli/src/cli/start.ts` — loads YAML presets from remote URLs
- `infra/pdk/src/utils/workspace.ts` — loads pnpm-workspace.yaml
- `multimodal/tarko/config-loader/src/index.ts` — loads config files from disk
- `scripts/merge-yml/merge-yml.ts` (2 occurrences) — loads build artifact YAML

While js-yaml v4 defaults to a safe schema (unlike v3 which was unsafe by default), not explicitly specifying `DEFAULT_SAFE_SCHEMA` is risky because:

1. **Dependency upgrades could change behavior** — If js-yaml ever changes its default schema in a future version, or if the project downgrades to v3, all these calls become vulnerable.
2. **Defense in depth** — Explicit safe schema declaration makes the security intent clear and auditable.
3. **Several of these load YAML from untrusted sources** — The preset loading code fetches YAML from arbitrary remote URLs (`options.presets` / `SettingStore.fetchPresetFromUrl`), making them particularly dangerous.

### Vulnerability Detail

Without a safe schema, `yaml.load()` can deserialize arbitrary JavaScript objects, including functions via `!!js/function` and regex via `!!js/regexp`. This can lead to **arbitrary code execution** when parsing untrusted YAML input.

### Fix

Replace all `yaml.load(x)` calls with `yaml.load(x, { schema: yaml.DEFAULT_SAFE_SCHEMA })`.

This explicitly restricts YAML parsing to the safe schema, which only supports standard YAML types and cannot deserialize JavaScript-specific types like functions.

### Files Changed

- `apps/ui-tars/src/main/store/setting.ts`
- `multimodal/gui-agent/cli/src/cli/start.ts`
- `packages/ui-tars/cli/src/cli/start.ts`
- `infra/pdk/src/utils/workspace.ts`
- `multimodal/tarko/config-loader/src/index.ts`
- `scripts/merge-yml/merge-yml.ts`

### Testing

- All changes are additive (only adding schema option) and do not affect output for valid YAML
- Safe schema supports all standard YAML types used by these files
- No functional behavior change expected
