### PR TITLE
feat: add scheduled tasks

### DIFF
--- a/apps/ui-tars/src/main/ipcRoutes/index.ts
+++ b/apps/ui-tars/src/main/ipcRoutes/index.ts
@@ -10,6 +10,7 @@ import { agentRoute } from './agent';
 import { browserRoute } from './browser';
 import { remoteResourceRouter } from './remoteResource';
 import { settingRoute } from './setting';
+import { scheduledTaskRoute } from './scheduledTask';
 
 const t = initIpc.create();
 
@@ -21,6 +22,7 @@ export const ipcRoutes = t.router({
   ...remoteResourceRouter,
   ...browserRoute,
   ...settingRoute,
+  ...scheduledTaskRoute,
 });
 export type Router = typeof ipcRoutes;
 

--- a/apps/ui-tars/src/main/ipcRoutes/scheduledTask.ts
+++ b/apps/ui-tars/src/main/ipcRoutes/scheduledTask.ts
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { initIpc } from '@ui-tars/electron-ipc/main';
+
+import { scheduledTaskService } from '@main/services/scheduledTasks';
+import type {
+  CreateScheduledTaskInput,
+  ScheduledTask,
+} from '@main/shared/scheduledTasks';
+
+const t = initIpc.create();
+
+export const scheduledTaskRoute = t.router({
+  listScheduledTasks: t.procedure.input<void>().handle(async () => {
+    return scheduledTaskService.list();
+  }),
+  createScheduledTask: t.procedure
+    .input<CreateScheduledTaskInput>()
+    .handle(async ({ input }) => {
+      return scheduledTaskService.create(input);
+    }),
+  updateScheduledTask: t.procedure
+    .input<{ id: string; updates: Partial<ScheduledTask> }>()
+    .handle(async ({ input }) => {
+      return scheduledTaskService.update(input.id, input.updates);
+    }),
+  deleteScheduledTask: t.procedure
+    .input<{ id: string }>()
+    .handle(async ({ input }) => {
+      return scheduledTaskService.delete(input.id);
+    }),
+  runScheduledTaskNow: t.procedure
+    .input<{ id: string }>()
+    .handle(async ({ input }) => {
+      return scheduledTaskService.runNow(input.id);
+    }),
+});

--- a/apps/ui-tars/src/main/main.ts
+++ b/apps/ui-tars/src/main/main.ts
@@ -30,6 +30,7 @@ import { registerSettingsHandlers } from './services/settings';
 import { sanitizeState } from './utils/sanitizeState';
 import { windowManager } from './services/windowManager';
 import { checkBrowserAvailability } from './services/browserCheck';
+import { scheduledTaskService } from './services/scheduledTasks';
 
 const { isProd } = env;
 
@@ -57,12 +58,8 @@ const loadDevDebugTools = async () => {
   });
 
   import('electron-devtools-installer')
-    .then(({ default: installExtensionDefault, REACT_DEVELOPER_TOOLS }) => {
-      // @ts-ignore
-      const installExtension = installExtensionDefault?.default;
-      const extensions = [installExtension(REACT_DEVELOPER_TOOLS)];
-
-      return Promise.all(extensions)
+    .then(({ default: installExtension, REACT_DEVELOPER_TOOLS }) => {
+      return Promise.all([installExtension(REACT_DEVELOPER_TOOLS)])
         .then((names) => logger.info('Added Extensions:', names.join(', ')))
         .catch((err) =>
           logger.error('An error occurred adding extension:', err),
@@ -147,6 +144,7 @@ const initializeApp = async () => {
   });
 
   logger.info('initializeApp end');
+  scheduledTaskService.start();
 
   // Check and update remote presets
   const settings = SettingStore.getStore();

--- a/apps/ui-tars/src/main/services/scheduledTasks.ts
+++ b/apps/ui-tars/src/main/services/scheduledTasks.ts
@@ -1,0 +1,263 @@
+/**
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import ElectronStore from 'electron-store';
+import { BrowserWindow } from 'electron';
+import { Conversation, StatusEnum } from '@ui-tars/shared/types';
+
+import { logger } from '@main/logger';
+import { runAgent } from '@main/services/runAgent';
+import { store } from '@main/store/create';
+import type {
+  ScheduledTask,
+  CreateScheduledTaskInput,
+} from '@main/shared/scheduledTasks';
+import { calculateNextRunAt } from '@main/shared/scheduledTaskMath';
+
+type ScheduledTaskStore = {
+  tasks: ScheduledTask[];
+};
+
+const DEFAULT_STORE: ScheduledTaskStore = {
+  tasks: [],
+};
+
+const MAX_TIMEOUT_MS = 2_147_483_647;
+
+const normalizeTimeOfDay = (timeOfDay?: string) => {
+  if (!timeOfDay || !/^\d{2}:\d{2}$/.test(timeOfDay)) {
+    return '09:00';
+  }
+
+  const [hours, minutes] = timeOfDay.split(':').map(Number);
+  if (hours > 23 || minutes > 59) {
+    return '09:00';
+  }
+
+  return timeOfDay;
+};
+
+class ScheduledTaskService {
+  private static instance: ScheduledTaskService;
+  private readonly store = new ElectronStore<ScheduledTaskStore>({
+    name: 'ui_tars.scheduled-tasks',
+    defaults: DEFAULT_STORE,
+  });
+  private timers = new Map<string, NodeJS.Timeout>();
+  private runningTaskIds = new Set<string>();
+
+  private constructor() {}
+
+  public static getInstance(): ScheduledTaskService {
+    if (!ScheduledTaskService.instance) {
+      ScheduledTaskService.instance = new ScheduledTaskService();
+    }
+    return ScheduledTaskService.instance;
+  }
+
+  public start() {
+    this.rescheduleAll();
+  }
+
+  public list() {
+    return this.getTasks().map((task) => this.withNextRun(task));
+  }
+
+  public create(input: CreateScheduledTaskInput) {
+    if (!input.prompt.trim()) {
+      throw new Error('Task prompt is required');
+    }
+
+    const now = Date.now();
+    const task = this.withNextRun({
+      ...input,
+      id: `task_${now}_${Math.random().toString(36).slice(2, 10)}`,
+      name: input.name.trim() || 'Scheduled task',
+      prompt: input.prompt.trim(),
+      enabled: input.enabled ?? true,
+      daysOfWeek: input.daysOfWeek?.length
+        ? input.daysOfWeek
+        : [new Date().getDay()],
+      timeOfDay: normalizeTimeOfDay(input.timeOfDay),
+      intervalMinutes: Math.max(1, input.intervalMinutes || 60),
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const tasks = [...this.getTasks(), task];
+    this.save(tasks);
+    return task;
+  }
+
+  public update(id: string, updates: Partial<ScheduledTask>) {
+    let updatedTask: ScheduledTask | null = null;
+    const tasks = this.getTasks().map((task) => {
+      if (task.id !== id) {
+        return task;
+      }
+
+      updatedTask = this.withNextRun({
+        ...task,
+        ...updates,
+        id: task.id,
+        name: updates.name?.trim() || task.name,
+        prompt: updates.prompt?.trim() || task.prompt,
+        updatedAt: Date.now(),
+      });
+      return updatedTask;
+    });
+
+    this.save(tasks);
+    return updatedTask;
+  }
+
+  public delete(id: string) {
+    this.clearTimer(id);
+    const currentTasks = this.getTasks();
+    const tasks = currentTasks.filter((task) => task.id !== id);
+    this.save(tasks);
+    return tasks.length !== currentTasks.length;
+  }
+
+  public async runNow(id: string) {
+    const task = this.list().find((item) => item.id === id);
+    if (!task) {
+      throw new Error('Scheduled task not found');
+    }
+
+    await this.runTask(task, true);
+    return this.list().find((item) => item.id === id) || null;
+  }
+
+  private async runTask(task: ScheduledTask, manual = false) {
+    if (this.runningTaskIds.has(task.id)) {
+      return;
+    }
+
+    const { thinking } = store.getState();
+    if (thinking) {
+      logger.warn(
+        '[ScheduledTask] skip because agent is already running',
+        task.id,
+      );
+      this.reschedule(task);
+      return;
+    }
+
+    this.runningTaskIds.add(task.id);
+
+    try {
+      const now = Date.now();
+      const humanMessage: Conversation = {
+        from: 'human',
+        value: task.prompt,
+        timing: { start: now, end: now, cost: 0 },
+      };
+
+      store.setState({
+        abortController: new AbortController(),
+        thinking: true,
+        errorMsg: null,
+        instructions: task.prompt,
+        messages: [humanMessage],
+        sessionHistoryMessages: [],
+      });
+
+      BrowserWindow.getAllWindows().forEach((win) => {
+        if (!win.isDestroyed()) {
+          win.show();
+          win.webContents.send('scheduled-task-started', task);
+        }
+      });
+
+      await runAgent(store.setState, store.getState);
+
+      const completedTask = {
+        ...task,
+        enabled: task.frequency === 'once' && !manual ? false : task.enabled,
+        lastRunAt: Date.now(),
+        updatedAt: Date.now(),
+      };
+
+      this.update(task.id, completedTask);
+    } catch (error) {
+      logger.error('[ScheduledTask] run failed', error);
+      store.setState({
+        status: StatusEnum.ERROR,
+        errorMsg: error instanceof Error ? error.message : String(error),
+      });
+      this.reschedule(task);
+    } finally {
+      store.setState({ thinking: false });
+      this.runningTaskIds.delete(task.id);
+    }
+  }
+
+  private withNextRun(task: ScheduledTask): ScheduledTask {
+    return {
+      ...task,
+      nextRunAt: calculateNextRunAt(task),
+    };
+  }
+
+  private rescheduleAll() {
+    this.timers.forEach((timer) => clearTimeout(timer));
+    this.timers.clear();
+    this.list().forEach((task) => this.reschedule(task));
+  }
+
+  private reschedule(task: ScheduledTask) {
+    this.clearTimer(task.id);
+    const nextRunAt = calculateNextRunAt(task);
+
+    const tasks = this.getTasks().map((item) =>
+      item.id === task.id ? { ...item, nextRunAt } : item,
+    );
+    this.save(tasks, false);
+
+    if (!nextRunAt) {
+      return;
+    }
+
+    const delay = Math.min(
+      Math.max(nextRunAt - Date.now(), 1000),
+      MAX_TIMEOUT_MS,
+    );
+    const timer = setTimeout(() => {
+      const latest = this.list().find((item) => item.id === task.id);
+      if (latest?.enabled) {
+        void this.runTask(latest);
+      }
+    }, delay);
+
+    this.timers.set(task.id, timer);
+  }
+
+  private clearTimer(id: string) {
+    const timer = this.timers.get(id);
+    if (timer) {
+      clearTimeout(timer);
+      this.timers.delete(id);
+    }
+  }
+
+  private getTasks() {
+    return this.store.get('tasks') || [];
+  }
+
+  private save(tasks: ScheduledTask[], schedule = true) {
+    this.store.set('tasks', tasks);
+    BrowserWindow.getAllWindows().forEach((win) => {
+      if (!win.isDestroyed()) {
+        win.webContents.send('scheduled-tasks-updated', tasks);
+      }
+    });
+
+    if (schedule) {
+      this.rescheduleAll();
+    }
+  }
+}
+
+export const scheduledTaskService = ScheduledTaskService.getInstance();

--- a/apps/ui-tars/src/main/shared/scheduledTaskMath.test.ts
+++ b/apps/ui-tars/src/main/shared/scheduledTaskMath.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { describe, expect, it } from 'vitest';
+import { calculateNextRunAt } from './scheduledTaskMath';
+import type { ScheduledTask } from './scheduledTasks';
+
+const baseTask: ScheduledTask = {
+  id: 'task',
+  name: 'Task',
+  prompt: 'Do something',
+  enabled: true,
+  frequency: 'once',
+  createdAt: Date.parse('2026-05-22T08:00:00'),
+  updatedAt: Date.parse('2026-05-22T08:00:00'),
+};
+
+describe('calculateNextRunAt', () => {
+  it('returns the future run date for one-time tasks', () => {
+    const nextRunAt = calculateNextRunAt(
+      {
+        ...baseTask,
+        runAt: '2026-05-22T09:30',
+      },
+      Date.parse('2026-05-22T09:00:00'),
+    );
+
+    expect(nextRunAt).toBe(Date.parse('2026-05-22T09:30:00'));
+  });
+
+  it('returns null for disabled tasks', () => {
+    expect(
+      calculateNextRunAt(
+        {
+          ...baseTask,
+          enabled: false,
+          runAt: '2026-05-22T09:30',
+        },
+        Date.parse('2026-05-22T09:00:00'),
+      ),
+    ).toBeNull();
+  });
+
+  it('moves daily tasks to tomorrow when today has passed', () => {
+    const nextRunAt = calculateNextRunAt(
+      {
+        ...baseTask,
+        frequency: 'daily',
+        timeOfDay: '09:00',
+      },
+      Date.parse('2026-05-22T10:00:00'),
+    );
+
+    expect(nextRunAt).toBe(Date.parse('2026-05-23T09:00:00'));
+  });
+
+  it('selects the next matching weekly day', () => {
+    const nextRunAt = calculateNextRunAt(
+      {
+        ...baseTask,
+        frequency: 'weekly',
+        daysOfWeek: [1],
+        timeOfDay: '08:30',
+      },
+      Date.parse('2026-05-22T10:00:00'),
+    );
+
+    expect(nextRunAt).toBe(Date.parse('2026-05-25T08:30:00'));
+  });
+
+  it('uses last run time for interval tasks', () => {
+    const nextRunAt = calculateNextRunAt(
+      {
+        ...baseTask,
+        frequency: 'interval',
+        intervalMinutes: 15,
+        lastRunAt: Date.parse('2026-05-22T09:00:00'),
+      },
+      Date.parse('2026-05-22T09:05:00'),
+    );
+
+    expect(nextRunAt).toBe(Date.parse('2026-05-22T09:15:00'));
+  });
+});

--- a/apps/ui-tars/src/main/shared/scheduledTaskMath.ts
+++ b/apps/ui-tars/src/main/shared/scheduledTaskMath.ts
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import type { ScheduledTask } from './scheduledTasks';
+
+const MIN_INTERVAL_MS = 60 * 1000;
+
+const normalizeTimeOfDay = (timeOfDay?: string) => {
+  if (!timeOfDay || !/^\d{2}:\d{2}$/.test(timeOfDay)) {
+    return '09:00';
+  }
+
+  const [hours, minutes] = timeOfDay.split(':').map(Number);
+  if (hours > 23 || minutes > 59) {
+    return '09:00';
+  }
+
+  return timeOfDay;
+};
+
+const getTimeParts = (timeOfDay?: string) => {
+  const [hours, minutes] = normalizeTimeOfDay(timeOfDay).split(':').map(Number);
+  return { hours, minutes };
+};
+
+const setTimeOfDay = (date: Date, timeOfDay?: string) => {
+  const { hours, minutes } = getTimeParts(timeOfDay);
+  date.setHours(hours, minutes, 0, 0);
+  return date;
+};
+
+export const calculateNextRunAt = (
+  task: ScheduledTask,
+  from = Date.now(),
+): number | null => {
+  if (!task.enabled) {
+    return null;
+  }
+
+  if (task.frequency === 'once') {
+    const timestamp = task.runAt ? new Date(task.runAt).getTime() : NaN;
+    return Number.isFinite(timestamp) && timestamp > from ? timestamp : null;
+  }
+
+  if (task.frequency === 'interval') {
+    const intervalMs = Math.max(1, task.intervalMinutes || 1) * MIN_INTERVAL_MS;
+    const base = task.lastRunAt || task.createdAt || from;
+    return Math.max(base + intervalMs, from + MIN_INTERVAL_MS);
+  }
+
+  if (task.frequency === 'daily') {
+    const next = setTimeOfDay(new Date(from), task.timeOfDay);
+    if (next.getTime() <= from) {
+      next.setDate(next.getDate() + 1);
+    }
+    return next.getTime();
+  }
+
+  const days = task.daysOfWeek?.length
+    ? task.daysOfWeek
+    : [new Date().getDay()];
+  const uniqueDays = Array.from(new Set(days)).filter(
+    (day) => day >= 0 && day <= 6,
+  );
+
+  for (let offset = 0; offset <= 7; offset += 1) {
+    const candidate = setTimeOfDay(new Date(from), task.timeOfDay);
+    candidate.setDate(candidate.getDate() + offset);
+
+    if (uniqueDays.includes(candidate.getDay()) && candidate.getTime() > from) {
+      return candidate.getTime();
+    }
+  }
+
+  return null;
+};

--- a/apps/ui-tars/src/main/shared/scheduledTasks.ts
+++ b/apps/ui-tars/src/main/shared/scheduledTasks.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+export type ScheduledTaskFrequency = 'once' | 'daily' | 'weekly' | 'interval';
+
+export type ScheduledTask = {
+  id: string;
+  name: string;
+  prompt: string;
+  enabled: boolean;
+  frequency: ScheduledTaskFrequency;
+  runAt?: string;
+  timeOfDay?: string;
+  daysOfWeek?: number[];
+  intervalMinutes?: number;
+  lastRunAt?: number;
+  nextRunAt?: number | null;
+  createdAt: number;
+  updatedAt: number;
+};
+
+export type CreateScheduledTaskInput = Omit<
+  ScheduledTask,
+  'id' | 'enabled' | 'lastRunAt' | 'nextRunAt' | 'createdAt' | 'updatedAt'
+> & {
+  enabled?: boolean;
+};

--- a/apps/ui-tars/src/preload/index.ts
+++ b/apps/ui-tars/src/preload/index.ts
@@ -8,6 +8,10 @@ import { IpcRendererEvent, contextBridge, ipcRenderer } from 'electron';
 import type { UTIOPayload } from '@ui-tars/utio';
 
 import type { AppState, LocalStore } from '@main/store/types';
+import type {
+  ScheduledTask,
+  CreateScheduledTaskInput,
+} from '@main/shared/scheduledTasks';
 
 export type Channels = '';
 
@@ -49,6 +53,23 @@ const electronHandler = {
     resetPreset: () => ipcRenderer.invoke('setting:resetPreset'),
     onUpdate: (callback: (setting: LocalStore) => void) => {
       ipcRenderer.on('setting-updated', (_, state) => callback(state));
+    },
+  },
+  scheduledTask: {
+    listScheduledTasks: () => ipcRenderer.invoke('listScheduledTasks'),
+    createScheduledTask: (task: CreateScheduledTaskInput) =>
+      ipcRenderer.invoke('createScheduledTask', task),
+    updateScheduledTask: (id: string, updates: Partial<ScheduledTask>) =>
+      ipcRenderer.invoke('updateScheduledTask', { id, updates }),
+    deleteScheduledTask: (id: string) =>
+      ipcRenderer.invoke('deleteScheduledTask', { id }),
+    runScheduledTaskNow: (id: string) =>
+      ipcRenderer.invoke('runScheduledTaskNow', { id }),
+    onUpdate: (callback: (tasks: ScheduledTask[]) => void) => {
+      ipcRenderer.on('scheduled-tasks-updated', (_, tasks) => callback(tasks));
+    },
+    onStarted: (callback: (task: ScheduledTask) => void) => {
+      ipcRenderer.on('scheduled-task-started', (_, task) => callback(task));
     },
   },
 };

--- a/apps/ui-tars/src/renderer/src/App.tsx
+++ b/apps/ui-tars/src/renderer/src/App.tsx
@@ -13,6 +13,7 @@ import './styles/globals.css';
 const Home = lazy(() => import('./pages/home'));
 const LocalOperator = lazy(() => import('./pages/local'));
 const FreeRemoteOperator = lazy(() => import('./pages/remote/free'));
+const ScheduledTasks = lazy(() => import('./pages/scheduled-tasks'));
 // const PaidRemoteOperator = lazy(() => import('./pages/remote/paid'));
 
 const Widget = lazy(() => import('./pages/widget'));
@@ -32,6 +33,7 @@ export default function App() {
             <Route path="/" element={<Home />} />
             <Route path="/local" element={<LocalOperator />} />
             <Route path="/free-remote" element={<FreeRemoteOperator />} />
+            <Route path="/scheduled-tasks" element={<ScheduledTasks />} />
             {/* <Route path="/paid-remote" element={<PaidRemoteOperator />} /> */}
           </Route>
 

--- a/apps/ui-tars/src/renderer/src/components/SideBar/app-sidebar.tsx
+++ b/apps/ui-tars/src/renderer/src/components/SideBar/app-sidebar.tsx
@@ -4,7 +4,7 @@
  */
 import { useCallback, useState, type ComponentProps } from 'react';
 import { useNavigate, useLocation } from 'react-router';
-import { Home } from 'lucide-react';
+import { CalendarClock, Home } from 'lucide-react';
 
 import {
   Sidebar,
@@ -42,7 +42,7 @@ export function AppSidebar({ ...props }: ComponentProps<typeof Sidebar>) {
   const { status } = useStore();
   const [isNavDialogOpen, setNavDialogOpen] = useState(false);
   const [pendingAction, setPendingAction] = useState<
-    'home' | { type: 'session'; id: string } | null
+    'home' | 'scheduledTasks' | { type: 'session'; id: string } | null
   >(null);
 
   const needsConfirm =
@@ -52,6 +52,11 @@ export function AppSidebar({ ...props }: ComponentProps<typeof Sidebar>) {
 
   const goHome = useCallback(async () => {
     await navigate('/');
+    await setActiveSession('');
+  }, [navigate, setActiveSession]);
+
+  const goScheduledTasks = useCallback(async () => {
+    await navigate('/scheduled-tasks');
     await setActiveSession('');
   }, [navigate, setActiveSession]);
 
@@ -98,6 +103,15 @@ export function AppSidebar({ ...props }: ComponentProps<typeof Sidebar>) {
     }
   }, [needsConfirm]);
 
+  const handleScheduledTasksClick = useCallback(() => {
+    if (needsConfirm) {
+      setPendingAction('scheduledTasks');
+      setNavDialogOpen(true);
+    } else {
+      goScheduledTasks();
+    }
+  }, [needsConfirm, goScheduledTasks]);
+
   const handleSessionClick = useCallback(
     (sessionId: string) => {
       if (needsConfirm) {
@@ -116,12 +130,14 @@ export function AppSidebar({ ...props }: ComponentProps<typeof Sidebar>) {
 
     if (pendingAction === 'home') {
       await goHome();
+    } else if (pendingAction === 'scheduledTasks') {
+      await goScheduledTasks();
     } else if (pendingAction?.type === 'session') {
       await onSessionClick(pendingAction.id);
     }
     setPendingAction(null);
     setNavDialogOpen(false);
-  }, [pendingAction, goHome, onSessionClick]);
+  }, [pendingAction, goHome, goScheduledTasks, onSessionClick]);
 
   const onCancel = useCallback(() => {
     setPendingAction(null);
@@ -151,6 +167,13 @@ export function AppSidebar({ ...props }: ComponentProps<typeof Sidebar>) {
             >
               <Home />
               Home
+            </SidebarMenuButton>
+            <SidebarMenuButton
+              className="font-medium"
+              onClick={handleScheduledTasksClick}
+            >
+              <CalendarClock />
+              Scheduled Tasks
             </SidebarMenuButton>
           </SidebarMenu>
         </SidebarHeader>

--- a/apps/ui-tars/src/renderer/src/pages/scheduled-tasks/index.tsx
+++ b/apps/ui-tars/src/renderer/src/pages/scheduled-tasks/index.tsx
@@ -1,0 +1,407 @@
+/**
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { CalendarClock, Clock, Play, Plus, Trash2 } from 'lucide-react';
+import { toast } from 'sonner';
+
+import { api } from '@renderer/api';
+import { Button } from '@renderer/components/ui/button';
+import { Badge } from '@renderer/components/ui/badge';
+import { Input } from '@renderer/components/ui/input';
+import { Label } from '@renderer/components/ui/label';
+import { ScrollArea } from '@renderer/components/ui/scroll-area';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@renderer/components/ui/select';
+import { Switch } from '@renderer/components/ui/switch';
+import { Textarea } from '@renderer/components/ui/textarea';
+import { SidebarTrigger } from '@renderer/components/ui/sidebar';
+import type {
+  CreateScheduledTaskInput,
+  ScheduledTask,
+  ScheduledTaskFrequency,
+} from '@main/shared/scheduledTasks';
+
+const DAYS = [
+  { value: 0, label: 'Sun' },
+  { value: 1, label: 'Mon' },
+  { value: 2, label: 'Tue' },
+  { value: 3, label: 'Wed' },
+  { value: 4, label: 'Thu' },
+  { value: 5, label: 'Fri' },
+  { value: 6, label: 'Sat' },
+];
+
+const formatDateTime = (timestamp?: number | null) => {
+  if (!timestamp) {
+    return 'Not scheduled';
+  }
+
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(timestamp);
+};
+
+const toDateTimeLocal = (date: Date) => {
+  const offsetMs = date.getTimezoneOffset() * 60_000;
+  return new Date(date.getTime() - offsetMs).toISOString().slice(0, 16);
+};
+
+const getDefaultRunAt = () => {
+  const date = new Date();
+  date.setMinutes(date.getMinutes() + 30);
+  date.setSeconds(0, 0);
+  return toDateTimeLocal(date);
+};
+
+const describeSchedule = (task: ScheduledTask) => {
+  if (task.frequency === 'once') {
+    return `Once at ${task.runAt ? formatDateTime(new Date(task.runAt).getTime()) : 'a selected time'}`;
+  }
+
+  if (task.frequency === 'daily') {
+    return `Daily at ${task.timeOfDay || '09:00'}`;
+  }
+
+  if (task.frequency === 'weekly') {
+    const labels = (task.daysOfWeek || [])
+      .map((day) => DAYS.find((item) => item.value === day)?.label)
+      .filter(Boolean)
+      .join(', ');
+    return `Weekly on ${labels || 'selected days'} at ${task.timeOfDay || '09:00'}`;
+  }
+
+  return `Every ${task.intervalMinutes || 60} minutes`;
+};
+
+export default function ScheduledTasks() {
+  const [tasks, setTasks] = useState<ScheduledTask[]>([]);
+  const [name, setName] = useState('');
+  const [prompt, setPrompt] = useState('');
+  const [frequency, setFrequency] = useState<ScheduledTaskFrequency>('once');
+  const [runAt, setRunAt] = useState(getDefaultRunAt);
+  const [timeOfDay, setTimeOfDay] = useState('09:00');
+  const [daysOfWeek, setDaysOfWeek] = useState<number[]>([new Date().getDay()]);
+  const [intervalMinutes, setIntervalMinutes] = useState(60);
+  const [submitting, setSubmitting] = useState(false);
+
+  const sortedTasks = useMemo(
+    () =>
+      [...tasks].sort(
+        (a, b) =>
+          (a.nextRunAt || Number.MAX_SAFE_INTEGER) -
+          (b.nextRunAt || Number.MAX_SAFE_INTEGER),
+      ),
+    [tasks],
+  );
+
+  const loadTasks = useCallback(async () => {
+    const nextTasks = await api.listScheduledTasks();
+    setTasks(nextTasks || []);
+  }, []);
+
+  useEffect(() => {
+    loadTasks();
+    window.electron.scheduledTask.onUpdate(setTasks);
+    window.electron.scheduledTask.onStarted((task) => {
+      toast.info(`Running scheduled task: ${task.name}`);
+    });
+  }, [loadTasks]);
+
+  const resetForm = () => {
+    setName('');
+    setPrompt('');
+    setFrequency('once');
+    setRunAt(getDefaultRunAt());
+    setTimeOfDay('09:00');
+    setDaysOfWeek([new Date().getDay()]);
+    setIntervalMinutes(60);
+  };
+
+  const toggleDay = (day: number) => {
+    setDaysOfWeek((current) => {
+      if (current.includes(day)) {
+        const next = current.filter((item) => item !== day);
+        return next.length ? next : current;
+      }
+      return [...current, day].sort();
+    });
+  };
+
+  const buildPayload = (): CreateScheduledTaskInput => ({
+    name: name.trim() || prompt.trim().slice(0, 48) || 'Scheduled task',
+    prompt: prompt.trim(),
+    frequency,
+    runAt: frequency === 'once' ? runAt : undefined,
+    timeOfDay:
+      frequency === 'daily' || frequency === 'weekly' ? timeOfDay : undefined,
+    daysOfWeek: frequency === 'weekly' ? daysOfWeek : undefined,
+    intervalMinutes:
+      frequency === 'interval' ? Math.max(1, intervalMinutes) : undefined,
+  });
+
+  const createTask = async () => {
+    if (!prompt.trim()) {
+      toast.warning('Enter a prompt for the task.');
+      return;
+    }
+
+    if (frequency === 'once' && new Date(runAt).getTime() <= Date.now()) {
+      toast.warning('Choose a future time.');
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      await api.createScheduledTask(buildPayload());
+      await loadTasks();
+      resetForm();
+      toast.success('Scheduled task created.');
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : 'Failed to create scheduled task.',
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const updateTask = async (id: string, updates: Partial<ScheduledTask>) => {
+    await api.updateScheduledTask({ id, updates });
+    await loadTasks();
+  };
+
+  const deleteTask = async (id: string) => {
+    await api.deleteScheduledTask({ id });
+    await loadTasks();
+  };
+
+  const runNow = async (id: string) => {
+    await api.runScheduledTaskNow({ id });
+    await loadTasks();
+  };
+
+  return (
+    <div className="flex h-full min-w-0 flex-col bg-white">
+      <div className="flex h-14 shrink-0 items-center justify-between border-b px-5">
+        <div className="flex items-center gap-3">
+          <SidebarTrigger variant="secondary" className="size-8" />
+          <CalendarClock className="size-5 text-muted-foreground" />
+          <div>
+            <h1 className="text-base font-medium">Scheduled Tasks</h1>
+            <p className="text-xs text-muted-foreground">
+              Runs while UI-TARS Desktop is open.
+            </p>
+          </div>
+        </div>
+        <Badge variant="secondary">{tasks.length} tasks</Badge>
+      </div>
+
+      <div className="grid min-h-0 flex-1 grid-cols-[360px_1fr]">
+        <div className="border-r p-5">
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="task-name">Name</Label>
+              <Input
+                id="task-name"
+                placeholder="Morning status check"
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="task-prompt">Prompt</Label>
+              <Textarea
+                id="task-prompt"
+                className="min-h-[140px] resize-none"
+                placeholder="Open the browser and summarize today's..."
+                value={prompt}
+                onChange={(event) => setPrompt(event.target.value)}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label>Schedule</Label>
+              <Select
+                value={frequency}
+                onValueChange={(value) =>
+                  setFrequency(value as ScheduledTaskFrequency)
+                }
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="once">Once</SelectItem>
+                  <SelectItem value="daily">Daily</SelectItem>
+                  <SelectItem value="weekly">Weekly</SelectItem>
+                  <SelectItem value="interval">Interval</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            {frequency === 'once' && (
+              <div className="space-y-2">
+                <Label htmlFor="run-at">Run at</Label>
+                <Input
+                  id="run-at"
+                  type="datetime-local"
+                  value={runAt}
+                  onChange={(event) => setRunAt(event.target.value)}
+                />
+              </div>
+            )}
+
+            {(frequency === 'daily' || frequency === 'weekly') && (
+              <div className="space-y-2">
+                <Label htmlFor="time-of-day">Time</Label>
+                <Input
+                  id="time-of-day"
+                  type="time"
+                  value={timeOfDay}
+                  onChange={(event) => setTimeOfDay(event.target.value)}
+                />
+              </div>
+            )}
+
+            {frequency === 'weekly' && (
+              <div className="space-y-2">
+                <Label>Days</Label>
+                <div className="grid grid-cols-7 gap-1">
+                  {DAYS.map((day) => (
+                    <Button
+                      key={day.value}
+                      type="button"
+                      variant={
+                        daysOfWeek.includes(day.value) ? 'default' : 'outline'
+                      }
+                      size="sm"
+                      className="px-0"
+                      onClick={() => toggleDay(day.value)}
+                    >
+                      {day.label}
+                    </Button>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {frequency === 'interval' && (
+              <div className="space-y-2">
+                <Label htmlFor="interval">Every</Label>
+                <div className="flex items-center gap-2">
+                  <Input
+                    id="interval"
+                    type="number"
+                    min={1}
+                    value={intervalMinutes}
+                    onChange={(event) =>
+                      setIntervalMinutes(Number(event.target.value))
+                    }
+                  />
+                  <span className="text-sm text-muted-foreground">minutes</span>
+                </div>
+              </div>
+            )}
+
+            <Button
+              className="w-full"
+              onClick={createTask}
+              disabled={submitting}
+            >
+              <Plus />
+              Create Task
+            </Button>
+          </div>
+        </div>
+
+        <ScrollArea className="min-h-0">
+          <div className="space-y-3 p-5">
+            {sortedTasks.length === 0 ? (
+              <div className="flex h-[calc(100vh-120px)] items-center justify-center rounded-md border border-dashed">
+                <div className="text-center">
+                  <Clock className="mx-auto mb-3 size-8 text-muted-foreground" />
+                  <p className="text-sm font-medium">No scheduled tasks</p>
+                  <p className="mt-1 text-sm text-muted-foreground">
+                    Create one to run an instruction later.
+                  </p>
+                </div>
+              </div>
+            ) : (
+              sortedTasks.map((task) => (
+                <div
+                  key={task.id}
+                  className="rounded-md border bg-white p-4 shadow-xs"
+                >
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="min-w-0 space-y-2">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <h2 className="truncate text-sm font-medium">
+                          {task.name}
+                        </h2>
+                        <Badge
+                          variant={task.enabled ? 'default' : 'outline'}
+                          className="capitalize"
+                        >
+                          {task.enabled ? 'Enabled' : 'Paused'}
+                        </Badge>
+                        <Badge variant="secondary" className="capitalize">
+                          {task.frequency}
+                        </Badge>
+                      </div>
+                      <p className="line-clamp-2 text-sm text-muted-foreground">
+                        {task.prompt}
+                      </p>
+                      <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+                        <span>{describeSchedule(task)}</span>
+                        <span>Next: {formatDateTime(task.nextRunAt)}</span>
+                        {task.lastRunAt && (
+                          <span>Last: {formatDateTime(task.lastRunAt)}</span>
+                        )}
+                      </div>
+                    </div>
+
+                    <div className="flex shrink-0 items-center gap-2">
+                      <Switch
+                        checked={task.enabled}
+                        onCheckedChange={(enabled) =>
+                          updateTask(task.id, { enabled })
+                        }
+                      />
+                      <Button
+                        variant="secondary"
+                        size="icon"
+                        onClick={() => runNow(task.id)}
+                      >
+                        <Play className="size-4" />
+                      </Button>
+                      <Button
+                        variant="outline"
+                        size="icon"
+                        onClick={() => deleteTask(task.id)}
+                      >
+                        <Trash2 className="size-4" />
+                      </Button>
+                    </div>
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+        </ScrollArea>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add a Scheduled Tasks page to UI-TARS Desktop with create, pause/resume, delete, and run-now actions.
- Persist scheduled tasks in the Electron main process and schedule them while the desktop app is running.
- Support one-time, daily, weekly, and interval schedules, reusing the existing agent run pipeline.
- Fix the development React DevTools installer import so startup no longer logs `installExtension is not a function`.

## Testing
- pnpm --filter ui-tars-desktop exec vitest run src/main/shared/scheduledTaskMath.test.ts
- pnpm --filter ui-tars-desktop typecheck
- pnpm run dev:ui-tars