### PR TITLE
fix(action-parser): match Python rounding for UI-TARS 1.5

### DIFF
--- a/packages/ui-tars/action-parser/src/actionParser.ts
+++ b/packages/ui-tars/action-parser/src/actionParser.ts
@@ -13,8 +13,24 @@ import {
 } from '@ui-tars/shared/types';
 import isNumber from 'lodash.isnumber';
 
+function roundHalfToEven(num: number): number {
+  const integerPart = Math.trunc(num);
+  const fraction = Math.abs(num - integerPart);
+
+  if (fraction !== 0.5) {
+    return Math.round(num);
+  }
+
+  const evenInteger =
+    Math.abs(integerPart) % 2 === 0
+      ? integerPart
+      : integerPart + Math.sign(num);
+
+  return evenInteger;
+}
+
 function roundByFactor(num: number, factor: number): number {
-  return Math.round(num / factor) * factor;
+  return roundHalfToEven(num / factor) * factor;
 }
 
 function floorByFactor(num: number, factor: number): number {

--- a/packages/ui-tars/action-parser/test/actionParser.test.ts
+++ b/packages/ui-tars/action-parser/test/actionParser.test.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { describe, it, expect } from 'vitest';
+import { UITarsModelVersion } from '@ui-tars/shared/types';
 import { parseActionVlm } from '../src/actionParser';
 
 describe('parseActionVlm', () => {
@@ -303,6 +304,35 @@ Action: click(start_box='[637,964,637,964]')`;
   });
 
   describe('Box coordinates normalization', () => {
+    it('should match Python smart_resize rounding for UI-TARS 1.5', () => {
+      const input = `Thought: I need to click on the bottom-right corner
+Action: click(start_box='(1512,1008)')`;
+
+      const result = parseActionVlm(
+        input,
+        [1000, 1000],
+        'bc',
+        {
+          width: 1522,
+          height: 1022,
+        },
+        1,
+        UITarsModelVersion.V1_5,
+      );
+
+      expect(result).toEqual([
+        {
+          action_inputs: {
+            start_box: '[1,1,1,1]',
+            start_coords: [1522, 1022],
+          },
+          action_type: 'click',
+          reflection: null,
+          thought: 'I need to click on the bottom-right corner',
+        },
+      ]);
+    });
+
     it('should correctly normalize box with four coordinates', () => {
       const input = `Thought: I need to click on this element
 Action: click(start_box='[130,226]')`;


### PR DESCRIPTION
## Summary

Fixes #1730

This PR updates the UI-TARS 1.5 smart resize rounding logic to match Python's `round()` behavior.

The model processor uses Python round-half-to-even semantics, while the TypeScript action parser previously used `Math.round()`. For `.5` cases, this can produce different resized dimensions and cause coordinate normalization drift, which may lead to incorrect clicks.

For example, with a `1022 x 1522` screen size:

- Python resize height: `1008`
- Previous TypeScript resize height: `1036`

This PR adds a Python-compatible round-half-to-even helper and uses it in `smartResizeForV15`.

A regression test was added for the reported case.

Tested with:

- `corepack pnpm --filter @ui-tars/action-parser test -- --run`
- `corepack pnpm --filter @ui-tars/action-parser build`

## Checklist  

- [x] Added or updated necessary tests (Optional).  
- [ ] Updated documentation to align with changes (Optional).  
- [x] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).  
- [ ] My change does not involve the above items. 
