### PR TITLE
docs: remove stale FIXME comment from README showcase section

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,6 @@ UI-TARS Desktop is a native GUI agent for your local computer, driven by [UI-TAR
 
 ### Showcase
 
-<!-- // FIXME: Choose only two demo, one local computer and one remote computer showcase. -->
 
 |                                                          Instruction                                                           |                                                Local Operator                                                |                                               Remote Operator                                                |
 | :----------------------------------------------------------------------------------------------------------------------------: | :----------------------------------------------------------------------------------------------------------: | :----------------------------------------------------------------------------------------------------------: |


### PR DESCRIPTION
Removes an internal FIXME comment that leaked into the public README showcase section.