### PR TITLE
feat: support MCP JSON configuration paste and CLI import (#544)

### DIFF
--- a/multimodal/tarko/agent-cli/src/config/builder.ts
+++ b/multimodal/tarko/agent-cli/src/config/builder.ts
@@ -15,6 +15,9 @@ import {
 } from '@tarko/interface';
 import { resolveValue, loadWorkspaceConfig } from '../utils';
 import { logDeprecatedWarning, logConfigComplete } from './display';
+import fs from 'fs';
+import path from 'path';
+import { parseMCPJsonConfig } from '@agent-infra/shared';
 
 /**
  * Handler for processing deprecated CLI options
@@ -81,6 +84,36 @@ export function buildAppConfig<
     server,
     ...cliConfigProps
   } = cliArguments;
+
+  // Handle --mcp-config: load MCP servers from JSON config file
+  if ((cliArguments as any).mcpConfig) {
+    const mcpConfigPath = (cliArguments as any).mcpConfig as string;
+    const resolvedPath = path.resolve(mcpConfigPath);
+    if (fs.existsSync(resolvedPath)) {
+      try {
+        const mcpJsonText = fs.readFileSync(resolvedPath, 'utf-8').trim();
+        const result = parseMCPJsonConfig(mcpJsonText);
+        if (result.errors.length > 0) {
+          console.warn(`Warning: MCP config parse errors: ${result.errors.join('; ')}`);
+        }
+        if (result.servers.length > 0) {
+          if (!cliConfigProps.mcpServers) {
+            (cliConfigProps as any).mcpServers = {};
+          }
+          for (const server of result.servers) {
+            const { id, name, ...serverConfig } = server as any;
+            (cliConfigProps as any).mcpServers[name] = serverConfig;
+          }
+        }
+      } catch (error) {
+        console.warn(
+          `Warning: Failed to load MCP config from ${resolvedPath}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    } else {
+      console.warn(`Warning: MCP config file not found: ${resolvedPath}`);
+    }
+  }
 
   // Handle deprecated options
   const deprecatedOptionValues = {

--- a/multimodal/tarko/agent-cli/src/core/options.ts
+++ b/multimodal/tarko/agent-cli/src/core/options.ts
@@ -101,6 +101,20 @@ export function addCommonOptions(command: Command): Command {
       },
     )
 
+    // MCP JSON config import
+    .option(
+      '--mcp-config <path>',
+      `Path to a standard MCP JSON configuration file
+
+                            Import MCP servers from a standard JSON config file.
+                            Supports the standard format:
+                              {"mcpServers": {"name": {"command": "...", "args": [...]}}}
+
+                            Example:
+                              --mcp-config ./mcp.json
+      `,
+    )
+
     // Workspace configuration
     .option('--workspace <path>', 'workspace path')
 

--- a/multimodal/tarko/agent-cli/src/utils/workspace-config.ts
+++ b/multimodal/tarko/agent-cli/src/utils/workspace-config.ts
@@ -6,12 +6,14 @@
 import fs from 'fs';
 import path from 'path';
 import { AgentAppConfig } from '@tarko/interface';
+import { parseMCPJsonConfig } from '@agent-infra/shared';
 
 /**
  * Workspace configuration file paths
  */
 export const WORKSPACE_CONFIG_PATHS = {
   INSTRUCTIONS: '.tarko/instructions.md',
+  MCP_CONFIG: '.tarko/mcp.json',
   // Future: RULES: '.tarko/rules/*.md',
 } as const;
 
@@ -36,6 +38,35 @@ export function loadWorkspaceConfig(workspacePath: string): Partial<AgentAppConf
     }
   }
 
+  // Load mcp.json if exists (standard MCP JSON config format)
+  const mcpConfigPath = path.join(workspacePath, WORKSPACE_CONFIG_PATHS.MCP_CONFIG);
+  if (fs.existsSync(mcpConfigPath)) {
+    try {
+      const mcpJsonText = fs.readFileSync(mcpConfigPath, 'utf-8').trim();
+      if (mcpJsonText) {
+        const result = parseMCPJsonConfig(mcpJsonText);
+        if (result.errors.length > 0) {
+          console.warn(
+            `Warning: MCP config parse errors in ${mcpConfigPath}: ${result.errors.join('; ')}`,
+          );
+        }
+        if (result.servers.length > 0) {
+          if (!config.mcpServers) {
+            config.mcpServers = {};
+          }
+          for (const server of result.servers) {
+            const { id, name, ...serverConfig } = server as any;
+            config.mcpServers[name] = serverConfig;
+          }
+        }
+      }
+    } catch (error) {
+      console.warn(
+        `Warning: Failed to read ${mcpConfigPath}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
   return config;
 }
 
@@ -49,5 +80,6 @@ export function hasWorkspaceConfig(workspacePath: string): boolean {
   }
 
   const instructionsPath = path.join(workspacePath, WORKSPACE_CONFIG_PATHS.INSTRUCTIONS);
-  return fs.existsSync(instructionsPath);
+  const mcpConfigPath = path.join(workspacePath, WORKSPACE_CONFIG_PATHS.MCP_CONFIG);
+  return fs.existsSync(instructionsPath) || fs.existsSync(mcpConfigPath);
 }

--- a/packages/agent-infra/shared/src/agent-tars-types/index.ts
+++ b/packages/agent-infra/shared/src/agent-tars-types/index.ts
@@ -1,2 +1,3 @@
 export * from './search';
 export * from './setting';
+export * from './mcp-json-parser';

--- a/packages/agent-infra/shared/src/agent-tars-types/mcp-json-parser.ts
+++ b/packages/agent-infra/shared/src/agent-tars-types/mcp-json-parser.ts
@@ -1,0 +1,205 @@
+/**
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { MCPServer } from '@agent-infra/mcp-shared/client';
+
+/**
+ * Standard MCP server configuration entry in JSON format.
+ * Supports both stdio (command-based) and network-based (url-based) servers.
+ */
+export interface MCPServerJsonEntry {
+  /** Command to launch the server (for stdio transport) */
+  command?: string;
+  /** Arguments to pass to the command */
+  args?: string[];
+  /** Environment variables for the server process */
+  env?: Record<string, string>;
+  /** Working directory for the server process */
+  cwd?: string;
+  /** URL for SSE or Streamable HTTP transport */
+  url?: string;
+  /** Headers for network-based transports */
+  headers?: Record<string, string>;
+  /** Custom description */
+  description?: string;
+  /** Timeout in seconds */
+  timeout?: number;
+  /** Any additional fields */
+  [key: string]: unknown;
+}
+
+/**
+ * Supported MCP JSON configuration formats
+ */
+export interface MCPJsonConfig {
+  /** Standard format key */
+  mcpServers?: Record<string, MCPServerJsonEntry>;
+  /** Alternative format key (some tools use "servers") */
+  servers?: Record<string, MCPServerJsonEntry>;
+  /** Allow top-level unknown fields */
+  [key: string]: unknown;
+}
+
+/**
+ * Result of parsing MCP JSON configuration
+ */
+export interface MCPJsonParseResult {
+  /** Successfully parsed servers */
+  servers: Array<MCPServer & { id: string }>;
+  /** Parse errors, if any */
+  errors: string[];
+}
+
+/**
+ * Parse standard MCP JSON configuration into the internal MCPServer format.
+ *
+ * Supports two common JSON formats:
+ * 1. `{"mcpServers": {"name": {"command": "...", "args": [...]}}}`
+ * 2. `{"servers": {"name": {"command": "...", "args": [...]}}}`
+ *
+ * Also supports URL-based servers:
+ * `{"mcpServers": {"name": {"url": "http://...", "headers": {...}}}}`
+ *
+ * @param jsonText - Raw JSON text to parse
+ * @returns Parse result with servers and errors
+ */
+export function parseMCPJsonConfig(jsonText: string): MCPJsonParseResult {
+  const errors: string[] = [];
+  const servers: Array<MCPServer & { id: string }> = [];
+
+  // Step 1: Parse JSON
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonText);
+  } catch (e) {
+    return {
+      servers: [],
+      errors: [`Invalid JSON: ${e instanceof Error ? e.message : String(e)}`],
+    };
+  }
+
+  // Step 2: Validate top-level structure
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return {
+      servers: [],
+      errors: ['Configuration must be a JSON object'],
+    };
+  }
+
+  const config = parsed as MCPJsonConfig;
+  const serverEntries = config.mcpServers || config.servers;
+
+  if (!serverEntries) {
+    return {
+      servers: [],
+      errors: [
+        'Missing "mcpServers" or "servers" key. Expected format: {"mcpServers": {"server-name": {...}}}',
+      ],
+    };
+  }
+
+  if (typeof serverEntries !== 'object' || Array.isArray(serverEntries)) {
+    return {
+      servers: [],
+      errors: ['"mcpServers"/"servers" must be an object mapping server names to configurations'],
+    };
+  }
+
+  // Step 3: Parse each server entry
+  for (const [name, entry] of Object.entries(serverEntries)) {
+    try {
+      const server = parseServerEntry(name, entry);
+      servers.push(server);
+    } catch (e) {
+      errors.push(`Server "${name}": ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+
+  return { servers, errors };
+}
+
+/**
+ * Parse a single server entry into the internal MCPServer format
+ */
+function parseServerEntry(
+  name: string,
+  entry: unknown,
+): MCPServer & { id: string } {
+  if (typeof entry !== 'object' || entry === null || Array.isArray(entry)) {
+    throw new Error('Server configuration must be a JSON object');
+  }
+
+  const config = entry as MCPServerJsonEntry;
+
+  // Determine transport type
+  const hasCommand = typeof config.command === 'string' && config.command.length > 0;
+  const hasUrl = typeof config.url === 'string' && config.url.length > 0;
+
+  if (!hasCommand && !hasUrl) {
+    throw new Error('Server must have either "command" (for stdio) or "url" (for SSE/HTTP)');
+  }
+
+  if (hasCommand && hasUrl) {
+    throw new Error('Server cannot have both "command" and "url" - use one transport type');
+  }
+
+  const baseServer = {
+    name,
+    id: name,
+    description: config.description,
+    timeout: config.timeout,
+  };
+
+  if (hasCommand) {
+    // stdio transport
+    if (config.args !== undefined && !Array.isArray(config.args)) {
+      throw new Error('"args" must be an array of strings');
+    }
+    if (config.env !== undefined && (typeof config.env !== 'object' || Array.isArray(config.env))) {
+      throw new Error('"env" must be an object mapping string keys to string values');
+    }
+
+    return {
+      ...baseServer,
+      type: 'stdio' as const,
+      command: config.command!,
+      args: config.args,
+      env: config.env,
+      cwd: config.cwd,
+    };
+  }
+
+  // SSE or Streamable HTTP transport
+  if (config.headers !== undefined && (typeof config.headers !== 'object' || Array.isArray(config.headers))) {
+    throw new Error('"headers" must be an object');
+  }
+
+  // Default to streamable-http for url-based servers
+  return {
+    ...baseServer,
+    type: 'streamable-http' as const,
+    url: config.url!,
+    headers: config.headers,
+  };
+}
+
+/**
+ * Generate example MCP JSON configuration text for display purposes
+ */
+export function getMCPJsonExample(): string {
+  return JSON.stringify(
+    {
+      mcpServers: {
+        'my-server': {
+          command: 'npx',
+          args: ['-y', '@example/mcp-server'],
+          env: { API_KEY: 'your-api-key' },
+        },
+      },
+    },
+    null,
+    2,
+  );
+}


### PR DESCRIPTION
Fixes #544

## Summary

Add support for importing MCP server configurations from the standard MCP JSON format (`{"mcpServers": {...}}`), making it easy for users to paste or load server configurations without manually filling forms.

### Changes

1. **MCP JSON Parser** (`packages/agent-infra/shared/src/agent-tars-types/mcp-json-parser.ts`)
   - `parseMCPJsonConfig()` — parses standard MCP JSON format into internal `MCPServer` format
   - Supports both `mcpServers` and `servers` keys
   - Supports stdio (command-based) and network-based (url-based) servers
   - `getMCPJsonExample()` — example JSON for UI display
   - Graceful error handling with detailed error messages

2. **CLI `--mcp-config` Option** (`multimodal/tarko/agent-cli/src/core/options.ts`)
   - New `--mcp-config <path>` CLI flag to load MCP servers from a JSON config file
   - Example: `agent-tars --mcp-config ./mcp.json`

3. **Workspace Config Auto-Loading** (`multimodal/tarko/agent-cli/src/utils/workspace-config.ts`)
   - Auto-loads `.tarko/mcp.json` from workspace config directory on startup
   - Merges parsed servers into the agent configuration

4. **Builder Integration** (`multimodal/tarko/agent-cli/src/config/builder.ts`)
   - Handles `--mcp-config` in the config build pipeline

### Usage

```bash
# CLI flag
agent-tars --mcp-config ./mcp.json

# Workspace auto-loading
# Place as .tarko/mcp.json in your workspace directory
```

### Supported JSON Format

```json
{
  "mcpServers": {
    "my-server": {
      "command": "npx",
      "args": ["-y", "@example/mcp-server"],
      "env": { "API_KEY": "your-key" }
    },
    "remote-server": {
      "url": "http://localhost:3000/mcp",
      "headers": { "Authorization": "Bearer token" }
    }
  }
}
```

Fixes #544