### PR TITLE
feat: add command safety approval gate

### DIFF
--- a/packages/agent-infra/mcp-servers/commands/README.md
+++ b/packages/agent-infra/mcp-servers/commands/README.md
@@ -4,17 +4,14 @@
 
 [![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/install-mcp?name=filesystem&config=eyJjb21tYW5kIjoibnB4IEBhZ2VudC1pbmZyYS9tY3Atc2VydmVyLWNvbW1hbmRzQGxhdGVzdCJ9) [<img src="https://img.shields.io/badge/VS_Code-VS_Code?style=flat-square&label=Install%20Server&color=0098FF" alt="Install in VS Code">](https://insiders.vscode.dev/redirect?url=vscode%253Amcp%252Finstall%253F%257B%2522name%2522%253A%2522commands%2522%252C%2522command%2522%253A%2522npx%2522%252C%2522args%2522%253A%255B%2522%2540agent-infra%252Fmcp-server-commands%2540latest%2522%255D%257D) [<img alt="Install in VS Code Insiders" src="https://img.shields.io/badge/VS_Code_Insiders-VS_Code_Insiders?style=flat-square&label=Install%20Server&color=24bfa5">](https://insiders.vscode.dev/redirect?url=vscode-insiders%253Amcp%252Finstall%253F%257B%2522name%2522%253A%2522commands%2522%252C%2522command%2522%253A%2522npx%2522%252C%2522args%2522%253A%255B%2522%2540agent-infra%252Fmcp-server-commands%2540latest%2522%255D%257D)
 
-
 A Model Context Protocol (MCP) server that provides execuate arbitrary commands.
 
 ![](https://github.com/user-attachments/assets/ee8df75f-04f4-46c8-8b57-0e32e4373c3e)
-
 
 ### Requirements
 
 - Node.js 18 or newer
 - VS Code, Cursor, Windsurf, Claude Desktop or any other MCP client
-
 
 ### Getting started
 
@@ -48,6 +45,7 @@ code --add-mcp '{"name":"commands","command":"npx","args":["@agent-infra/mcp-ser
 ```
 
 After installation, the Commands MCP server will be available for use with your GitHub Copilot agent in VS Code.
+
 </details>
 
 <details>
@@ -68,6 +66,7 @@ Go to `Cursor Settings` -> `MCP` -> `Add new MCP Server`. Name to your liking, u
   }
 }
 ```
+
 </details>
 
 <details>
@@ -88,6 +87,7 @@ Follow Windsuff MCP [documentation](https://docs.windsurf.com/windsurf/cascade/m
   }
 }
 ```
+
 </details>
 
 <details>
@@ -108,6 +108,7 @@ Follow the MCP install [guide](https://modelcontextprotocol.io/quickstart/user),
   }
 }
 ```
+
 </details>
 
 #### Remote (SSE / Streamable HTTP)
@@ -120,9 +121,9 @@ npx @agent-infra/mcp-server-commands --port 8089
 ```
 
 You can use one of the two MCP Server remote endpoint:
+
 - Streamable HTTP(Recommended): `http://127.0.0.1::8089/mcp`
 - SSE: `http://127.0.0.1::8089/sse`
-
 
 And then in MCP client config, set the `url` to the SSE endpoint:
 
@@ -194,6 +195,38 @@ const toolResult = await client.callTool({
 });
 console.log(toolResult);
 ```
+
+### Safety policy
+
+Commands MCP includes a server-side safety policy for high-risk command
+execution. Commands that match the default destructive patterns are not
+executed immediately; the tool returns an `approval_required` result with the
+matched rule id and approval request id.
+
+Default approval-required categories include recursive or forceful deletion,
+disk or partition mutation, shutdown or restart operations, privileged command
+execution, destructive git commands, and remote script execution such as
+`curl | sh`.
+
+In-process callers can customize the policy:
+
+```js
+const server = createServer({
+  safety: {
+    rules: [
+      {
+        id: 'allow-known-cleanup',
+        action: 'allow',
+        reason: 'This cleanup command is handled by the host approval flow.',
+        patterns: [String.raw`git\s+clean\s+-fd\s+build`],
+      },
+    ],
+  },
+});
+```
+
+Set `COMMANDS_SAFETY_ENABLED=false` to disable the policy for trusted,
+externally sandboxed environments.
 
 ### Developement
 

--- a/packages/agent-infra/mcp-servers/commands/src/safety-policy.ts
+++ b/packages/agent-infra/mcp-servers/commands/src/safety-policy.ts
@@ -1,0 +1,222 @@
+import { createHash } from 'node:crypto';
+
+type CommandSafetyAction = 'allow' | 'deny' | 'require_approval';
+
+type CommandSafetyRule = {
+  id: string;
+  action: CommandSafetyAction;
+  reason: string;
+  patterns: string[];
+};
+
+type CommandSafetyPolicyConfig = {
+  enabled?: boolean;
+  defaultAction?: CommandSafetyAction;
+  defaultReason?: string;
+  useDefaultRules?: boolean;
+  rules?: CommandSafetyRule[];
+};
+
+type CommandSafetySubject = {
+  toolName: string;
+  command?: string;
+  interpreter?: string;
+  script?: string;
+  cwd?: string;
+};
+
+type CommandSafetyDecision = {
+  action: CommandSafetyAction;
+  reason?: string;
+  ruleId?: string;
+  approvalRequestId?: string;
+};
+
+const DEFAULT_COMMAND_SAFETY_RULES: CommandSafetyRule[] = [
+  {
+    id: 'destructive-file-removal',
+    action: 'require_approval',
+    reason:
+      'The command appears to recursively or forcefully remove filesystem data.',
+    patterns: [
+      String.raw`(?:^|[;&|]\s*)rm\s+(?:-[^\s]*[rRfF][^\s]*|--recursive|--force)`,
+      String.raw`(?:^|[;&|]\s*)rmdir\s+(?:/s|-[^\s]*r)`,
+      String.raw`(?:^|[;&|]\s*)del(?:ete)?\s+[\s\S]*(?:/s|/q)`,
+      String.raw`\bRemove-Item\b[\s\S]*(?:-Recurse|-Force)`,
+    ],
+  },
+  {
+    id: 'disk-or-partition-mutation',
+    action: 'require_approval',
+    reason: 'The command appears to modify disks, partitions, or filesystems.',
+    patterns: [
+      String.raw`(?:^|[;&|]\s*)(?:format|mkfs(?:\.[a-z0-9]+)?|fdisk|parted|diskpart|diskutil)\b`,
+    ],
+  },
+  {
+    id: 'system-power-action',
+    action: 'require_approval',
+    reason:
+      'The command appears to shut down, restart, or power off the system.',
+    patterns: [
+      String.raw`(?:^|[;&|]\s*)(?:shutdown|reboot|halt|poweroff)\b`,
+      String.raw`\bRestart-Computer\b`,
+      String.raw`\bStop-Computer\b`,
+    ],
+  },
+  {
+    id: 'privileged-or-recursive-permission-change',
+    action: 'require_approval',
+    reason:
+      'The command appears to request elevated privileges or recursively change permissions.',
+    patterns: [
+      String.raw`(?:^|[;&|]\s*)(?:sudo|su)\b`,
+      String.raw`(?:^|[;&|]\s*)(?:chmod|chown)\s+[\s\S]*(?:-R|--recursive)`,
+    ],
+  },
+  {
+    id: 'destructive-git-operation',
+    action: 'require_approval',
+    reason:
+      'The command appears to destructively modify git working tree state.',
+    patterns: [
+      String.raw`(?:^|[;&|]\s*)git\s+reset\s+--hard\b`,
+      String.raw`(?:^|[;&|]\s*)git\s+clean\s+-[^\s]*f`,
+    ],
+  },
+  {
+    id: 'remote-script-execution',
+    action: 'require_approval',
+    reason:
+      'The command appears to download remote content and pipe it into a shell or evaluator.',
+    patterns: [
+      String.raw`\b(?:curl|wget)\b[\s\S]*\|[\s\S]*(?:sh|bash|zsh|fish|powershell|pwsh)\b`,
+      String.raw`\b(?:Invoke-WebRequest|Invoke-RestMethod|iwr|irm)\b[\s\S]*(?:Invoke-Expression|\biex\b)`,
+    ],
+  },
+];
+
+function resolveSafetyPolicy(policy?: CommandSafetyPolicyConfig): Required<
+  Pick<CommandSafetyPolicyConfig, 'enabled' | 'defaultAction' | 'rules'>
+> & {
+  defaultReason?: string;
+} {
+  const useDefaultRules = policy?.useDefaultRules ?? true;
+  return {
+    enabled: policy?.enabled ?? process.env.COMMANDS_SAFETY_ENABLED !== 'false',
+    defaultAction: policy?.defaultAction ?? 'allow',
+    defaultReason: policy?.defaultReason,
+    rules: [
+      ...(policy?.rules ?? []),
+      ...(useDefaultRules ? DEFAULT_COMMAND_SAFETY_RULES : []),
+    ],
+  };
+}
+
+function evaluateCommandSafety(
+  subject: CommandSafetySubject,
+  policy?: CommandSafetyPolicyConfig,
+): CommandSafetyDecision {
+  const resolvedPolicy = resolveSafetyPolicy(policy);
+
+  if (!resolvedPolicy.enabled) {
+    return { action: 'allow' };
+  }
+
+  const executableText = getExecutableText(subject);
+
+  for (const rule of resolvedPolicy.rules) {
+    if (
+      rule.patterns.some((pattern) => matchesPattern(pattern, executableText))
+    ) {
+      if (rule.action === 'allow') {
+        return { action: 'allow' };
+      }
+      return decisionForAction(rule.action, subject, rule.reason, rule.id);
+    }
+  }
+
+  if (resolvedPolicy.defaultAction !== 'allow') {
+    return decisionForAction(
+      resolvedPolicy.defaultAction,
+      subject,
+      resolvedPolicy.defaultReason ?? 'The command requires explicit approval.',
+    );
+  }
+
+  return { action: 'allow' };
+}
+
+function formatSafetyDecision(decision: CommandSafetyDecision): string {
+  const status =
+    decision.action === 'require_approval'
+      ? 'approval_required'
+      : decision.action;
+
+  const lines = [
+    `Command safety policy: ${status}`,
+    'No command was executed.',
+  ];
+
+  if (decision.ruleId) {
+    lines.push(`Rule: ${decision.ruleId}`);
+  }
+  if (decision.reason) {
+    lines.push(`Reason: ${decision.reason}`);
+  }
+  if (decision.approvalRequestId) {
+    lines.push(`Approval request: ${decision.approvalRequestId}`);
+  }
+
+  return lines.join('\n');
+}
+
+function getExecutableText(subject: CommandSafetySubject): string {
+  return [subject.command, subject.interpreter, subject.script]
+    .filter((part): part is string => Boolean(part))
+    .join('\n');
+}
+
+function matchesPattern(pattern: string, value: string): boolean {
+  return new RegExp(pattern, 'im').test(value);
+}
+
+function decisionForAction(
+  action: Exclude<CommandSafetyAction, 'allow'>,
+  subject: CommandSafetySubject,
+  reason?: string,
+  ruleId?: string,
+): CommandSafetyDecision {
+  return {
+    action,
+    reason,
+    ruleId,
+    approvalRequestId:
+      action === 'require_approval'
+        ? createApprovalRequestId(subject, ruleId)
+        : undefined,
+  };
+}
+
+function createApprovalRequestId(
+  subject: CommandSafetySubject,
+  ruleId?: string,
+): string {
+  return createHash('sha256')
+    .update(JSON.stringify({ ...subject, ruleId }))
+    .digest('hex')
+    .slice(0, 16);
+}
+
+export {
+  DEFAULT_COMMAND_SAFETY_RULES,
+  evaluateCommandSafety,
+  formatSafetyDecision,
+};
+export type {
+  CommandSafetyAction,
+  CommandSafetyDecision,
+  CommandSafetyPolicyConfig,
+  CommandSafetyRule,
+  CommandSafetySubject,
+};

--- a/packages/agent-infra/mcp-servers/commands/src/server.ts
+++ b/packages/agent-infra/mcp-servers/commands/src/server.ts
@@ -23,15 +23,26 @@ import {
   messagesFor,
   always_log,
 } from './exec-utils.js';
+import {
+  evaluateCommandSafety,
+  formatSafetyDecision,
+  type CommandSafetyPolicyConfig,
+} from './safety-policy.js';
 
 // TODO use .promises? in node api
 const execAsync = promisify(exec);
 
-function createServer(serverConfig?: { cwd?: string }): McpServer {
+type CommandServerConfig = {
+  cwd?: string;
+  safety?: CommandSafetyPolicyConfig;
+};
+
+function createServer(serverConfig?: CommandServerConfig): McpServer {
   const server = new McpServer({
     name: 'Run Commands',
     version: process.env.VERSION || '0.0.1',
   });
+  const safetyPolicy = serverConfig?.safety;
 
   // === Tools ===
   // @ts-ignore
@@ -48,7 +59,7 @@ function createServer(serverConfig?: { cwd?: string }): McpServer {
           .describe('Current working directory, leave empty in most cases'),
       },
     },
-    async (args) => await runCommand(args),
+    async (args) => await runCommand(args, safetyPolicy),
   );
 
   server.registerTool(
@@ -70,7 +81,7 @@ function createServer(serverConfig?: { cwd?: string }): McpServer {
           .describe('Current working directory, leave empty in most cases'),
       },
     },
-    async (args) => await runScript(args),
+    async (args) => await runScript(args, safetyPolicy),
   );
 
   // ==== Prompts ====
@@ -85,6 +96,31 @@ function createServer(serverConfig?: { cwd?: string }): McpServer {
       },
     },
     async ({ command }) => {
+      const safetyDecision = evaluateCommandSafety(
+        {
+          toolName: 'prompt/run_command',
+          command,
+        },
+        safetyPolicy,
+      );
+      if (safetyDecision.action !== 'allow') {
+        const messages: PromptMessage[] = [
+          {
+            role: 'user',
+            content: {
+              type: 'text',
+              text: formatSafetyDecision(safetyDecision),
+            },
+          },
+        ];
+        always_log('WARN: run_command prompt blocked by safety policy', {
+          action: safetyDecision.action,
+          ruleId: safetyDecision.ruleId,
+          approvalRequestId: safetyDecision.approvalRequestId,
+        });
+        return { messages };
+      }
+
       const { stdout, stderr } = await execAsync(command);
       // TODO gracefully handle errors and turn them into a prompt message that can be used by LLM to troubleshoot the issue, currently errors result in nothing inserted into the prompt and instead it shows the Zed's chat panel as a failure
 
@@ -127,15 +163,29 @@ function createServer(serverConfig?: { cwd?: string }): McpServer {
 
 async function runCommand(
   args: Record<string, unknown> | undefined,
+  safetyPolicy?: CommandSafetyPolicyConfig,
 ): Promise<CallToolResult> {
-  const command = String(args?.command);
-  if (!command) {
+  const command = stringArg(args?.command);
+  if (!command?.trim()) {
     throw new Error('Command is required');
   }
 
+  const cwd = stringArg(args?.cwd);
+  const safetyDecision = evaluateCommandSafety(
+    {
+      toolName: 'run_command',
+      command,
+      cwd,
+    },
+    safetyPolicy,
+  );
+  if (safetyDecision.action !== 'allow') {
+    return blockedToolResult(safetyDecision);
+  }
+
   const options: ExecOptions = {};
-  if (args?.cwd) {
-    options.cwd = String(args.cwd);
+  if (cwd) {
+    options.cwd = cwd;
     // ENOENT is thrown if the cwd doesn't exist, and I think LLMs can understand that?
   }
 
@@ -160,9 +210,10 @@ async function runCommand(
 
 async function runScript(
   args: Record<string, unknown> | undefined,
+  safetyPolicy?: CommandSafetyPolicyConfig,
 ): Promise<CallToolResult> {
-  const interpreter = String(args?.interpreter);
-  if (!interpreter) {
+  const interpreter = stringArg(args?.interpreter);
+  if (!interpreter?.trim()) {
     throw new Error('Interpreter is required');
   }
 
@@ -171,14 +222,28 @@ async function runScript(
     // constrains typescript too, to string based overload
     encoding: 'utf8',
   };
-  if (args?.cwd) {
-    options.cwd = String(args.cwd);
+  const cwd = stringArg(args?.cwd);
+  if (cwd) {
+    options.cwd = cwd;
     // ENOENT is thrown if the cwd doesn't exist, and I think LLMs can understand that?
   }
 
-  const script = String(args?.script);
-  if (!script) {
+  const script = stringArg(args?.script);
+  if (!script?.trim()) {
     throw new Error('Script is required');
+  }
+
+  const safetyDecision = evaluateCommandSafety(
+    {
+      toolName: 'run_script',
+      interpreter,
+      script,
+      cwd,
+    },
+    safetyPolicy,
+  );
+  if (safetyDecision.action !== 'allow') {
+    return blockedToolResult(safetyDecision);
   }
 
   try {
@@ -197,4 +262,42 @@ async function runScript(
   }
 }
 
+function blockedToolResult(
+  safetyDecision: ReturnType<typeof evaluateCommandSafety>,
+): CallToolResult {
+  const response = {
+    isError: true,
+    content: [
+      {
+        type: 'text' as const,
+        name: 'SAFETY_POLICY',
+        text: formatSafetyDecision(safetyDecision),
+      },
+    ],
+  };
+  always_log('WARN: command blocked by safety policy', {
+    action: safetyDecision.action,
+    ruleId: safetyDecision.ruleId,
+    approvalRequestId: safetyDecision.approvalRequestId,
+  });
+  return response;
+}
+
+function stringArg(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
 export { createServer };
+export {
+  evaluateCommandSafety,
+  formatSafetyDecision,
+  DEFAULT_COMMAND_SAFETY_RULES,
+} from './safety-policy.js';
+export type {
+  CommandSafetyAction,
+  CommandSafetyDecision,
+  CommandSafetyPolicyConfig,
+  CommandSafetyRule,
+  CommandSafetySubject,
+} from './safety-policy.js';
+export type { CommandServerConfig };

--- a/packages/agent-infra/mcp-servers/commands/tests/integration/exec-utils.test.ts
+++ b/packages/agent-infra/mcp-servers/commands/tests/integration/exec-utils.test.ts
@@ -6,7 +6,7 @@
  * Copyright (c) 2025 g0t4
  * https://github.com/g0t4/mcp-server-commands/blob/master/LICENSE
  */
-import os from 'os';
+import { spawnSync } from 'node:child_process';
 import { execFileWithInput } from '../../src/exec-utils.js';
 import { describe, test, expect } from 'vitest';
 
@@ -14,15 +14,17 @@ import { describe, test, expect } from 'vitest';
 // I am going to keep asking Claude to add new tests to see how I feel about that workflow
 
 describe('execFileWithInput integration tests', () => {
+  const bashTest = isCommandAvailable('bash') ? test : test.skip;
+
   // ok, impressive choice of "seam" to add testing of the most critical part, executing the command! this is EXACTLY what I had in mind and didn't even tell Claude I wanted.
 
-  test('should execute a simple bash command', async () => {
+  bashTest('should execute a simple bash command', async () => {
     const result = await execFileWithInput('bash', 'echo "Hello World"', {});
     expect(result.stdout.trim()).toBe('Hello World');
     expect(result.stderr).toBe('');
   });
 
-  test('should handle command errors properly in bash', async () => {
+  bashTest('should handle command errors properly in bash', async () => {
     try {
       await execFileWithInput('bash', 'nonexistentcommand', {});
       expect.fail('Should have thrown an error');
@@ -88,7 +90,7 @@ Number 3
 `);
   });
 
-  test('should respect working directory option', async () => {
+  bashTest('should respect working directory option', async () => {
     // FYI best to pick a path that is common on both macOS and Linux
     //  unfortunately, on macOS /tmp is a symlink to /private/tmp so that can cause issues
     // TODO make sure cwd is not already / in the test?
@@ -97,7 +99,7 @@ Number 3
     expect(result.stdout.trim()).toBe('/');
   });
 
-  test('should handle bash multiline scripts', async () => {
+  bashTest('should handle bash multiline scripts', async () => {
     const script = `
       echo "Line 1"
       echo "Line 2"
@@ -110,6 +112,11 @@ Line 2
 Line 3`);
   });
 });
+
+function isCommandAvailable(command: string): boolean {
+  const result = spawnSync(command, ['--version'], { stdio: 'ignore' });
+  return result.status === 0;
+}
 
 // TODO add testing of try/catch in runScript block
 //   just make sure I cover failure cases through the catch blocks

--- a/packages/agent-infra/mcp-servers/commands/tests/server-in-memory.test.ts
+++ b/packages/agent-infra/mcp-servers/commands/tests/server-in-memory.test.ts
@@ -1,33 +1,40 @@
 import { describe, expect, test } from 'vitest';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
-import { createServer } from '../src/server.js';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { createServer, evaluateCommandSafety } from '../src/server.js';
 import path from 'path';
+
+async function createConnectedClient(server: McpServer): Promise<Client> {
+  const client = new Client(
+    {
+      name: 'test client',
+      version: '1.0',
+    },
+    {
+      capabilities: {
+        roots: {
+          listChanged: true,
+        },
+      },
+    },
+  );
+
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+
+  await Promise.all([
+    client.connect(clientTransport),
+    server.connect(serverTransport),
+  ]);
+
+  return client;
+}
 
 describe('MCP Server in memory', () => {
   test('listTools should return a list of tools', async () => {
-    const client = new Client(
-      {
-        name: 'test client',
-        version: '1.0',
-      },
-      {
-        capabilities: {
-          roots: {
-            listChanged: true,
-          },
-        },
-      },
-    );
-
     const server = createServer();
-    const [clientTransport, serverTransport] =
-      InMemoryTransport.createLinkedPair();
-
-    await Promise.all([
-      client.connect(clientTransport),
-      server.connect(serverTransport),
-    ]);
+    const client = await createConnectedClient(server);
 
     const result = await client.listTools();
 
@@ -35,44 +42,22 @@ describe('MCP Server in memory', () => {
   });
 
   test('callTool run_command should return a result', async () => {
-    const client = new Client({
-      name: 'test client',
-      version: '1.0',
-    });
-
     const server = createServer();
-    const [clientTransport, serverTransport] =
-      InMemoryTransport.createLinkedPair();
+    const client = await createConnectedClient(server);
 
-    await Promise.all([
-      client.connect(clientTransport),
-      server.connect(serverTransport),
-    ]);
-
+    const currentFileName = path.basename(__filename);
     const result = await client.callTool({
       name: 'run_command',
       arguments: {
-        command: `ls ${__dirname}`,
+        command: `node -e "console.log('${currentFileName}')"`,
       },
     });
-    const currentFileName = path.basename(__filename);
     expect(JSON.stringify(result)).toMatch(currentFileName);
   });
 
   test('callTool run_script should return a result', async () => {
-    const client = new Client({
-      name: 'test client',
-      version: '1.0',
-    });
-
     const server = createServer();
-    const [clientTransport, serverTransport] =
-      InMemoryTransport.createLinkedPair();
-
-    await Promise.all([
-      client.connect(clientTransport),
-      server.connect(serverTransport),
-    ]);
+    const client = await createConnectedClient(server);
 
     const result = await client.callTool({
       name: 'run_script',
@@ -91,5 +76,112 @@ describe('MCP Server in memory', () => {
       ],
       isError: false,
     });
+  });
+
+  test('safety policy should require approval for destructive default rules', () => {
+    const decision = evaluateCommandSafety({
+      toolName: 'run_command',
+      command: 'git reset --hard HEAD',
+    });
+
+    expect(decision.action).toBe('require_approval');
+    expect(decision.ruleId).toBe('destructive-git-operation');
+    expect(decision.approvalRequestId).toBeTruthy();
+  });
+
+  test('custom allow rules should run before destructive default rules', () => {
+    const decision = evaluateCommandSafety(
+      {
+        toolName: 'run_command',
+        command: 'git reset --hard HEAD',
+      },
+      {
+        rules: [
+          {
+            id: 'allow-known-git-reset',
+            action: 'allow',
+            reason: 'The caller already approved this exact operation.',
+            patterns: [String.raw`git\s+reset\s+--hard\s+HEAD`],
+          },
+        ],
+      },
+    );
+
+    expect(decision.action).toBe('allow');
+  });
+
+  test('run_command should return an approval request without executing', async () => {
+    const server = createServer({
+      safety: {
+        rules: [
+          {
+            id: 'test-command-approval',
+            action: 'require_approval',
+            reason: 'Test command requires user approval.',
+            patterns: [String.raw`node\s+-e`],
+          },
+        ],
+      },
+    });
+    const client = await createConnectedClient(server);
+
+    const result = await client.callTool({
+      name: 'run_command',
+      arguments: {
+        command: `node -e "console.log('EXECUTED_COMMAND')"`,
+      },
+    });
+
+    const serialized = JSON.stringify(result);
+    expect(result.isError).toBe(true);
+    expect(serialized).toContain('approval_required');
+    expect(serialized).toContain('test-command-approval');
+    expect(serialized).not.toContain('EXECUTED_COMMAND');
+  });
+
+  test('run_script should return an approval request without executing', async () => {
+    const server = createServer({
+      safety: {
+        rules: [
+          {
+            id: 'test-script-approval',
+            action: 'require_approval',
+            reason: 'Test script requires user approval.',
+            patterns: [String.raw`EXECUTED_SCRIPT`],
+          },
+        ],
+      },
+    });
+    const client = await createConnectedClient(server);
+
+    const result = await client.callTool({
+      name: 'run_script',
+      arguments: {
+        interpreter: 'node',
+        script: "console.log('EXECUTED_SCRIPT');",
+      },
+    });
+
+    const serialized = JSON.stringify(result);
+    expect(result.isError).toBe(true);
+    expect(serialized).toContain('approval_required');
+    expect(serialized).toContain('test-script-approval');
+    expect(serialized).not.toContain('EXECUTED_SCRIPT');
+  });
+
+  test('run_command prompt should return an approval request without executing', async () => {
+    const server = createServer();
+    const client = await createConnectedClient(server);
+
+    const result = await client.getPrompt({
+      name: 'run_command',
+      arguments: {
+        command: 'git reset --hard HEAD',
+      },
+    });
+
+    const serialized = JSON.stringify(result);
+    expect(serialized).toContain('approval_required');
+    expect(serialized).toContain('destructive-git-operation');
   });
 });


### PR DESCRIPTION
## Summary
- Add a command safety policy for the Commands MCP server with default approval-required rules for high-risk operations.
- Apply the gate before `run_command`, `run_script`, and the `run_command` prompt execute anything.
- Document policy configuration and make shell-specific integration tests skip when the required shell is unavailable.

## Validation
- `pnpm --filter @agent-infra/mcp-server-commands test`
- `pnpm --filter @agent-infra/mcp-server-commands exec tsc --noEmit --target ES2022 --module Node16 --moduleResolution Node16 --strict --esModuleInterop --skipLibCheck src/server.ts src/safety-policy.ts src/exec-utils.ts`