### PR TITLE
feat: add Astraflow provider support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,14 @@ VLM_PROVIDER=huggingface
 VLM_BASE_URL=http://your_endpoint.aws.endpoints.huggingface.cloud/v1
 VLM_API_KEY=hf_your_api_key
 VLM_MODEL_NAME=your_model_name
+
+# Astraflow by UCloud — OpenAI-compatible platform supporting 200+ models
+# Global endpoint: https://astraflow.ucloud-global.com
+# ASTRAFLOW_API_KEY=<your-global-api-key>
+# VLM_PROVIDER=Astraflow (Global) for UI-TARS
+# VLM_BASE_URL=https://api-us-ca.umodelverse.ai/v1
+
+# China endpoint: https://astraflow.ucloud.cn
+# ASTRAFLOW_CN_API_KEY=<your-china-api-key>
+# VLM_PROVIDER=Astraflow (China) for UI-TARS
+# VLM_BASE_URL=https://api.modelverse.cn/v1

--- a/apps/ui-tars/src/main/store/types.ts
+++ b/apps/ui-tars/src/main/store/types.ts
@@ -46,6 +46,8 @@ export enum VLMProviderV2 {
   ui_tars_1_5 = 'Hugging Face for UI-TARS-1.5',
   doubao_1_5 = 'VolcEngine Ark for Doubao-1.5-UI-TARS',
   doubao_1_5_vl = 'VolcEngine Ark for Doubao-1.5-thinking-vision-pro',
+  astraflow = 'Astraflow (Global) for UI-TARS',
+  astraflow_cn = 'Astraflow (China) for UI-TARS',
 }
 
 export enum SearchEngineForSettings {

--- a/apps/ui-tars/src/main/utils/agent.ts
+++ b/apps/ui-tars/src/main/utils/agent.ts
@@ -32,6 +32,9 @@ export const getModelVersion = (
       return UITarsModelVersion.DOUBAO_1_5_15B;
     case VLMProviderV2.doubao_1_5_vl:
       return UITarsModelVersion.DOUBAO_1_5_20B;
+    case VLMProviderV2.astraflow:
+    case VLMProviderV2.astraflow_cn:
+      return UITarsModelVersion.V1_5;
     default:
       return UITarsModelVersion.V1_0;
   }


### PR DESCRIPTION
## Summary

Adds **Astraflow** (by UCloud / 优刻得) as a supported VLM provider in UI-TARS-desktop.

[Astraflow](https://astraflow.ucloud-global.com) is an OpenAI-compatible AI model aggregation platform supporting 200+ models. Because it is fully OpenAI-compatible, integration only requires registering the provider enum and pointing to the correct `base_url` — no new SDK or subpackage is needed.

### Changes

#### `apps/ui-tars/src/main/store/types.ts`
- Added two new entries to the `VLMProviderV2` enum:
  - `astraflow` → `'Astraflow (Global) for UI-TARS'` — uses the global endpoint (`https://api-us-ca.umodelverse.ai/v1`, env var `ASTRAFLOW_API_KEY`)
  - `astraflow_cn` → `'Astraflow (China) for UI-TARS'` — uses the China endpoint (`https://api.modelverse.cn/v1`, env var `ASTRAFLOW_CN_API_KEY`)

  Because the Settings UI iterates `Object.values(VLMProviderV2)` and the Zod schema uses `z.nativeEnum(VLMProviderV2)`, both providers are automatically surfaced in the UI and accepted in preset validation with no further UI changes required.

#### `apps/ui-tars/src/main/utils/agent.ts`
- Added `case VLMProviderV2.astraflow` and `case VLMProviderV2.astraflow_cn` to `getModelVersion()`, mapping them to `UITarsModelVersion.V1_5` (the most capable UI-TARS model version for OpenAI-compatible endpoints).

#### `.env.example`
- Added commented-out documentation for both Astraflow endpoints so users know which env vars and base URLs to use when configuring the provider.

### Usage

**Global endpoint** — sign up at https://astraflow.ucloud-global.com:
```yaml
vlmProvider: "Astraflow (Global) for UI-TARS"
vlmBaseUrl: "https://api-us-ca.umodelverse.ai/v1"
vlmApiKey: "<ASTRAFLOW_API_KEY>"
vlmModelName: "<model-name>"
```

**China endpoint** — sign up at https://astraflow.ucloud.cn:
```yaml
vlmProvider: "Astraflow (China) for UI-TARS"
vlmBaseUrl: "https://api.modelverse.cn/v1"
vlmApiKey: "<ASTRAFLOW_CN_API_KEY>"
vlmModelName: "<model-name>"
```

## Checklist  

- [ ] Added or updated necessary tests (Optional).  
- [x] Updated documentation to align with changes (Optional).  
- [x] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).  
- [ ] My change does not involve the above items.