### PR TITLE
feat: add proxy configuration support (#335)

### DIFF
--- a/apps/ui-tars/src/main/env.ts
+++ b/apps/ui-tars/src/main/env.ts
@@ -22,6 +22,9 @@ export const vlmBaseUrl = process.env.VLM_BASE_URL;
 export const vlmApiKey = process.env.VLM_API_KEY;
 export const vlmModelName = process.env.VLM_MODEL_NAME;
 
+export const httpProxy = process.env.HTTP_PROXY || process.env.http_proxy;
+export const httpsProxy = process.env.HTTPS_PROXY || process.env.https_proxy;
+
 const { platform } = process;
 export const isMacOS = platform === 'darwin';
 

--- a/apps/ui-tars/src/main/main.ts
+++ b/apps/ui-tars/src/main/main.ts
@@ -27,6 +27,7 @@ import { store } from './store/create';
 import { SettingStore } from './store/setting';
 import { createTray } from './tray';
 import { registerSettingsHandlers } from './services/settings';
+import { applyProxySettings, registerProxySettingsWatcher } from './services/proxy';
 import { sanitizeState } from './utils/sanitizeState';
 import { windowManager } from './services/windowManager';
 import { checkBrowserAvailability } from './services/browserCheck';
@@ -87,6 +88,10 @@ const initializeApp = async () => {
   // if (env.isDev) {
   await loadDevDebugTools();
   // }
+
+  // Apply proxy settings before any network requests
+  await applyProxySettings();
+  registerProxySettingsWatcher();
 
   logger.info('createTray');
   // Tray

--- a/apps/ui-tars/src/main/services/proxy.ts
+++ b/apps/ui-tars/src/main/services/proxy.ts
@@ -1,0 +1,149 @@
+/**
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { session } from 'electron';
+
+import { logger } from '@main/logger';
+import { SettingStore } from '@main/store/setting';
+import { LocalStore } from '@main/store/validate';
+
+/**
+ * Apply proxy settings to Electron session and Node.js environment variables.
+ */
+export async function applyProxySettings(settings?: Partial<LocalStore>) {
+  const store = settings ?? SettingStore.getStore();
+  const { proxyEnabled, proxyMode, httpProxy, httpsProxy, noProxy } = store;
+
+  if (!proxyEnabled) {
+    // Clear proxy
+    await session.defaultSession.setProxy({ mode: 'direct' });
+    delete process.env.HTTP_PROXY;
+    delete process.env.HTTPS_PROXY;
+    delete process.env.NO_PROXY;
+    delete process.env.http_proxy;
+    delete process.env.https_proxy;
+    delete process.env.no_proxy;
+    logger.info('[Proxy] Proxy disabled, cleared all proxy settings');
+    return;
+  }
+
+  if (proxyMode === 'system') {
+    // Use system proxy - Electron will read from OS settings
+    await session.defaultSession.setProxy({ mode: 'system' });
+    // Clear env vars so Node.js also uses system proxy behavior
+    delete process.env.HTTP_PROXY;
+    delete process.env.HTTPS_PROXY;
+    delete process.env.NO_PROXY;
+    delete process.env.http_proxy;
+    delete process.env.https_proxy;
+    delete process.env.no_proxy;
+    logger.info('[Proxy] Using system proxy settings');
+    return;
+  }
+
+  // Custom proxy mode
+  const proxyUrl = httpProxy?.trim();
+  if (!proxyUrl) {
+    logger.warn('[Proxy] Custom proxy enabled but no proxy URL configured');
+    await session.defaultSession.setProxy({ mode: 'direct' });
+    return;
+  }
+
+  // Validate and normalize proxy URL
+  const normalizedProxyUrl = normalizeProxyUrl(proxyUrl);
+  const normalizedHttpsProxyUrl = httpsProxy?.trim()
+    ? normalizeProxyUrl(httpsProxy.trim())
+    : undefined;
+
+  // Build proxy rules for Electron session
+  const proxyRules = buildProxyRules(
+    normalizedProxyUrl,
+    normalizedHttpsProxyUrl,
+    noProxy?.trim(),
+  );
+
+  await session.defaultSession.setProxy({
+    mode: 'fixed_servers',
+    proxyRules,
+  });
+
+  // Set Node.js environment variables for HTTP clients (e.g. OpenAI SDK, fetch)
+  process.env.HTTP_PROXY = normalizedProxyUrl;
+  process.env.http_proxy = normalizedProxyUrl;
+
+  if (normalizedHttpsProxyUrl) {
+    process.env.HTTPS_PROXY = normalizedHttpsProxyUrl;
+    process.env.https_proxy = normalizedHttpsProxyUrl;
+  } else {
+    process.env.HTTPS_PROXY = normalizedProxyUrl;
+    process.env.https_proxy = normalizedProxyUrl;
+  }
+
+  if (noProxy?.trim()) {
+    process.env.NO_PROXY = noProxy.trim();
+    process.env.no_proxy = noProxy.trim();
+  } else {
+    delete process.env.NO_PROXY;
+    delete process.env.no_proxy;
+  }
+
+  logger.info('[Proxy] Applied custom proxy:', proxyRules);
+}
+
+/**
+ * Normalize proxy URL to include protocol if missing.
+ */
+function normalizeProxyUrl(url: string): string {
+  if (url.startsWith('http://') || url.startsWith('https://') || url.startsWith('socks5://') || url.startsWith('socks4://')) {
+    return url;
+  }
+  // Default to http:// if no protocol specified
+  return `http://${url}`;
+}
+
+/**
+ * Build Electron proxy rules string.
+ * Format: "http=proxy:port;https=proxy:port" or "proxy:port"
+ * @see https://www.electronjs.org/docs/latest/api/session#sessetproxyconfig
+ */
+function buildProxyRules(
+  httpProxy: string,
+  httpsProxy?: string,
+  noProxy?: string,
+): string {
+  let rules = `http=${httpProxy}`;
+
+  if (httpsProxy) {
+    rules += `;https=${httpsProxy}`;
+  } else {
+    rules += `;https=${httpProxy}`;
+  }
+
+  if (noProxy) {
+    rules += `;bypass-list=${noProxy}`;
+  }
+
+  return rules;
+}
+
+/**
+ * Register a listener to apply proxy settings whenever they change.
+ */
+export function registerProxySettingsWatcher() {
+  SettingStore.getInstance().onDidChange('proxyEnabled', () => {
+    applyProxySettings();
+  });
+  SettingStore.getInstance().onDidChange('proxyMode', () => {
+    applyProxySettings();
+  });
+  SettingStore.getInstance().onDidChange('httpProxy', () => {
+    applyProxySettings();
+  });
+  SettingStore.getInstance().onDidChange('httpsProxy', () => {
+    applyProxySettings();
+  });
+  SettingStore.getInstance().onDidChange('noProxy', () => {
+    applyProxySettings();
+  });
+}

--- a/apps/ui-tars/src/main/services/settings.ts
+++ b/apps/ui-tars/src/main/services/settings.ts
@@ -6,6 +6,7 @@ import { ipcMain } from 'electron';
 import { SettingStore } from '../store/setting';
 import { logger } from '../logger';
 import { LocalStore } from '@main/store/validate';
+import { applyProxySettings } from './proxy';
 
 export function registerSettingsHandlers() {
   /**
@@ -34,6 +35,7 @@ export function registerSettingsHandlers() {
    */
   ipcMain.handle('setting:update', async (_, settings: LocalStore) => {
     SettingStore.setStore(settings);
+    await applyProxySettings(settings);
   });
 
   /**

--- a/apps/ui-tars/src/main/store/setting.ts
+++ b/apps/ui-tars/src/main/store/setting.ts
@@ -30,6 +30,12 @@ export const DEFAULT_SETTING: LocalStore = {
   operator: Operator.LocalComputer,
   reportStorageBaseUrl: '',
   utioBaseUrl: '',
+  // Proxy Settings
+  proxyEnabled: false,
+  proxyMode: 'system',
+  httpProxy: '',
+  httpsProxy: '',
+  noProxy: '',
 };
 
 export class SettingStore {

--- a/apps/ui-tars/src/main/store/validate.ts
+++ b/apps/ui-tars/src/main/store/validate.ts
@@ -33,6 +33,13 @@ export const PresetSchema = z.object({
   reportStorageBaseUrl: z.string().url().optional(),
   utioBaseUrl: z.string().url().optional(),
   presetSource: PresetSourceSchema.optional(),
+
+  // Proxy Settings
+  proxyEnabled: z.boolean().optional(),
+  proxyMode: z.enum(['system', 'custom']).optional(),
+  httpProxy: z.string().optional(),
+  httpsProxy: z.string().optional(),
+  noProxy: z.string().optional(),
 });
 
 export type PresetSource = z.infer<typeof PresetSourceSchema>;

--- a/apps/ui-tars/src/renderer/src/components/Settings/category/proxy.tsx
+++ b/apps/ui-tars/src/renderer/src/components/Settings/category/proxy.tsx
@@ -1,0 +1,208 @@
+/**
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { useEffect } from 'react';
+import * as z from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+
+import { useSetting } from '@renderer/hooks/useSetting';
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@renderer/components/ui/form';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@renderer/components/ui/select';
+import { Input } from '@renderer/components/ui/input';
+import { Switch } from '@renderer/components/ui/switch';
+
+const formSchema = z.object({
+  proxyEnabled: z.boolean(),
+  proxyMode: z.enum(['system', 'custom']),
+  httpProxy: z.string().optional(),
+  httpsProxy: z.string().optional(),
+  noProxy: z.string().optional(),
+});
+
+export function ProxySettings() {
+  const { settings, updateSetting } = useSetting();
+
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      proxyEnabled: false,
+      proxyMode: 'system',
+      httpProxy: '',
+      httpsProxy: '',
+      noProxy: '',
+    },
+  });
+
+  const proxyEnabled = form.watch('proxyEnabled');
+  const proxyMode = form.watch('proxyMode');
+
+  useEffect(() => {
+    if (Object.keys(settings).length) {
+      form.reset({
+        proxyEnabled: settings.proxyEnabled ?? false,
+        proxyMode: settings.proxyMode ?? 'system',
+        httpProxy: settings.httpProxy ?? '',
+        httpsProxy: settings.httpsProxy ?? '',
+        noProxy: settings.noProxy ?? '',
+      });
+    }
+  }, [settings, form]);
+
+  // Auto-save on change
+  useEffect(() => {
+    if (!Object.keys(settings).length) {
+      return;
+    }
+
+    const subscription = form.watch((value) => {
+      updateSetting({
+        ...settings,
+        proxyEnabled: value.proxyEnabled,
+        proxyMode: value.proxyMode,
+        httpProxy: value.httpProxy ?? '',
+        httpsProxy: value.httpsProxy ?? '',
+        noProxy: value.noProxy ?? '',
+      });
+    });
+
+    return () => subscription.unsubscribe();
+  }, [settings, updateSetting, form]);
+
+  return (
+    <>
+      <Form {...form}>
+        <form className="space-y-6">
+          <FormField
+            control={form.control}
+            name="proxyEnabled"
+            render={({ field }) => (
+              <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
+                <div className="space-y-0.5">
+                  <FormLabel className="text-base">Enable Proxy</FormLabel>
+                  <FormDescription>
+                    Route HTTP requests through a proxy server
+                  </FormDescription>
+                </div>
+                <FormControl>
+                  <Switch
+                    checked={field.value}
+                    onCheckedChange={field.onChange}
+                  />
+                </FormControl>
+              </FormItem>
+            )}
+          />
+
+          {proxyEnabled && (
+            <>
+              <FormField
+                control={form.control}
+                name="proxyMode"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Proxy Mode</FormLabel>
+                    <FormDescription>
+                      Use system proxy settings or configure a custom proxy
+                    </FormDescription>
+                    <Select
+                      onValueChange={field.onChange}
+                      value={field.value}
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select proxy mode" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="system">System Proxy</SelectItem>
+                        <SelectItem value="custom">Custom Proxy</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              {proxyMode === 'custom' && (
+                <>
+                  <FormField
+                    control={form.control}
+                    name="httpProxy"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>HTTP Proxy</FormLabel>
+                        <FormDescription>
+                          HTTP proxy address (e.g. http://127.0.0.1:7890)
+                        </FormDescription>
+                        <FormControl>
+                          <Input
+                            placeholder="http://127.0.0.1:7890"
+                            {...field}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="httpsProxy"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>HTTPS Proxy</FormLabel>
+                        <FormDescription>
+                          HTTPS proxy address (leave empty to use HTTP proxy)
+                        </FormDescription>
+                        <FormControl>
+                          <Input
+                            placeholder="http://127.0.0.1:7890"
+                            {...field}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="noProxy"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>No Proxy</FormLabel>
+                        <FormDescription>
+                          Comma-separated list of hosts to bypass proxy (e.g.
+                          localhost,127.0.0.1)
+                        </FormDescription>
+                        <FormControl>
+                          <Input
+                            placeholder="localhost,127.0.0.1"
+                            {...field}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </>
+              )}
+            </>
+          )}
+        </form>
+      </Form>
+    </>
+  );
+}

--- a/apps/ui-tars/src/renderer/src/pages/settings/Settings.tsx
+++ b/apps/ui-tars/src/renderer/src/pages/settings/Settings.tsx
@@ -37,6 +37,7 @@ import { BROWSER_OPERATOR } from '@renderer/const';
 import { PresetImport } from './PresetImport';
 import { Tabs, TabsList, TabsTrigger } from '@renderer/components/ui/tabs';
 import { PresetBanner } from './PresetBanner';
+import { ProxySettings } from '@renderer/components/Settings/category/proxy';
 
 import googleIcon from '@resources/icons/google-color.svg?url';
 import bingIcon from '@resources/icons/bing-color.svg?url';
@@ -57,11 +58,17 @@ const formSchema = z.object({
   searchEngineForBrowser: z.nativeEnum(SearchEngineForSettings),
   reportStorageBaseUrl: z.string().optional(),
   utioBaseUrl: z.string().optional(),
+  proxyEnabled: z.boolean().optional(),
+  proxyMode: z.enum(['system', 'custom']).optional(),
+  httpProxy: z.string().optional(),
+  httpsProxy: z.string().optional(),
+  noProxy: z.string().optional(),
 });
 
 const SECTIONS = {
   vlm: 'VLM Settings',
   chat: 'Chat Settings',
+  proxy: 'Proxy Settings',
   report: 'Report Settings',
   general: 'General',
 } as const;
@@ -127,6 +134,11 @@ export default function Settings() {
       reportStorageBaseUrl: '',
       searchEngineForBrowser: SearchEngineForSettings.GOOGLE,
       utioBaseUrl: '',
+      proxyEnabled: false,
+      proxyMode: 'system',
+      httpProxy: '',
+      httpsProxy: '',
+      noProxy: '',
       ...settings,
     },
   });
@@ -143,6 +155,11 @@ export default function Settings() {
         searchEngineForBrowser: settings.searchEngineForBrowser,
         reportStorageBaseUrl: settings.reportStorageBaseUrl,
         utioBaseUrl: settings.utioBaseUrl,
+        proxyEnabled: settings.proxyEnabled,
+        proxyMode: settings.proxyMode,
+        httpProxy: settings.httpProxy,
+        httpsProxy: settings.httpsProxy,
+        noProxy: settings.noProxy,
       });
     }
   }, [settings, form]);
@@ -496,6 +513,17 @@ export default function Settings() {
                     </FormItem>
                   )}
                 />
+              </div>
+              {/* Proxy Settings */}
+              <div
+                id="proxy"
+                ref={(el) => {
+                  sectionRefs.current.proxy = el;
+                }}
+                className="space-y-6 pt-6 ml-1 mr-4"
+              >
+                <h2 className="text-lg font-medium">{SECTIONS.proxy}</h2>
+                <ProxySettings />
               </div>
               <div
                 id="report"


### PR DESCRIPTION
Fixes #335

## Summary

Add proxy configuration support so users can set HTTP proxy for all Node.js network requests in the app. This solves the problem where Electron/Node.js requests don't use the system proxy.

### Changes

1. **Proxy Service** (`apps/ui-tars/src/main/services/proxy.ts`)
   - Applies proxy settings to Electron's `session.defaultSession` via `setProxy()`
   - Sets `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY` environment variables for Node.js HTTP clients
   - Supports three modes: system proxy, custom proxy, and disabled
   - Auto-normalizes proxy URLs (adds `http://` if no protocol)
   - Re-applies proxy when settings change

2. **Settings UI** (`apps/ui-tars/src/renderer/src/components/Settings/category/proxy.tsx`)
   - Enable/disable proxy toggle
   - System vs Custom proxy mode selector
   - HTTP Proxy URL, HTTPS Proxy URL (optional), No Proxy bypass list fields
   - Auto-saves on change

3. **Settings Integration**
   - Added proxy fields to `PresetSchema` (Zod validation)
   - Added proxy defaults to `DEFAULT_SETTING`
   - Integrated proxy service into app startup and settings update flow

### How It Works
- On app startup, proxy settings are loaded from the Electron store and applied to both the Electron session (for Chromium network requests) and Node.js environment variables (for OpenAI SDK, fetch, etc.)
- Users can choose "System Proxy" (reads OS proxy settings) or "Custom Proxy" (manual URL entry)
- Settings auto-save and dynamically re-apply when changed

Fixes #335