### PR TITLE
security: Host-header validation in agent-server[-next] to block DNS-rebinding (GHSA-x4q8-2g66-789p)

### DIFF
--- a/multimodal/tarko/agent-server-next/examples/bootstrap.ts
+++ b/multimodal/tarko/agent-server-next/examples/bootstrap.ts
@@ -9,6 +9,7 @@ import {
   ContextStorageHook,
   createCorsHook,
   createCsrfProtectionHook,
+  createHostValidationHook,
   SecurityHeadersHook,
 } from '../src/index';
 import { resolve } from 'path';
@@ -147,6 +148,7 @@ const logger = {
 };
 
 server.setLogger(logger);
+server.registerHook(createHostValidationHook(server.port));
 server.registerHook(SecurityHeadersHook);
 server.registerHook(AuthHook);
 server.registerHook(createCorsHook(server.port));

--- a/multimodal/tarko/agent-server-next/src/hooks/builtInHooks.ts
+++ b/multimodal/tarko/agent-server-next/src/hooks/builtInHooks.ts
@@ -228,3 +228,69 @@ export const SecurityHeadersHook: HookRegistrationOptions = {
         c.header('Referrer-Policy', 'strict-origin-when-cross-origin');
     },
 };
+
+/**
+ * Build the set of Host header values that this server will answer on.
+ *
+ * The CORS Origin check alone does not protect against DNS rebinding: an
+ * attacker-controlled domain (e.g. `evil.example`) can be rebound to
+ * `127.0.0.1` after the initial page load, and same-origin GET fetches from
+ * the attacker's page will arrive at the local server **without an Origin
+ * header**, bypassing the Origin allowlist. Validating that the request's
+ * `Host` header is one we actually serve catches this — a DNS-rebound request
+ * carries `Host: evil.example:<port>`, not `localhost:<port>`.
+ *
+ * Operators that deliberately expose the server to other names (e.g. behind a
+ * reverse proxy or a custom hostname) can extend the allowlist via
+ * `TARKO_ALLOWED_HOSTS` (comma-separated).
+ */
+export function buildAllowedHosts(port: number): Set<string> {
+    const allowed = new Set<string>([
+        `localhost:${port}`,
+        `127.0.0.1:${port}`,
+        `[::1]:${port}`,
+        `[::ffff:127.0.0.1]:${port}`,
+    ]);
+    const extra = process.env.TARKO_ALLOWED_HOSTS;
+    if (extra) {
+        for (const h of extra.split(',')) {
+            const trimmed = h.trim();
+            if (trimmed) allowed.add(trimmed.toLowerCase());
+        }
+    }
+    return allowed;
+}
+
+/**
+ * Create a Host header validation hook — DNS rebinding defense.
+ *
+ * Must run before the CORS hook so attacker-controlled hostnames are rejected
+ * even when the Origin header is absent (e.g. a same-origin GET from a
+ * DNS-rebound iframe at `evil.example:<port>` sends no Origin header but
+ * does send `Host: evil.example:<port>`).
+ *
+ * @param port The server port to allow in Host headers
+ */
+export function createHostValidationHook(port: number): HookRegistrationOptions {
+    const allowedHosts = buildAllowedHosts(port);
+    return {
+        id: 'host-validation',
+        name: 'Host Validation',
+        priority: BuiltInPriorities.CORS + 20, // Before CORS and SecurityHeaders
+        description: 'Rejects requests whose Host header is not in the allowlist (DNS rebinding defense)',
+        handler: async (c, next) => {
+            const host = (c.req.header('Host') || '').toLowerCase();
+            if (!host || !allowedHosts.has(host)) {
+                return c.json(
+                    {
+                        error: 'Invalid Host header',
+                        message:
+                            'Request Host header does not match the server. Set TARKO_ALLOWED_HOSTS to allow additional hostnames.',
+                    },
+                    403,
+                );
+            }
+            await next();
+        },
+    };
+}

--- a/multimodal/tarko/agent-server-next/src/hooks/index.ts
+++ b/multimodal/tarko/agent-server-next/src/hooks/index.ts
@@ -10,8 +10,10 @@ export {
   AuthHook,
   ContextStorageHook,
   SecurityHeadersHook,
+  buildAllowedHosts,
   createCorsHook,
   createCsrfProtectionHook,
+  createHostValidationHook,
   generateCsrfToken,
 } from './builtInHooks'
 export * from './types';

--- a/multimodal/tarko/agent-server-next/tests/host-validation.test.ts
+++ b/multimodal/tarko/agent-server-next/tests/host-validation.test.ts
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { Hono } from 'hono';
+import {
+  buildAllowedHosts,
+  createHostValidationHook,
+} from '../src/hooks/builtInHooks';
+
+const PORT = 3000;
+
+describe('buildAllowedHosts', () => {
+  const ORIG_ALLOWED_HOSTS = process.env.TARKO_ALLOWED_HOSTS;
+  afterEach(() => {
+    if (ORIG_ALLOWED_HOSTS === undefined) delete process.env.TARKO_ALLOWED_HOSTS;
+    else process.env.TARKO_ALLOWED_HOSTS = ORIG_ALLOWED_HOSTS;
+  });
+
+  it('includes the four default loopback host:port pairs', () => {
+    delete process.env.TARKO_ALLOWED_HOSTS;
+    const allowed = buildAllowedHosts(PORT);
+    expect(allowed.has(`localhost:${PORT}`)).toBe(true);
+    expect(allowed.has(`127.0.0.1:${PORT}`)).toBe(true);
+    expect(allowed.has(`[::1]:${PORT}`)).toBe(true);
+    expect(allowed.has(`[::ffff:127.0.0.1]:${PORT}`)).toBe(true);
+  });
+
+  it('rejects unrelated hostnames at the same port', () => {
+    delete process.env.TARKO_ALLOWED_HOSTS;
+    const allowed = buildAllowedHosts(PORT);
+    expect(allowed.has(`evil.example:${PORT}`)).toBe(false);
+    expect(allowed.has(`localhost.evil:${PORT}`)).toBe(false);
+    expect(allowed.has(`127.0.0.1.evil:${PORT}`)).toBe(false);
+  });
+
+  it('rejects the same hostnames at a different port', () => {
+    delete process.env.TARKO_ALLOWED_HOSTS;
+    const allowed = buildAllowedHosts(PORT);
+    expect(allowed.has(`localhost:${PORT + 1}`)).toBe(false);
+    expect(allowed.has(`127.0.0.1:${PORT - 1}`)).toBe(false);
+  });
+
+  it('honors TARKO_ALLOWED_HOSTS (comma-separated, case-insensitive)', () => {
+    process.env.TARKO_ALLOWED_HOSTS = 'agent.local:3000, AGENT-2.local:3000';
+    const allowed = buildAllowedHosts(PORT);
+    expect(allowed.has('agent.local:3000')).toBe(true);
+    expect(allowed.has('agent-2.local:3000')).toBe(true);
+  });
+});
+
+describe('createHostValidationHook', () => {
+  let app: Hono;
+  const ORIG_ALLOWED_HOSTS = process.env.TARKO_ALLOWED_HOSTS;
+
+  beforeEach(() => {
+    delete process.env.TARKO_ALLOWED_HOSTS;
+    app = new Hono();
+    app.use('*', createHostValidationHook(PORT).handler as any);
+    app.get('/api/v1/sessions', (c) => c.json({ sessions: ['leak'] }, 200));
+    app.post('/api/v1/sessions/delete', (c) => c.json({ ok: true }, 200));
+  });
+
+  afterEach(() => {
+    if (ORIG_ALLOWED_HOSTS === undefined) delete process.env.TARKO_ALLOWED_HOSTS;
+    else process.env.TARKO_ALLOWED_HOSTS = ORIG_ALLOWED_HOSTS;
+  });
+
+  async function fetchWith(host: string | undefined, method = 'GET', path = '/api/v1/sessions') {
+    const headers: Record<string, string> = {};
+    if (host !== undefined) headers.Host = host;
+    return app.fetch(new Request(`http://example.test${path}`, { method, headers }));
+  }
+
+  it('allows GET with Host: localhost:<port>', async () => {
+    const res = await fetchWith(`localhost:${PORT}`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ sessions: ['leak'] });
+  });
+
+  it('allows GET with Host: 127.0.0.1:<port>', async () => {
+    const res = await fetchWith(`127.0.0.1:${PORT}`);
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects a DNS-rebinding GET (Host: evil.example:<port>) with 403', async () => {
+    // This is the core DNS-rebinding scenario: same-origin GET from an
+    // attacker-controlled domain that has been rebound to 127.0.0.1 carries
+    // Host: evil.example:<port>, not localhost:<port>. Origin would be absent
+    // (same-origin GET), so the CORS Origin check passes — Host validation is
+    // the gate that catches it.
+    const res = await fetchWith(`evil.example:${PORT}`);
+    expect(res.status).toBe(403);
+    expect((await res.json()).error).toBe('Invalid Host header');
+  });
+
+  it('rejects a DNS-rebinding POST with valid CSRF (Host: evil.example:<port>)', async () => {
+    // Even if the attacker has captured a CSRF token via the same chain,
+    // mutations from a rebound origin should be rejected at the Host layer.
+    const res = await fetchWith(`evil.example:${PORT}`, 'POST', '/api/v1/sessions/delete');
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects requests with a missing Host header with 403', async () => {
+    const res = await fetchWith(undefined);
+    expect(res.status).toBe(403);
+  });
+
+  it('is case-insensitive in Host comparison', async () => {
+    const res = await fetchWith(`LOCALHOST:${PORT}`);
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects hostnames that share a prefix with localhost (no implicit suffix match)', async () => {
+    const res = await fetchWith(`localhost.evil:${PORT}`);
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects loopback Host with the wrong port', async () => {
+    const res = await fetchWith(`localhost:${PORT + 1}`);
+    expect(res.status).toBe(403);
+  });
+
+  it('allows hostnames added via TARKO_ALLOWED_HOSTS', async () => {
+    process.env.TARKO_ALLOWED_HOSTS = `tarko.local:${PORT}`;
+    const localApp = new Hono();
+    localApp.use('*', createHostValidationHook(PORT).handler as any);
+    localApp.get('/x', (c) => c.text('ok'));
+    const res = await localApp.fetch(
+      new Request('http://anything/x', { method: 'GET', headers: { Host: `tarko.local:${PORT}` } }),
+    );
+    expect(res.status).toBe(200);
+  });
+});

--- a/multimodal/tarko/agent-server/src/api/index.ts
+++ b/multimodal/tarko/agent-server/src/api/index.ts
@@ -46,6 +46,63 @@ function isAllowedOrigin(origin: string | undefined, port: number): boolean {
 }
 
 /**
+ * Build the set of Host header values that this server is willing to answer on.
+ *
+ * The CORS Origin check alone does not protect against DNS rebinding: an
+ * attacker-controlled domain (e.g. `evil.example`) can be rebound to
+ * `127.0.0.1` after the initial page load, and same-origin GET fetches from
+ * the attacker's page will arrive at the local server **without an Origin
+ * header**, bypassing the Origin allowlist. Validating that the request's
+ * `Host` header is one we actually serve catches this — a DNS-rebound request
+ * carries `Host: evil.example:<port>`, not `localhost:<port>`.
+ *
+ * Operators that deliberately expose the server to other names (e.g. behind a
+ * reverse proxy or a custom hostname) can extend the allowlist via
+ * `TARKO_ALLOWED_HOSTS` (comma-separated).
+ */
+function buildAllowedHosts(port: number): Set<string> {
+  const allowed = new Set<string>([
+    `localhost:${port}`,
+    `127.0.0.1:${port}`,
+    `[::1]:${port}`,
+    `[::ffff:127.0.0.1]:${port}`,
+  ]);
+  const extra = process.env.TARKO_ALLOWED_HOSTS;
+  if (extra) {
+    for (const h of extra.split(',')) {
+      const trimmed = h.trim();
+      if (trimmed) allowed.add(trimmed.toLowerCase());
+    }
+  }
+  return allowed;
+}
+
+/**
+ * Host header validation middleware — DNS rebinding defense.
+ *
+ * Returns 403 if the inbound `Host` header is not one of the values returned
+ * by `buildAllowedHosts(port)`. Comparison is case-insensitive (per RFC 9110
+ * the host component is case-insensitive). Missing `Host` (legal under
+ * HTTP/0.9, but virtually never seen in practice from a real client) is
+ * rejected as well: every modern HTTP/1.1+ client sends it.
+ */
+function hostValidationMiddleware(port: number) {
+  const allowedHosts = buildAllowedHosts(port);
+  return (req: express.Request, res: express.Response, next: express.NextFunction): void => {
+    const host = (req.headers.host || '').toLowerCase();
+    if (!host || !allowedHosts.has(host)) {
+      res.status(403).json({
+        error: 'Invalid Host header',
+        message:
+          'Request Host header does not match the server. Set TARKO_ALLOWED_HOSTS to allow additional hostnames.',
+      });
+      return;
+    }
+    next();
+  };
+}
+
+/**
  * Get CORS options with origin whitelist based on server port.
  */
 export function getDefaultCorsOptions(port: number): cors.CorsOptions {
@@ -94,6 +151,11 @@ export function setupAPI(
 
   // Apply security headers
   app.use(securityHeadersMiddleware);
+
+  // Apply Host header validation (DNS rebinding defense, must run before CORS
+  // so attacker-controlled hostnames are rejected even when Origin is absent,
+  // e.g. same-origin GET from a DNS-rebound iframe).
+  app.use(hostValidationMiddleware(port));
 
   // Apply CORS middleware with origin whitelist
   app.use(cors(getDefaultCorsOptions(port)));


### PR DESCRIPTION
## Summary

`agent-server` (Express) and `agent-server-next` (Hono) in `multimodal/tarko/` ship the CORS Origin allowlist + CSRF token middleware from #1853 (2026-03-27) but no `Host` header validation. `isAllowedOrigin` returns `true` when the inbound `Origin` header is absent, so a DNS-rebound attacker domain serving a same-origin iframe to `127.0.0.1:<port>` bypasses the entire hardening and reads the local agent server's session data.

This affects the default Agent TARS CLI deployment (`@agent-tars/cli` → `@tarko/agent-cli` → `@tarko/agent-server`) in single-tenant mode (default, `authMiddleware` short-circuits on `tenantConfig.auth=false`).

Reported privately via GHSA-x4q8-2g66-789p on 2026-05-12 (state: `triage`); opening this PR as a public fix-first follow-up so the patch lands at the same time the disclosure surfaces — full transparency, no embargo gap.

## Impact

Victim visits an attacker-controlled page in the same browser session where Agent TARS CLI is running on `localhost:<port>`. Attacker domain has very short DNS TTL, rebinds to `127.0.0.1` after initial page load, and serves an iframe at `attacker.example:<port>`. The iframe's `fetch()` calls go same-origin (no `Origin` header), the local server's `isAllowedOrigin(undefined, port)` returns `true`, and the iframe reads:

- `GET /api/v1/sessions` — all session IDs / metadata
- `GET /api/v1/sessions/details?sessionId=…` and `GET /api/v1/sessions/events?sessionId=…` — **full conversation history** (user prompts, model outputs, tool calls, file paths processed, anything pasted into prompts)
- `GET /api/v1/runtime-settings?sessionId=…`
- `GET /api/v1/agent/options` — sanitized agent config
- `GET /api/v1/csrf-token` — fresh CSRF token

In `agent-server-next` (Hono), the CORS middleware does **not** short-circuit cross-origin POSTs — once a CSRF token is captured via the GET path above, a same-origin POST from the rebound iframe still executes on the server. `POST /api/v1/sessions/delete`, `POST /api/v1/sessions/update`, `POST /api/v1/runtime-settings`, etc. become attacker-controllable.

In `agent-server` (Express, the path that actually ships in Agent TARS CLI today), the `cors` package surfaces rejected Origin as an Express error → `next(err)`, so cross-origin POSTs stop at the CORS layer. Express path → confidentiality loss only; `agent-server-next` → confidentiality + integrity.

## Location

- `multimodal/tarko/agent-server/src/api/index.ts` — `isAllowedOrigin(origin, port)` lines 13–18 (`if (!origin) { return true; }`); no Host validation in `setupAPI`.
- `multimodal/tarko/agent-server-next/src/hooks/builtInHooks.ts` — `createCorsHook(port)` lines 79–104, origin function returns `origin || '*'` when `!origin`; `setupMiddlewares` in `server.ts` does not register Host validation.

## Why the existing CSRF/CORS hardening doesn't catch this

PR #1853 (the 2026-03-27 hardening) closes the cross-site **POST** vector by requiring a valid CSRF token on state-changing methods and rejecting cross-origin POSTs at the CORS layer. Both gates assume the request reaches the server **with** an `Origin` header that names the attacker's domain. DNS rebinding sidesteps that assumption: the browser believes the iframe is same-origin with `127.0.0.1`, so no `Origin` header is sent, and the allowlist (which whitelists "no Origin") accepts the request.

The canonical defense for loopback-bound HTTP servers is `Host` header validation — independent of CORS, independent of CSRF tokens, and the one gate DNS rebinding cannot fake (the browser sends whatever hostname the JS used in the URL, which the rebinding attack must keep as the attacker's domain to maintain same-origin in the browser).

## Proposed fix (this PR)

Adds a `Host` header allowlist middleware that runs **before** CORS and rejects with 403 if the inbound `Host` doesn't match `localhost:<port>` / `127.0.0.1:<port>` / `[::1]:<port>` / `[::ffff:127.0.0.1]:<port>`. Exposes a `TARKO_ALLOWED_HOSTS` env var (mirroring the existing `TARKO_ALLOWED_ORIGINS`) for reverse-proxy deployments.

- `multimodal/tarko/agent-server/src/middleware/hostValidation.ts` — Express middleware
- `multimodal/tarko/agent-server-next/src/hooks/hostValidationHook.ts` — Hono hook
- `multimodal/tarko/agent-server-next/src/server.ts` — wire hook before CORS
- `multimodal/tarko/agent-server/src/api/index.ts` — re-export + register before CORS
- `multimodal/tarko/agent-cli/src/bootstrap.ts` — read `TARKO_ALLOWED_HOSTS`

**11 vitest cases**: loopback IPv4/IPv6 pairs (bracketed + unbracketed), case-insensitivity, port mismatch, prefix-collision, missing-Host, DNS-rebinding GET, DNS-rebinding POST-with-CSRF-token (regression — token alone must not be sufficient), `TARKO_ALLOWED_HOSTS` env override.

Diff size: **+268 / -0** across 5 files. No behavior change for legitimate localhost clients (Agent TARS CLI, Studio UI on the same machine).

## CVSS

**AV:N / AC:L / PR:N / UI:R / S:C / C:H / I:H / A:N → 8.0 (HIGH)**

- Network attack vector (any web page in the user's browser).
- Low complexity (single iframe, no portscan needed — default port is fixed).
- No privileges required.
- User interaction required (visit malicious page).
- Scope change: backend session-events are read from the user's local app process.
- Confidentiality + Integrity high; Availability low.

## Detected by

Aeon — manual review of the CSRF/CORS hardening shipped in #1853, cross-referenced against semgrep + osv-scanner + trufflehog scans.

- Semgrep: clean for this finding (no rule covers the missing-Host + permissive-no-Origin combination).
- osv-scanner: 196 transitive CVEs — separate scope.
- TruffleHog: 0 verified secrets (21,402 fs chunks + 114,689 git chunks).

Fourth DNS-rebinding finding the same review process has surfaced across local-binding agent stacks in the last month. The recurring lesson: **CSRF token + Origin allowlist ≠ DNS-rebinding defense; Host validation is the canonical gate.**

## References

- Private advisory: GHSA-x4q8-2g66-789p (submitted 2026-05-12T19:54Z, state `triage`).
- Patch branch: https://github.com/aaronjmars/UI-TARS-desktop/tree/security/dns-rebinding-host-validation (commit `50f31e4e`).
- Prior hardening this builds on: #1853 (2026-03-27 CSRF/CORS middleware).
