### PR TITLE
fix(sdk): cap UI-TARS 1.5 default output tokens

### DIFF
--- a/packages/ui-tars/sdk/src/Model.ts
+++ b/packages/ui-tars/sdk/src/Model.ts
@@ -37,6 +37,9 @@ type OpenAIChatCompletionCreateParams = Omit<ClientOptions, 'maxRetries'> &
     'model' | 'max_tokens' | 'temperature' | 'top_p'
   >;
 
+const DEFAULT_MAX_TOKENS = 1000;
+const DEFAULT_MAX_TOKENS_V1_5 = 8192;
+
 export interface UITarsModelConfig extends OpenAIChatCompletionCreateParams {
   /** Whether to use OpenAI Response API instead of Chat Completions API */
   useResponsesApi?: boolean;
@@ -107,7 +110,9 @@ export class UITarsModel extends Model {
       baseURL,
       apiKey,
       model,
-      max_tokens = uiTarsVersion == UITarsModelVersion.V1_5 ? 65535 : 1000,
+      max_tokens = uiTarsVersion === UITarsModelVersion.V1_5
+        ? DEFAULT_MAX_TOKENS_V1_5
+        : DEFAULT_MAX_TOKENS,
       temperature = 0,
       top_p = 0.7,
       ...restOptions

--- a/packages/ui-tars/sdk/tests/Model.test.ts
+++ b/packages/ui-tars/sdk/tests/Model.test.ts
@@ -4,6 +4,7 @@
  */
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { UITarsModel } from '../src/Model';
+import { UITarsModelVersion } from '@ui-tars/shared/types';
 
 // Mock OpenAI
 const mockCreate = vi.fn();
@@ -111,6 +112,63 @@ describe('UITarsModel', () => {
         expect.any(Object),
       );
     });
+
+    it('uses a provider-safe default max_tokens for UI-TARS 1.5', async () => {
+      const model = new UITarsModel({
+        apiKey: 'test-key',
+        baseURL: 'https://test.com',
+        model: 'test-model',
+        useResponsesApi: false,
+      });
+
+      mockCreate.mockResolvedValue({
+        choices: [{ message: { content: 'test response' } }],
+        usage: { total_tokens: 100 },
+      });
+
+      await model.invoke({
+        conversations: [{ from: 'human', value: 'test' }],
+        images: [],
+        screenContext: { width: 1920, height: 1080 },
+        uiTarsVersion: UITarsModelVersion.V1_5,
+      });
+
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          max_tokens: 8192,
+        }),
+        expect.any(Object),
+      );
+    });
+
+    it('preserves explicit max_tokens overrides for UI-TARS 1.5', async () => {
+      const model = new UITarsModel({
+        apiKey: 'test-key',
+        baseURL: 'https://test.com',
+        model: 'test-model',
+        useResponsesApi: false,
+        max_tokens: 12000,
+      });
+
+      mockCreate.mockResolvedValue({
+        choices: [{ message: { content: 'test response' } }],
+        usage: { total_tokens: 100 },
+      });
+
+      await model.invoke({
+        conversations: [{ from: 'human', value: 'test' }],
+        images: [],
+        screenContext: { width: 1920, height: 1080 },
+        uiTarsVersion: UITarsModelVersion.V1_5,
+      });
+
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          max_tokens: 12000,
+        }),
+        expect.any(Object),
+      );
+    });
   });
 
   describe('Response API', () => {
@@ -170,6 +228,35 @@ describe('UITarsModel', () => {
               ],
             },
           ],
+        }),
+        expect.any(Object),
+      );
+    });
+
+    it('uses the same safe UI-TARS 1.5 default for Response API max_output_tokens', async () => {
+      const model = new UITarsModel({
+        apiKey: 'test-key',
+        baseURL: 'https://test.com',
+        model: 'test-model',
+        useResponsesApi: true,
+      });
+
+      mockResponsesCreate.mockResolvedValue({
+        id: 'response-1',
+        output_text: 'test response',
+        usage: { total_tokens: 50 },
+      });
+
+      await model.invoke({
+        conversations: [{ from: 'human', value: 'test' }],
+        images: [],
+        screenContext: { width: 1920, height: 1080 },
+        uiTarsVersion: UITarsModelVersion.V1_5,
+      });
+
+      expect(mockResponsesCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          max_output_tokens: 8192,
         }),
         expect.any(Object),
       );


### PR DESCRIPTION
## Summary
- Replace the UI-TARS 1.5 default `max_tokens` value of `65535` with a provider-safe default of `8192`.
- Keep explicit caller-provided `max_tokens` overrides intact.
- Cover both Chat Completions and Responses API request shaping in SDK tests.

## Why
The current 1.5 default can exceed provider output-token limits before the request reaches the model, causing avoidable API failures for the default SDK configuration.

## Test
- `corepack pnpm --filter @ui-tars/sdk exec vitest --environment node --run tests/Model.test.ts`
- `corepack pnpm --filter @ui-tars/sdk run build`
