### PR TITLE
fix(ui-tars): prevent main window from stealing focus after agent completes

### DIFF
--- a/apps/ui-tars/src/main/window/index.ts
+++ b/apps/ui-tars/src/main/window/index.ts
@@ -85,7 +85,7 @@ export async function showMainWindow() {
       mainWindow?.setAlwaysOnTop(false);
     }, 100);
     mainWindow?.setFocusable(true);
-    mainWindow?.show();
+    mainWindow?.showInactive();
   } catch (error) {
     logger.error('[showMainWindow]', error);
   }


### PR DESCRIPTION
## Summary
- Use `showInactive()` instead of `show()` in `showMainWindow()` to prevent the UI-TARS Desktop window from stealing system focus when the agent finishes execution
- This fixes focus-sensitive applications (e.g. games) losing foreground focus and becoming unresponsive to automated clicks

## Problem
When the agent completes its execution, `afterAgentRun()` calls `showMainWindow()` which uses `mainWindow.show()`. This activates the window and steals system focus from the target application. For focus-sensitive apps (like games), this causes them to stop responding to automated clicks even though coordinates are correct.

## Fix
Change `mainWindow.show()` to `mainWindow.showInactive()` in `showMainWindow()`. This shows the window without activating it, allowing the target application to retain focus.

The `showInactive()` method was already available in this file (line 14) but was never used. User-initiated actions (tray "Show" menu, `stopRun`) still use `showWindow()` with `show()` as expected.

Fixes #1864

## Test plan
- [ ] Run UI-TARS Desktop with a focus-sensitive application (e.g. a game)
- [ ] Start an agent task and let it complete
- [ ] Verify the target application retains focus after the agent finishes
- [ ] Verify the main window becomes visible (but not focused) after agent completion
- [ ] Verify clicking tray "Show" still properly focuses the window

🤖 Generated with [Claude Code](https://claude.com/claude-code)