### PR TITLE
feat(ui-tars): ProofPilot - auditable, approval-gated, simulation-first agent execution

### DIFF
--- a/apps/ui-tars/electron.vite.config.ts
+++ b/apps/ui-tars/electron.vite.config.ts
@@ -16,12 +16,13 @@ import pkg from './package.json';
 import { getExternalPkgs } from './scripts/getExternalPkgs';
 import tailwindcss from '@tailwindcss/vite';
 
+const appPrivateKeyBase64 = process.env.UI_TARS_APP_PRIVATE_KEY_BASE64;
+
 export default defineConfig({
   main: {
     define: {
-      'process.env.UI_TARS_APP_PRIVATE_KEY_BASE64': JSON.stringify(
-        process.env.UI_TARS_APP_PRIVATE_KEY_BASE64,
-      ),
+      'process.env.UI_TARS_APP_PRIVATE_KEY_BASE64':
+        JSON.stringify(appPrivateKeyBase64),
     },
     build: {
       outDir: 'dist/main',
@@ -40,10 +41,14 @@ export default defineConfig({
       },
     },
     plugins: [
-      bytecodePlugin({
-        chunkAlias: 'app_private',
-        protectedStrings: [process.env.UI_TARS_APP_PRIVATE_KEY_BASE64!],
-      }),
+      ...(appPrivateKeyBase64
+        ? [
+            bytecodePlugin({
+              chunkAlias: 'app_private',
+              protectedStrings: [appPrivateKeyBase64],
+            }),
+          ]
+        : []),
       tsconfigPaths(),
       externalizeDepsPlugin({
         include: [...getExternalPkgs()],

--- a/apps/ui-tars/scripts/vitest-setup.ts
+++ b/apps/ui-tars/scripts/vitest-setup.ts
@@ -1,0 +1,5 @@
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+export {};

--- a/apps/ui-tars/src/main/ipcRoutes/agent.ts
+++ b/apps/ui-tars/src/main/ipcRoutes/agent.ts
@@ -11,6 +11,7 @@ import { showWindow } from '@main/window/index';
 import { closeScreenMarker } from '@main/window/ScreenMarker';
 import { GUIAgent } from '@ui-tars/sdk';
 import { Operator } from '@ui-tars/sdk/core';
+import type { AgentRunMode } from '@main/store/types';
 
 const t = initIpc.create();
 
@@ -42,22 +43,26 @@ export class GUIAgentManager {
 }
 
 export const agentRoute = t.router({
-  runAgent: t.procedure.input<void>().handle(async () => {
-    const { thinking } = store.getState();
-    if (thinking) {
-      return;
-    }
+  runAgent: t.procedure
+    .input<{ sessionId?: string; mode?: AgentRunMode } | void>()
+    .handle(async ({ input }) => {
+      const { thinking } = store.getState();
+      if (thinking) {
+        return;
+      }
 
-    store.setState({
-      abortController: new AbortController(),
-      thinking: true,
-      errorMsg: null,
-    });
+      store.setState({
+        abortController: new AbortController(),
+        activeSessionId: input?.sessionId ?? null,
+        runMode: input?.mode === 'simulation' ? 'simulation' : 'live',
+        thinking: true,
+        errorMsg: null,
+      });
 
-    await runAgent(store.setState, store.getState);
+      await runAgent(store.setState, store.getState);
 
-    store.setState({ thinking: false });
-  }),
+      store.setState({ thinking: false });
+    }),
   pauseRun: t.procedure.input<void>().handle(async () => {
     const guiAgent = GUIAgentManager.getInstance().getAgent();
     if (guiAgent instanceof GUIAgent) {
@@ -109,6 +114,8 @@ export const agentRoute = t.router({
       thinking: false,
       errorMsg: null,
       instructions: '',
+      activeSessionId: null,
+      runMode: 'live',
     });
   }),
 });

--- a/apps/ui-tars/src/main/ipcRoutes/approval.ts
+++ b/apps/ui-tars/src/main/ipcRoutes/approval.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { initIpc } from '@ui-tars/electron-ipc/main';
+
+import { ApprovalQueue } from '@main/services/approvalQueue';
+import type { ApprovalRequestInput } from '@main/services/approvalQueue';
+
+const t = initIpc.create();
+
+export const approvalRoute = t.router({
+  listApprovalRequests: t.procedure.input<void>().handle(async () => {
+    return ApprovalQueue.getInstance().list();
+  }),
+  submitApprovalRequest: t.procedure
+    .input<ApprovalRequestInput>()
+    .handle(async ({ input }) => {
+      return ApprovalQueue.getInstance().submit(input);
+    }),
+  resolveApprovalRequest: t.procedure
+    .input<{
+      id: string;
+      status: 'approved' | 'denied';
+      decisionReason?: string;
+    }>()
+    .handle(async ({ input }) => {
+      return ApprovalQueue.getInstance().resolve(
+        input.id,
+        input.status,
+        input.decisionReason,
+      );
+    }),
+  clearResolvedApprovalRequests: t.procedure.input<void>().handle(async () => {
+    return ApprovalQueue.getInstance().clearResolved();
+  }),
+});

--- a/apps/ui-tars/src/main/ipcRoutes/index.ts
+++ b/apps/ui-tars/src/main/ipcRoutes/index.ts
@@ -12,6 +12,7 @@ import { remoteResourceRouter } from './remoteResource';
 import { settingRoute } from './setting';
 import { proofPilotRoute } from './proofPilot';
 import { approvalRoute } from './approval';
+import { teamRoute } from './team';
 
 const t = initIpc.create();
 
@@ -25,6 +26,7 @@ export const ipcRoutes = t.router({
   ...settingRoute,
   ...proofPilotRoute,
   ...approvalRoute,
+  ...teamRoute,
 });
 export type Router = typeof ipcRoutes;
 

--- a/apps/ui-tars/src/main/ipcRoutes/index.ts
+++ b/apps/ui-tars/src/main/ipcRoutes/index.ts
@@ -11,6 +11,7 @@ import { browserRoute } from './browser';
 import { remoteResourceRouter } from './remoteResource';
 import { settingRoute } from './setting';
 import { proofPilotRoute } from './proofPilot';
+import { approvalRoute } from './approval';
 
 const t = initIpc.create();
 
@@ -23,6 +24,7 @@ export const ipcRoutes = t.router({
   ...browserRoute,
   ...settingRoute,
   ...proofPilotRoute,
+  ...approvalRoute,
 });
 export type Router = typeof ipcRoutes;
 

--- a/apps/ui-tars/src/main/ipcRoutes/index.ts
+++ b/apps/ui-tars/src/main/ipcRoutes/index.ts
@@ -10,6 +10,7 @@ import { agentRoute } from './agent';
 import { browserRoute } from './browser';
 import { remoteResourceRouter } from './remoteResource';
 import { settingRoute } from './setting';
+import { proofPilotRoute } from './proofPilot';
 
 const t = initIpc.create();
 
@@ -21,6 +22,7 @@ export const ipcRoutes = t.router({
   ...remoteResourceRouter,
   ...browserRoute,
   ...settingRoute,
+  ...proofPilotRoute,
 });
 export type Router = typeof ipcRoutes;
 

--- a/apps/ui-tars/src/main/ipcRoutes/proofPilot.ts
+++ b/apps/ui-tars/src/main/ipcRoutes/proofPilot.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { initIpc } from '@ui-tars/electron-ipc/main';
+import { shell } from 'electron';
+
+import { FlightRecorder } from '@main/services/flightRecorder';
+
+const t = initIpc.create();
+
+export const proofPilotRoute = t.router({
+  listProofPilotRuns: t.procedure.input<void>().handle(async () => {
+    return FlightRecorder.getInstance().listRuns();
+  }),
+  getProofPilotRun: t.procedure
+    .input<{ runId: string }>()
+    .handle(async ({ input }) => {
+      return FlightRecorder.getInstance().getRun(input.runId);
+    }),
+  exportProofPilotRun: t.procedure
+    .input<{ runId: string; open?: boolean }>()
+    .handle(async ({ input }) => {
+      const exportResult = await FlightRecorder.getInstance().exportProofPack(
+        input.runId,
+      );
+      const openError =
+        input.open === false
+          ? undefined
+          : await shell.openPath(exportResult.htmlPath);
+
+      return {
+        ...exportResult,
+        openError: openError || undefined,
+      };
+    }),
+  exportProofPilotWorkflowCapsule: t.procedure
+    .input<{ runId: string; reveal?: boolean }>()
+    .handle(async ({ input }) => {
+      const exportResult =
+        await FlightRecorder.getInstance().exportWorkflowCapsule(input.runId);
+
+      if (input.reveal !== false) {
+        shell.showItemInFolder(exportResult.capsulePath);
+      }
+
+      return exportResult;
+    }),
+  compileProofPilotWorkflow: t.procedure
+    .input<{ runId: string; reveal?: boolean }>()
+    .handle(async ({ input }) => {
+      const exportResult = await FlightRecorder.getInstance().compileWorkflow(
+        input.runId,
+      );
+
+      if (input.reveal !== false) {
+        shell.showItemInFolder(exportResult.workflowPath);
+      }
+
+      return exportResult;
+    }),
+});

--- a/apps/ui-tars/src/main/ipcRoutes/team.ts
+++ b/apps/ui-tars/src/main/ipcRoutes/team.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { initIpc } from '@ui-tars/electron-ipc/main';
+import { shell } from 'electron';
+
+import { ApprovalQueue } from '@main/services/approvalQueue';
+import { FlightRecorder } from '@main/services/flightRecorder';
+import { TeamWorkspaceStore } from '@main/services/teamWorkspace';
+import type {
+  TeamMemberInput,
+  TeamWorkspaceUpdate,
+} from '@main/services/teamWorkspace';
+
+const t = initIpc.create();
+
+export const teamRoute = t.router({
+  getTeamWorkspace: t.procedure.input<void>().handle(async () => {
+    return TeamWorkspaceStore.getInstance().getWorkspace();
+  }),
+  updateTeamWorkspace: t.procedure
+    .input<TeamWorkspaceUpdate>()
+    .handle(async ({ input }) => {
+      return TeamWorkspaceStore.getInstance().updateWorkspace(input);
+    }),
+  upsertTeamMember: t.procedure
+    .input<TeamMemberInput>()
+    .handle(async ({ input }) => {
+      return TeamWorkspaceStore.getInstance().upsertMember(input);
+    }),
+  removeTeamMember: t.procedure
+    .input<{ id: string }>()
+    .handle(async ({ input }) => {
+      return TeamWorkspaceStore.getInstance().removeMember(input.id);
+    }),
+  exportTeamAuditReport: t.procedure
+    .input<{ reveal?: boolean } | void>()
+    .handle(async ({ input }) => {
+      const [runs, approvals] = await Promise.all([
+        FlightRecorder.getInstance().listRuns(),
+        ApprovalQueue.getInstance().list(),
+      ]);
+      const exportResult =
+        await TeamWorkspaceStore.getInstance().exportAuditReport({
+          runs,
+          approvals,
+        });
+
+      if (input?.reveal !== false) {
+        shell.showItemInFolder(exportResult.htmlPath);
+      }
+
+      return exportResult;
+    }),
+});

--- a/apps/ui-tars/src/main/services/approvalQueue.test.ts
+++ b/apps/ui-tars/src/main/services/approvalQueue.test.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { mkdtemp } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn(() => os.tmpdir()),
+  },
+}));
+
+import { ApprovalQueue } from './approvalQueue';
+
+describe('ApprovalQueue', () => {
+  it('persists approval requests and decisions', async () => {
+    const storageRoot = await mkdtemp(
+      path.join(os.tmpdir(), 'proofpilot-approval-queue-'),
+    );
+    const storagePath = path.join(storageRoot, 'approval-queue.json');
+    let tick = 0;
+    const queue = new ApprovalQueue({
+      storagePath,
+      now: () => new Date(`2026-05-26T00:00:0${tick++}.000Z`),
+    });
+
+    const request = await queue.submit({
+      title: 'Approve destructive command',
+      reason: 'The command forcefully removes files.',
+      source: 'commands',
+      riskLevel: 'critical',
+      ruleId: 'destructive-file-removal',
+      subject: {
+        toolName: 'run_command',
+        command: 'rm -rf ./dist',
+        cwd: '/repo',
+      },
+    });
+
+    expect(request.status).toBe('pending');
+    await expect(queue.list()).resolves.toMatchObject({
+      counts: {
+        pending: 1,
+        approved: 0,
+        denied: 0,
+      },
+      requests: [
+        {
+          id: request.id,
+          status: 'pending',
+          riskLevel: 'critical',
+        },
+      ],
+    });
+
+    await queue.resolve(
+      request.id,
+      'approved',
+      'User verified the target path.',
+    );
+
+    const reloadedQueue = new ApprovalQueue({ storagePath });
+    await expect(reloadedQueue.list()).resolves.toMatchObject({
+      counts: {
+        pending: 0,
+        approved: 1,
+        denied: 0,
+      },
+      requests: [
+        {
+          id: request.id,
+          status: 'approved',
+          decisionReason: 'User verified the target path.',
+        },
+      ],
+    });
+  });
+
+  it('can clear resolved requests while keeping pending requests', async () => {
+    const storageRoot = await mkdtemp(
+      path.join(os.tmpdir(), 'proofpilot-approval-queue-'),
+    );
+    const queue = new ApprovalQueue({
+      storagePath: path.join(storageRoot, 'approval-queue.json'),
+    });
+
+    const first = await queue.submit({
+      title: 'Approve command',
+      reason: 'Needs approval.',
+      source: 'commands',
+    });
+    await queue.submit({
+      title: 'Approve script',
+      reason: 'Needs approval.',
+      source: 'commands',
+    });
+    await queue.resolve(first.id, 'denied');
+
+    await expect(queue.clearResolved()).resolves.toMatchObject({
+      counts: {
+        pending: 1,
+        approved: 0,
+        denied: 0,
+      },
+    });
+  });
+});

--- a/apps/ui-tars/src/main/services/approvalQueue.ts
+++ b/apps/ui-tars/src/main/services/approvalQueue.ts
@@ -1,0 +1,262 @@
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { createHash } from 'node:crypto';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+
+const require = createRequire(import.meta.url);
+
+type ApprovalStatus = 'pending' | 'approved' | 'denied';
+type ApprovalRiskLevel = 'low' | 'medium' | 'high' | 'critical';
+
+type ApprovalSubject = {
+  toolName?: string;
+  command?: string;
+  interpreter?: string;
+  script?: string;
+  cwd?: string;
+  sessionId?: string;
+  runId?: string;
+  summary?: string;
+};
+
+type ApprovalRequestInput = {
+  id?: string;
+  title: string;
+  reason: string;
+  source: string;
+  riskLevel?: ApprovalRiskLevel;
+  ruleId?: string;
+  subject?: ApprovalSubject;
+  createdAt?: string;
+};
+
+type ApprovalRequest = Required<
+  Pick<ApprovalRequestInput, 'title' | 'reason' | 'source'>
+> & {
+  id: string;
+  status: ApprovalStatus;
+  riskLevel: ApprovalRiskLevel;
+  ruleId?: string;
+  subject?: ApprovalSubject;
+  createdAt: string;
+  updatedAt: string;
+  decidedAt?: string;
+  decisionReason?: string;
+};
+
+type ApprovalQueueCounts = Record<ApprovalStatus, number>;
+
+type ApprovalQueueSnapshot = {
+  requests: ApprovalRequest[];
+  counts: ApprovalQueueCounts;
+};
+
+type ApprovalQueueOptions = {
+  storagePath?: string;
+  now?: () => Date;
+};
+
+class ApprovalQueue {
+  private static instance?: ApprovalQueue;
+
+  private readonly storagePath: string;
+  private readonly now: () => Date;
+  private requests?: ApprovalRequest[];
+
+  constructor(options: ApprovalQueueOptions = {}) {
+    this.storagePath = options.storagePath ?? getDefaultStoragePath();
+    this.now = options.now ?? (() => new Date());
+  }
+
+  static getInstance(): ApprovalQueue {
+    if (!ApprovalQueue.instance) {
+      ApprovalQueue.instance = new ApprovalQueue();
+    }
+    return ApprovalQueue.instance;
+  }
+
+  async list(): Promise<ApprovalQueueSnapshot> {
+    const requests = await this.loadRequests();
+    return {
+      requests: [...requests].sort(sortRequests),
+      counts: countRequests(requests),
+    };
+  }
+
+  async submit(input: ApprovalRequestInput): Promise<ApprovalRequest> {
+    const requests = await this.loadRequests();
+    const requestId = input.id ?? createApprovalRequestId(input);
+    const existing = requests.find((request) => request.id === requestId);
+
+    if (existing?.status === 'pending') {
+      return existing;
+    }
+
+    const now = input.createdAt ?? this.now().toISOString();
+    const request: ApprovalRequest = {
+      id: requestId,
+      title: input.title,
+      reason: input.reason,
+      source: input.source,
+      riskLevel: input.riskLevel ?? 'medium',
+      ruleId: input.ruleId,
+      subject: input.subject,
+      status: 'pending',
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    const nextRequests = existing
+      ? requests.map((item) => (item.id === request.id ? request : item))
+      : [...requests, request];
+    this.requests = nextRequests;
+    await this.persistRequests();
+
+    return request;
+  }
+
+  async resolve(
+    id: string,
+    status: Extract<ApprovalStatus, 'approved' | 'denied'>,
+    decisionReason?: string,
+  ): Promise<ApprovalRequest> {
+    const requests = await this.loadRequests();
+    const index = requests.findIndex((request) => request.id === id);
+    if (index === -1) {
+      throw new Error('Approval request was not found');
+    }
+
+    const now = this.now().toISOString();
+    const request: ApprovalRequest = {
+      ...requests[index],
+      status,
+      decisionReason,
+      decidedAt: now,
+      updatedAt: now,
+    };
+    requests[index] = request;
+    this.requests = requests;
+    await this.persistRequests();
+
+    return request;
+  }
+
+  async clearResolved(): Promise<ApprovalQueueSnapshot> {
+    const requests = await this.loadRequests();
+    this.requests = requests.filter((request) => request.status === 'pending');
+    await this.persistRequests();
+    return this.list();
+  }
+
+  private async loadRequests(): Promise<ApprovalRequest[]> {
+    if (this.requests) {
+      return this.requests;
+    }
+
+    try {
+      const json = await readFile(this.storagePath, 'utf8');
+      this.requests = (JSON.parse(json) as ApprovalRequest[]).filter(
+        isApprovalRequest,
+      );
+      return this.requests;
+    } catch (error) {
+      if (isNodeError(error) && error.code === 'ENOENT') {
+        this.requests = [];
+        return this.requests;
+      }
+
+      throw error;
+    }
+  }
+
+  private async persistRequests(): Promise<void> {
+    await mkdir(path.dirname(this.storagePath), { recursive: true });
+    await writeFile(
+      this.storagePath,
+      `${JSON.stringify(this.requests ?? [], null, 2)}\n`,
+      'utf8',
+    );
+  }
+}
+
+function getDefaultStoragePath(): string {
+  const { app } = require('electron') as typeof import('electron');
+  return path.join(
+    app.getPath('userData'),
+    'proofpilot',
+    'approval-queue.json',
+  );
+}
+
+function createApprovalRequestId(input: ApprovalRequestInput): string {
+  return createHash('sha256')
+    .update(
+      JSON.stringify({
+        title: input.title,
+        source: input.source,
+        ruleId: input.ruleId,
+        subject: input.subject,
+      }),
+    )
+    .digest('hex')
+    .slice(0, 16);
+}
+
+function sortRequests(a: ApprovalRequest, b: ApprovalRequest): number {
+  if (a.status === 'pending' && b.status !== 'pending') {
+    return -1;
+  }
+  if (a.status !== 'pending' && b.status === 'pending') {
+    return 1;
+  }
+
+  return b.createdAt.localeCompare(a.createdAt);
+}
+
+function countRequests(requests: ApprovalRequest[]): ApprovalQueueCounts {
+  return requests.reduce<ApprovalQueueCounts>(
+    (counts, request) => {
+      counts[request.status] += 1;
+      return counts;
+    },
+    { pending: 0, approved: 0, denied: 0 },
+  );
+}
+
+function isApprovalRequest(value: unknown): value is ApprovalRequest {
+  return (
+    isRecord(value) &&
+    typeof value.id === 'string' &&
+    typeof value.title === 'string' &&
+    typeof value.reason === 'string' &&
+    typeof value.source === 'string' &&
+    isApprovalStatus(value.status)
+  );
+}
+
+function isApprovalStatus(value: unknown): value is ApprovalStatus {
+  return value === 'pending' || value === 'approved' || value === 'denied';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isNodeError(error: unknown): error is Error & { code?: string } {
+  return error instanceof Error && 'code' in error;
+}
+
+export { ApprovalQueue };
+export type {
+  ApprovalQueueCounts,
+  ApprovalQueueSnapshot,
+  ApprovalRequest,
+  ApprovalRequestInput,
+  ApprovalRiskLevel,
+  ApprovalStatus,
+  ApprovalSubject,
+};

--- a/apps/ui-tars/src/main/services/flightRecorder.test.ts
+++ b/apps/ui-tars/src/main/services/flightRecorder.test.ts
@@ -1,0 +1,368 @@
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { mkdtemp, readFile, stat, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { GUIAgentData, ShareVersion, StatusEnum } from '@ui-tars/shared/types';
+import { Operator } from '@main/store/types';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn(() => os.tmpdir()),
+  },
+}));
+
+import { FlightRecorder } from './flightRecorder';
+
+describe('FlightRecorder', () => {
+  it('writes a run manifest, event log, and screenshot artifacts', async () => {
+    const storageRoot = await mkdtemp(
+      path.join(os.tmpdir(), 'proofpilot-flight-recorder-'),
+    );
+    let idCount = 0;
+    const recorder = new FlightRecorder({
+      storageRoot,
+      now: () => new Date('2026-05-26T00:00:00.000Z'),
+      idFactory: () => `id-${++idCount}`,
+    });
+
+    const recording = await recorder.startRun({
+      sessionId: 'session-1',
+      instruction: 'Open the report and summarize it',
+      operator: Operator.LocalComputer,
+      modelName: 'ui-tars-test',
+      modelProvider: 'test-provider',
+    });
+
+    const screenshotBase64 = `data:image/png;base64,${Buffer.from(
+      'fake-png',
+    ).toString('base64')}`;
+    await recording.recordAgentData(
+      createAgentData({
+        status: StatusEnum.RUNNING,
+        conversations: [
+          {
+            from: 'human',
+            value: '<image>',
+            screenshotBase64,
+            screenshotContext: {
+              size: {
+                width: 1280,
+                height: 720,
+              },
+              mime: 'image/png',
+              scaleFactor: 1,
+            },
+            timing: {
+              start: 1,
+              end: 2,
+              cost: 1,
+            },
+          },
+          {
+            from: 'gpt',
+            value: 'Click the export button',
+            predictionParsed: [
+              {
+                action_type: 'left_click',
+                action_inputs: {
+                  start_box: '[10,20,30,40]',
+                },
+                thought: 'The export button is visible.',
+                reflection: null,
+              },
+            ],
+            timing: {
+              start: 3,
+              end: 4,
+              cost: 1,
+            },
+          },
+        ],
+      }),
+    );
+    await recording.finish(StatusEnum.END);
+
+    const manifest = JSON.parse(
+      await readFile(path.join(recording.directory, 'manifest.json'), 'utf8'),
+    );
+    const eventLog = await readFile(
+      path.join(recording.directory, 'events.jsonl'),
+      'utf8',
+    );
+    const events = eventLog
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line));
+
+    expect(manifest).toMatchObject({
+      version: 1,
+      sessionId: 'session-1',
+      mode: 'live',
+      instruction: 'Open the report and summarize it',
+      status: StatusEnum.END,
+      eventCount: 6,
+      artifactCount: 1,
+      integrityAlgorithm: 'sha256',
+    });
+    expect(manifest.recordingHash).toBe(events.at(-1).eventHash);
+    expect(events.map((event) => event.type)).toEqual([
+      'run_started',
+      'status_changed',
+      'conversation_added',
+      'conversation_added',
+      'action_planned',
+      'run_finished',
+    ]);
+    expect(events[0].previousHash).toBeNull();
+    expect(events[0].payload.mode).toBe('live');
+    expect(events[0].eventHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(events[1].previousHash).toBe(events[0].eventHash);
+    expect(eventLog).not.toContain(screenshotBase64);
+
+    const screenshot = events.find((event) => event.payload.screenshot)?.payload
+      .screenshot;
+    await expect(
+      stat(path.join(recording.directory, screenshot.relativePath)),
+    ).resolves.toBeTruthy();
+
+    const runs = await recorder.listRuns();
+    expect(runs).toHaveLength(1);
+    expect(runs[0]).toMatchObject({
+      runId: recording.runId,
+      storagePath: recording.directory,
+      eventCount: 6,
+      artifactCount: 1,
+    });
+
+    const detail = await recorder.getRun(recording.runId);
+    expect(detail?.events.map((event) => event.type)).toEqual([
+      'run_started',
+      'status_changed',
+      'conversation_added',
+      'conversation_added',
+      'action_planned',
+      'run_finished',
+    ]);
+    expect(detail?.integrity).toMatchObject({
+      status: 'verified',
+      valid: true,
+      verifiedEventCount: 6,
+      recordingHash: manifest.recordingHash,
+    });
+    const screenshotPreview = detail?.events.find(
+      (event) => event.payload.screenshot,
+    )?.payload.screenshot as { dataUrl?: string };
+    expect(screenshotPreview.dataUrl).toBe(screenshotBase64);
+
+    const proofPack = await recorder.exportProofPack(recording.runId);
+    const proofPackHtml = await readFile(proofPack.htmlPath, 'utf8');
+    const proofPackJson = await readFile(proofPack.jsonPath, 'utf8');
+    expect(proofPack.integrity.status).toBe('verified');
+    expect(proofPackHtml).toContain('ProofPilot Proof Pack');
+    expect(proofPackHtml).toContain('Verified');
+    expect(proofPackHtml).toContain(
+      'artifacts/screenshots/screenshot_f084b1351c41cf3c.png',
+    );
+    expect(proofPackJson).not.toContain(screenshotBase64);
+    await expect(
+      stat(
+        path.join(
+          proofPack.exportDirectory,
+          'artifacts',
+          'screenshots',
+          'screenshot_f084b1351c41cf3c.png',
+        ),
+      ),
+    ).resolves.toBeTruthy();
+
+    const capsule = await recorder.exportWorkflowCapsule(recording.runId);
+    const capsuleJson = JSON.parse(await readFile(capsule.capsulePath, 'utf8'));
+    expect(capsule).toMatchObject({
+      runId: recording.runId,
+      stepCount: 1,
+    });
+    expect(capsuleJson).toMatchObject({
+      version: 1,
+      status: 'draft',
+      sourceRun: {
+        runId: recording.runId,
+        mode: 'live',
+        recordingHash: manifest.recordingHash,
+        integrity: {
+          status: 'verified',
+        },
+      },
+      stepCount: 1,
+      steps: [
+        {
+          id: 'step_001',
+          actionType: 'left_click',
+          actionInputs: {
+            start_box: '[10,20,30,40]',
+          },
+          thought: 'The export button is visible.',
+          sourceConversation: {
+            message: 'Click the export button',
+          },
+        },
+      ],
+    });
+    expect(capsuleJson.steps[0].sourceEventHash).toBe(events[4].eventHash);
+    expect(JSON.stringify(capsuleJson)).not.toContain(screenshotBase64);
+
+    const compiled = await recorder.compileWorkflow(recording.runId);
+    const compiledJson = JSON.parse(
+      await readFile(compiled.workflowPath, 'utf8'),
+    );
+    const compiledMarkdown = await readFile(compiled.markdownPath, 'utf8');
+    expect(compiled).toMatchObject({
+      runId: recording.runId,
+      stepCount: 1,
+    });
+    expect(compiledJson).toMatchObject({
+      version: 1,
+      kind: 'proofpilot.workflow',
+      status: 'ready_for_simulation',
+      sourceRun: {
+        runId: recording.runId,
+        recordingHash: manifest.recordingHash,
+      },
+      guardrails: {
+        defaultRunMode: 'simulation',
+        requireIntegrityVerification: true,
+      },
+      stepCount: 1,
+      steps: [
+        {
+          id: 'step_001',
+          actionType: 'left_click',
+          requiresApproval: true,
+          evidence: {
+            sourceEventHash: events[4].eventHash,
+          },
+        },
+      ],
+    });
+    expect(compiledJson.workflowId).toMatch(/^[a-f0-9]{16}$/);
+    expect(compiledMarkdown).toContain('# Open the report and summarize it');
+    expect(compiledMarkdown).toContain('Approval required: yes');
+
+    await expect(recorder.getRun('../outside')).rejects.toThrow(
+      'Invalid ProofPilot run id',
+    );
+  });
+
+  it('records skipped execution events for simulation runs', async () => {
+    const storageRoot = await mkdtemp(
+      path.join(os.tmpdir(), 'proofpilot-flight-recorder-'),
+    );
+    let idCount = 0;
+    const recorder = new FlightRecorder({
+      storageRoot,
+      now: () => new Date('2026-05-26T00:00:00.000Z'),
+      idFactory: () => `id-${++idCount}`,
+    });
+
+    const recording = await recorder.startRun({
+      mode: 'simulation',
+      instruction: 'Preview the export flow',
+      operator: Operator.LocalBrowser,
+      modelName: 'ui-tars-test',
+      modelProvider: 'test-provider',
+    });
+    await recording.recordSimulationActionSkipped({
+      action_type: 'left_click',
+      action_inputs: {
+        start_box: '[10,20,30,40]',
+      },
+      thought: 'The export button should be clicked next.',
+      reflection: null,
+    });
+    await recording.finish(StatusEnum.END);
+
+    const manifest = JSON.parse(
+      await readFile(path.join(recording.directory, 'manifest.json'), 'utf8'),
+    );
+    const detail = await recorder.getRun(recording.runId);
+    const proofPack = await recorder.exportProofPack(recording.runId);
+    const proofPackHtml = await readFile(proofPack.htmlPath, 'utf8');
+
+    expect(manifest).toMatchObject({
+      mode: 'simulation',
+      eventCount: 3,
+    });
+    expect(detail).toMatchObject({
+      mode: 'simulation',
+      integrity: {
+        status: 'verified',
+        valid: true,
+      },
+    });
+    expect(detail?.events.map((event) => event.type)).toEqual([
+      'run_started',
+      'simulation_action_skipped',
+      'run_finished',
+    ]);
+    expect(detail?.events[1].payload).toMatchObject({
+      actionType: 'left_click',
+      actionInputs: {
+        start_box: '[10,20,30,40]',
+      },
+      thought: 'The export button should be clicked next.',
+    });
+    expect(proofPackHtml).toContain('simulation');
+    expect(proofPackHtml).toContain('Simulation action skipped');
+  });
+
+  it('detects tampered event logs', async () => {
+    const storageRoot = await mkdtemp(
+      path.join(os.tmpdir(), 'proofpilot-flight-recorder-'),
+    );
+    let idCount = 0;
+    const recorder = new FlightRecorder({
+      storageRoot,
+      now: () => new Date('2026-05-26T00:00:00.000Z'),
+      idFactory: () => `id-${++idCount}`,
+    });
+
+    const recording = await recorder.startRun({
+      instruction: 'Open the report and summarize it',
+      operator: Operator.LocalComputer,
+    });
+    await recording.finish(StatusEnum.END);
+
+    const eventLogPath = path.join(recording.directory, 'events.jsonl');
+    const eventLog = await readFile(eventLogPath, 'utf8');
+    await writeFile(
+      eventLogPath,
+      eventLog.replace('Open the report and summarize it', 'Changed task'),
+      'utf8',
+    );
+
+    const detail = await recorder.getRun(recording.runId);
+    expect(detail?.integrity).toMatchObject({
+      status: 'failed',
+      valid: false,
+      failureSequence: 1,
+    });
+  });
+});
+
+function createAgentData(
+  partial: Pick<GUIAgentData, 'status' | 'conversations'>,
+): GUIAgentData {
+  return {
+    version: ShareVersion.V1,
+    instruction: 'Open the report and summarize it',
+    systemPrompt: 'system prompt',
+    modelName: 'ui-tars-test',
+    logTime: Date.now(),
+    status: partial.status,
+    conversations: partial.conversations,
+  };
+}

--- a/apps/ui-tars/src/main/services/flightRecorder.ts
+++ b/apps/ui-tars/src/main/services/flightRecorder.ts
@@ -1,0 +1,1443 @@
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { createHash, randomUUID } from 'node:crypto';
+import {
+  mkdir,
+  writeFile,
+  appendFile,
+  readFile,
+  readdir,
+  copyFile,
+} from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+
+import {
+  GUIAgentData,
+  StatusEnum,
+  type PredictionParsed,
+} from '@ui-tars/shared/types';
+import { ConversationWithSoM } from '@main/shared/types';
+import { Operator } from '@main/store/types';
+
+const require = createRequire(import.meta.url);
+
+type FlightRecorderEventType =
+  | 'run_started'
+  | 'status_changed'
+  | 'conversation_added'
+  | 'action_planned'
+  | 'simulation_action_skipped'
+  | 'run_error'
+  | 'run_finished';
+
+type FlightRecorderRunMode = 'live' | 'simulation';
+
+type FlightRecorderRunContext = {
+  sessionId?: string | null;
+  mode?: FlightRecorderRunMode;
+  instruction: string;
+  operator: Operator;
+  modelName?: string;
+  modelProvider?: string;
+};
+
+type FlightRecorderArtifact = {
+  id: string;
+  kind: 'screenshot' | 'som_screenshot';
+  relativePath: string;
+  sha256: string;
+  bytes: number;
+  mime: string;
+  createdAt: string;
+};
+
+type FlightRecorderArtifactPreview = FlightRecorderArtifact & {
+  dataUrl?: string;
+  missing?: boolean;
+};
+
+type FlightRecorderIntegrity = {
+  algorithm: 'sha256';
+  status: 'verified' | 'failed' | 'legacy';
+  valid: boolean;
+  eventCount: number;
+  verifiedEventCount: number;
+  recordingHash?: string;
+  expectedRecordingHash?: string;
+  failureSequence?: number;
+  failureReason?: string;
+};
+
+type FlightRecorderManifest = {
+  version: 1;
+  runId: string;
+  sessionId?: string;
+  mode: FlightRecorderRunMode;
+  instruction: string;
+  operator: Operator;
+  modelName?: string;
+  modelProvider?: string;
+  startedAt: string;
+  updatedAt: string;
+  finishedAt?: string;
+  status: StatusEnum;
+  eventCount: number;
+  artifactCount: number;
+  integrityAlgorithm?: 'sha256';
+  recordingHash?: string;
+};
+
+type FlightRecorderEvent = {
+  id: string;
+  runId: string;
+  sequence: number;
+  timestamp: string;
+  type: FlightRecorderEventType;
+  payload: Record<string, unknown>;
+  previousHash?: string | null;
+  eventHash?: string;
+};
+
+type FlightRecorderRunSummary = FlightRecorderManifest & {
+  storagePath: string;
+};
+
+type FlightRecorderRunDetail = FlightRecorderRunSummary & {
+  events: FlightRecorderEvent[];
+  integrity: FlightRecorderIntegrity;
+};
+
+type ProofPackExport = {
+  runId: string;
+  exportDirectory: string;
+  htmlPath: string;
+  jsonPath: string;
+  generatedAt: string;
+  integrity: FlightRecorderIntegrity;
+};
+
+type WorkflowCapsuleStep = {
+  id: string;
+  sourceEventId: string;
+  sourceSequence: number;
+  sourceEventHash?: string;
+  actionType: string;
+  actionInputs: unknown;
+  thought?: string;
+  reflection?: string;
+  sourceConversation?: {
+    eventId: string;
+    sequence: number;
+    timestamp: string;
+    from?: string;
+    message?: string;
+    screenshot?: unknown;
+    somScreenshot?: unknown;
+  };
+};
+
+type WorkflowCapsule = {
+  version: 1;
+  generatedAt: string;
+  status: 'draft';
+  sourceRun: {
+    runId: string;
+    mode: FlightRecorderRunMode;
+    instruction: string;
+    operator: Operator;
+    modelName?: string;
+    modelProvider?: string;
+    startedAt: string;
+    finishedAt?: string;
+    recordingHash?: string;
+    integrity: FlightRecorderIntegrity;
+  };
+  stepCount: number;
+  steps: WorkflowCapsuleStep[];
+};
+
+type WorkflowCapsuleExport = {
+  runId: string;
+  capsuleDirectory: string;
+  capsulePath: string;
+  generatedAt: string;
+  stepCount: number;
+  integrity: FlightRecorderIntegrity;
+};
+
+type CompiledWorkflowInput = {
+  key: string;
+  label: string;
+  type: 'text' | 'number' | 'boolean';
+  required: boolean;
+  defaultValue?: unknown;
+};
+
+type CompiledWorkflowStep = {
+  id: string;
+  order: number;
+  title: string;
+  instruction: string;
+  actionType: string;
+  actionInputs: unknown;
+  requiresApproval: boolean;
+  retryPolicy: {
+    maxAttempts: number;
+    onFailure: 'request_human_review';
+  };
+  evidence: {
+    sourceEventId: string;
+    sourceSequence: number;
+    sourceEventHash?: string;
+    screenshot?: unknown;
+    somScreenshot?: unknown;
+  };
+};
+
+type CompiledWorkflow = {
+  version: 1;
+  kind: 'proofpilot.workflow';
+  workflowId: string;
+  name: string;
+  generatedAt: string;
+  status: 'ready_for_simulation';
+  sourceRun: WorkflowCapsule['sourceRun'];
+  inputs: CompiledWorkflowInput[];
+  guardrails: {
+    defaultRunMode: FlightRecorderRunMode;
+    requireIntegrityVerification: boolean;
+    requireApprovalForRiskyActions: boolean;
+    stopConditions: string[];
+  };
+  stepCount: number;
+  steps: CompiledWorkflowStep[];
+};
+
+type CompiledWorkflowExport = {
+  runId: string;
+  workflowDirectory: string;
+  workflowPath: string;
+  markdownPath: string;
+  generatedAt: string;
+  workflowId: string;
+  stepCount: number;
+  integrity: FlightRecorderIntegrity;
+};
+
+type FlightRecorderOptions = {
+  storageRoot?: string;
+  now?: () => Date;
+  idFactory?: () => string;
+};
+
+class FlightRecorder {
+  private static instance?: FlightRecorder;
+
+  private readonly storageRoot: string;
+  private readonly now: () => Date;
+  private readonly idFactory: () => string;
+
+  constructor(options: FlightRecorderOptions = {}) {
+    this.storageRoot = options.storageRoot ?? getDefaultStorageRoot();
+    this.now = options.now ?? (() => new Date());
+    this.idFactory = options.idFactory ?? (() => randomUUID());
+  }
+
+  static getInstance(): FlightRecorder {
+    if (!FlightRecorder.instance) {
+      FlightRecorder.instance = new FlightRecorder();
+    }
+    return FlightRecorder.instance;
+  }
+
+  async startRun(context: FlightRecorderRunContext): Promise<FlightRecording> {
+    const startedAt = this.now();
+    const now = startedAt.toISOString();
+    const runId = `run_${startedAt.getTime()}_${this.idFactory()}`;
+    const runDirectory = path.join(this.storageRoot, runId);
+    const manifest: FlightRecorderManifest = {
+      version: 1,
+      runId,
+      sessionId: context.sessionId ?? undefined,
+      mode: context.mode ?? 'live',
+      instruction: context.instruction,
+      operator: context.operator,
+      modelName: context.modelName,
+      modelProvider: context.modelProvider,
+      startedAt: now,
+      updatedAt: now,
+      status: StatusEnum.INIT,
+      eventCount: 0,
+      artifactCount: 0,
+    };
+
+    await mkdir(path.join(runDirectory, 'screenshots'), { recursive: true });
+
+    const recording = new FlightRecording({
+      runDirectory,
+      manifest,
+      now: this.now,
+      idFactory: this.idFactory,
+    });
+    await recording.writeManifest();
+    await recording.appendEvent('run_started', {
+      sessionId: context.sessionId,
+      mode: context.mode ?? 'live',
+      instruction: context.instruction,
+      operator: context.operator,
+      modelName: context.modelName,
+      modelProvider: context.modelProvider,
+    });
+
+    return recording;
+  }
+
+  async listRuns(): Promise<FlightRecorderRunSummary[]> {
+    let entries: Awaited<ReturnType<typeof readdir>>;
+    try {
+      entries = await readdir(this.storageRoot, { withFileTypes: true });
+    } catch (error) {
+      if (isNodeError(error) && error.code === 'ENOENT') {
+        return [];
+      }
+
+      throw error;
+    }
+
+    const runs = await Promise.all(
+      entries
+        .filter((entry) => entry.isDirectory())
+        .map(async (entry) => {
+          try {
+            const runDirectory = this.resolveRunDirectory(entry.name);
+            const manifest = await readManifest(runDirectory);
+            return {
+              ...manifest,
+              storagePath: runDirectory,
+            };
+          } catch {
+            return null;
+          }
+        }),
+    );
+
+    return runs
+      .filter(isDefined)
+      .sort((a, b) => b.startedAt.localeCompare(a.startedAt));
+  }
+
+  async getRun(runId: string): Promise<FlightRecorderRunDetail | null> {
+    const runDirectory = this.resolveRunDirectory(runId);
+
+    try {
+      const manifest = await readManifest(runDirectory);
+      const events = await readEvents(runDirectory);
+      const integrity = validateEventChain(events, manifest);
+      const eventsWithPreviews = await Promise.all(
+        events.map((event) => this.withArtifactPreviews(runDirectory, event)),
+      );
+
+      return {
+        ...manifest,
+        storagePath: runDirectory,
+        events: eventsWithPreviews,
+        integrity,
+      };
+    } catch (error) {
+      if (isNodeError(error) && error.code === 'ENOENT') {
+        return null;
+      }
+
+      throw error;
+    }
+  }
+
+  private resolveRunDirectory(runId: string): string {
+    if (!/^[A-Za-z0-9_.-]+$/.test(runId)) {
+      throw new Error('Invalid ProofPilot run id');
+    }
+
+    return resolveInside(this.storageRoot, runId);
+  }
+
+  private async withArtifactPreviews(
+    runDirectory: string,
+    event: FlightRecorderEvent,
+  ): Promise<FlightRecorderEvent> {
+    const payload = { ...event.payload };
+    payload.screenshot = await this.withArtifactPreview(
+      runDirectory,
+      payload.screenshot,
+    );
+    payload.somScreenshot = await this.withArtifactPreview(
+      runDirectory,
+      payload.somScreenshot,
+    );
+
+    return {
+      ...event,
+      payload,
+    };
+  }
+
+  private async withArtifactPreview(
+    runDirectory: string,
+    value: unknown,
+  ): Promise<unknown> {
+    if (!isArtifact(value)) {
+      return value;
+    }
+
+    try {
+      const artifactPath = resolveInside(runDirectory, value.relativePath);
+      const buffer = await readFile(artifactPath);
+      return {
+        ...value,
+        dataUrl: `data:${value.mime};base64,${buffer.toString('base64')}`,
+      } satisfies FlightRecorderArtifactPreview;
+    } catch (error) {
+      if (isNodeError(error) && error.code === 'ENOENT') {
+        return {
+          ...value,
+          missing: true,
+        } satisfies FlightRecorderArtifactPreview;
+      }
+
+      throw error;
+    }
+  }
+
+  async exportProofPack(runId: string): Promise<ProofPackExport> {
+    const runDirectory = this.resolveRunDirectory(runId);
+    const detail = await this.getRun(runId);
+    if (!detail) {
+      throw new Error('ProofPilot run was not found');
+    }
+
+    const generatedAt = this.now().toISOString();
+    const exportDirectory = path.join(runDirectory, 'proof-pack');
+    const htmlPath = path.join(exportDirectory, 'index.html');
+    const jsonPath = path.join(exportDirectory, 'proof-pack.json');
+    const exportPayload = stripPreviewData({
+      version: 1,
+      generatedAt,
+      run: {
+        ...detail,
+        storagePath: undefined,
+      },
+    });
+
+    await mkdir(exportDirectory, { recursive: true });
+    await copyProofPackArtifacts(runDirectory, exportDirectory, detail.events);
+    await writeFile(
+      jsonPath,
+      `${JSON.stringify(exportPayload, null, 2)}\n`,
+      'utf8',
+    );
+    await writeFile(htmlPath, renderProofPackHtml(detail, generatedAt), 'utf8');
+
+    return {
+      runId,
+      exportDirectory,
+      htmlPath,
+      jsonPath,
+      generatedAt,
+      integrity: detail.integrity,
+    };
+  }
+
+  async exportWorkflowCapsule(runId: string): Promise<WorkflowCapsuleExport> {
+    const runDirectory = this.resolveRunDirectory(runId);
+    const detail = await this.getRun(runId);
+    if (!detail) {
+      throw new Error('ProofPilot run was not found');
+    }
+
+    const generatedAt = this.now().toISOString();
+    const capsule = createWorkflowCapsule(detail, generatedAt);
+    const capsuleDirectory = path.join(runDirectory, 'workflow-capsule');
+    const capsulePath = path.join(capsuleDirectory, 'workflow-capsule.json');
+
+    await mkdir(capsuleDirectory, { recursive: true });
+    await writeFile(
+      capsulePath,
+      `${JSON.stringify(stripPreviewData(capsule), null, 2)}\n`,
+      'utf8',
+    );
+
+    return {
+      runId,
+      capsuleDirectory,
+      capsulePath,
+      generatedAt,
+      stepCount: capsule.stepCount,
+      integrity: detail.integrity,
+    };
+  }
+
+  async compileWorkflow(runId: string): Promise<CompiledWorkflowExport> {
+    const runDirectory = this.resolveRunDirectory(runId);
+    const detail = await this.getRun(runId);
+    if (!detail) {
+      throw new Error('ProofPilot run was not found');
+    }
+
+    const generatedAt = this.now().toISOString();
+    const workflow = createCompiledWorkflow(detail, generatedAt);
+    const workflowDirectory = path.join(runDirectory, 'compiled-workflow');
+    const workflowPath = path.join(workflowDirectory, 'workflow.json');
+    const markdownPath = path.join(workflowDirectory, 'workflow.md');
+
+    await mkdir(workflowDirectory, { recursive: true });
+    await writeFile(
+      workflowPath,
+      `${JSON.stringify(stripPreviewData(workflow), null, 2)}\n`,
+      'utf8',
+    );
+    await writeFile(
+      markdownPath,
+      renderCompiledWorkflowMarkdown(workflow),
+      'utf8',
+    );
+
+    return {
+      runId,
+      workflowDirectory,
+      workflowPath,
+      markdownPath,
+      generatedAt,
+      workflowId: workflow.workflowId,
+      stepCount: workflow.stepCount,
+      integrity: detail.integrity,
+    };
+  }
+}
+
+class FlightRecording {
+  private readonly runDirectory: string;
+  private readonly eventLogPath: string;
+  private readonly manifestPath: string;
+  private readonly now: () => Date;
+  private readonly idFactory: () => string;
+  private manifest: FlightRecorderManifest;
+  private sequence = 0;
+  private previousHash: string | null = null;
+  private lastStatus?: StatusEnum;
+  private seenConversationKeys = new Set<string>();
+
+  constructor(options: {
+    runDirectory: string;
+    manifest: FlightRecorderManifest;
+    now: () => Date;
+    idFactory: () => string;
+  }) {
+    this.runDirectory = options.runDirectory;
+    this.eventLogPath = path.join(this.runDirectory, 'events.jsonl');
+    this.manifestPath = path.join(this.runDirectory, 'manifest.json');
+    this.manifest = options.manifest;
+    this.now = options.now;
+    this.idFactory = options.idFactory;
+  }
+
+  get runId(): string {
+    return this.manifest.runId;
+  }
+
+  get directory(): string {
+    return this.runDirectory;
+  }
+
+  async recordAgentData(data: GUIAgentData): Promise<void> {
+    if (data.status !== this.lastStatus) {
+      this.lastStatus = data.status;
+      this.manifest.status = data.status;
+      await this.appendEvent('status_changed', { status: data.status });
+    }
+
+    for (const conversation of data.conversations ?? []) {
+      await this.recordConversation(conversation as ConversationWithSoM);
+    }
+  }
+
+  async recordError(error: unknown): Promise<void> {
+    await this.appendEvent('run_error', {
+      error: serializeError(error),
+    });
+  }
+
+  async recordSimulationActionSkipped(action: PredictionParsed): Promise<void> {
+    await this.appendEvent('simulation_action_skipped', {
+      actionType: action.action_type,
+      actionInputs: action.action_inputs,
+      thought: action.thought,
+      reflection: action.reflection,
+    });
+  }
+
+  async finish(status: StatusEnum): Promise<void> {
+    const now = this.now().toISOString();
+    this.manifest.status = status;
+    this.manifest.finishedAt = now;
+    this.manifest.updatedAt = now;
+    await this.appendEvent('run_finished', { status });
+  }
+
+  async writeManifest(): Promise<void> {
+    await writeFile(
+      this.manifestPath,
+      `${JSON.stringify(this.manifest, null, 2)}\n`,
+      'utf8',
+    );
+  }
+
+  async appendEvent(
+    type: FlightRecorderEventType,
+    payload: Record<string, unknown>,
+  ): Promise<void> {
+    this.sequence += 1;
+    const timestamp = this.now().toISOString();
+    const eventWithoutHash: Omit<FlightRecorderEvent, 'eventHash'> = {
+      id: this.idFactory(),
+      runId: this.manifest.runId,
+      sequence: this.sequence,
+      timestamp,
+      type,
+      payload,
+      previousHash: this.previousHash,
+    };
+    const eventHash = createEventHash(eventWithoutHash);
+    const event: FlightRecorderEvent = {
+      ...eventWithoutHash,
+      eventHash,
+    };
+
+    await appendFile(this.eventLogPath, `${JSON.stringify(event)}\n`, 'utf8');
+    this.previousHash = eventHash;
+    this.manifest.eventCount = this.sequence;
+    this.manifest.updatedAt = timestamp;
+    this.manifest.integrityAlgorithm = 'sha256';
+    this.manifest.recordingHash = eventHash;
+    await this.writeManifest();
+  }
+
+  private async recordConversation(
+    conversation: ConversationWithSoM,
+  ): Promise<void> {
+    const key = createConversationKey(conversation);
+    if (this.seenConversationKeys.has(key)) {
+      return;
+    }
+    this.seenConversationKeys.add(key);
+
+    const screenshot = await this.persistScreenshot(
+      conversation.screenshotBase64,
+      'screenshot',
+    );
+    const somScreenshot = await this.persistScreenshot(
+      conversation.screenshotBase64WithElementMarker,
+      'som_screenshot',
+    );
+
+    await this.appendEvent('conversation_added', {
+      from: conversation.from,
+      value: conversation.value,
+      timing: conversation.timing,
+      screenshotContext: conversation.screenshotContext,
+      screenshot,
+      somScreenshot,
+      actionCount: conversation.predictionParsed?.length ?? 0,
+    });
+
+    for (const [index, action] of (
+      conversation.predictionParsed ?? []
+    ).entries()) {
+      await this.appendEvent('action_planned', {
+        index,
+        actionType: action.action_type,
+        actionInputs: action.action_inputs,
+        thought: action.thought,
+        reflection: action.reflection,
+      });
+    }
+  }
+
+  private async persistScreenshot(
+    base64: string | undefined,
+    kind: FlightRecorderArtifact['kind'],
+  ): Promise<FlightRecorderArtifact | undefined> {
+    if (!base64) {
+      return undefined;
+    }
+
+    const mime = readMime(base64);
+    const extension = mime === 'image/jpeg' ? 'jpg' : 'png';
+    const buffer = Buffer.from(stripDataUrlPrefix(base64), 'base64');
+    const sha256 = createHash('sha256').update(buffer).digest('hex');
+    const id = `${kind}_${sha256.slice(0, 16)}`;
+    const relativePath = path.join('screenshots', `${id}.${extension}`);
+    const artifact: FlightRecorderArtifact = {
+      id,
+      kind,
+      relativePath,
+      sha256,
+      bytes: buffer.byteLength,
+      mime,
+      createdAt: this.now().toISOString(),
+    };
+
+    await writeFile(path.join(this.runDirectory, relativePath), buffer);
+    this.manifest.artifactCount += 1;
+    return artifact;
+  }
+}
+
+function getDefaultStorageRoot(): string {
+  const { app } = require('electron') as typeof import('electron');
+  return path.join(app.getPath('userData'), 'proofpilot', 'flight-records');
+}
+
+function createConversationKey(conversation: ConversationWithSoM): string {
+  return [
+    conversation.from,
+    conversation.value,
+    conversation.timing?.start,
+    conversation.timing?.end,
+    conversation.predictionParsed
+      ?.map((prediction) => prediction.action_type)
+      .join(','),
+  ].join(':');
+}
+
+function stripDataUrlPrefix(base64: string): string {
+  return base64.replace(/^data:image\/\w+;base64,/, '');
+}
+
+function readMime(base64: string): string {
+  const match = /^data:(image\/\w+);base64,/.exec(base64);
+  return match?.[1] ?? 'image/png';
+}
+
+async function readManifest(
+  runDirectory: string,
+): Promise<FlightRecorderManifest> {
+  const manifest = await readFile(
+    path.join(runDirectory, 'manifest.json'),
+    'utf8',
+  );
+  const parsedManifest = JSON.parse(
+    manifest,
+  ) as Partial<FlightRecorderManifest>;
+  return {
+    ...parsedManifest,
+    mode: parsedManifest.mode ?? 'live',
+  } as FlightRecorderManifest;
+}
+
+async function readEvents(
+  runDirectory: string,
+): Promise<FlightRecorderEvent[]> {
+  try {
+    const eventLog = await readFile(
+      path.join(runDirectory, 'events.jsonl'),
+      'utf8',
+    );
+
+    return eventLog
+      .split('\n')
+      .filter((line) => line.trim() !== '')
+      .map((line) => JSON.parse(line) as FlightRecorderEvent);
+  } catch (error) {
+    if (isNodeError(error) && error.code === 'ENOENT') {
+      return [];
+    }
+
+    throw error;
+  }
+}
+
+function validateEventChain(
+  events: FlightRecorderEvent[],
+  manifest: FlightRecorderManifest,
+): FlightRecorderIntegrity {
+  let previousHash: string | null = null;
+
+  if (manifest.eventCount !== events.length) {
+    return {
+      algorithm: 'sha256',
+      status: 'failed',
+      valid: false,
+      eventCount: events.length,
+      verifiedEventCount: 0,
+      recordingHash: manifest.recordingHash,
+      failureReason: `Manifest event count ${manifest.eventCount} does not match event log count ${events.length}`,
+    };
+  }
+
+  for (const event of events) {
+    if (!event.eventHash || event.previousHash === undefined) {
+      return {
+        algorithm: 'sha256',
+        status: 'legacy',
+        valid: false,
+        eventCount: events.length,
+        verifiedEventCount: event.sequence - 1,
+        recordingHash: manifest.recordingHash,
+        failureSequence: event.sequence,
+        failureReason: 'This run was recorded before event hashing existed.',
+      };
+    }
+
+    if (event.previousHash !== previousHash) {
+      return {
+        algorithm: 'sha256',
+        status: 'failed',
+        valid: false,
+        eventCount: events.length,
+        verifiedEventCount: event.sequence - 1,
+        recordingHash: manifest.recordingHash,
+        failureSequence: event.sequence,
+        failureReason: 'Previous event hash does not match the chain.',
+      };
+    }
+
+    const { eventHash: _eventHash, ...eventWithoutHash } = event;
+    const expectedHash = createEventHash(eventWithoutHash);
+    if (event.eventHash !== expectedHash) {
+      return {
+        algorithm: 'sha256',
+        status: 'failed',
+        valid: false,
+        eventCount: events.length,
+        verifiedEventCount: event.sequence - 1,
+        recordingHash: manifest.recordingHash,
+        expectedRecordingHash: expectedHash,
+        failureSequence: event.sequence,
+        failureReason: 'Event content does not match its recorded hash.',
+      };
+    }
+
+    previousHash = event.eventHash;
+  }
+
+  if (manifest.recordingHash && manifest.recordingHash !== previousHash) {
+    return {
+      algorithm: 'sha256',
+      status: 'failed',
+      valid: false,
+      eventCount: events.length,
+      verifiedEventCount: events.length,
+      recordingHash: manifest.recordingHash,
+      expectedRecordingHash: previousHash ?? undefined,
+      failureReason: 'Manifest recording hash does not match the event chain.',
+    };
+  }
+
+  return {
+    algorithm: 'sha256',
+    status: 'verified',
+    valid: true,
+    eventCount: events.length,
+    verifiedEventCount: events.length,
+    recordingHash: manifest.recordingHash ?? previousHash ?? undefined,
+    expectedRecordingHash: previousHash ?? undefined,
+  };
+}
+
+function createEventHash(
+  event: Omit<FlightRecorderEvent, 'eventHash'>,
+): string {
+  return createHash('sha256')
+    .update(stableStringify(dropJsonUndefined(event)))
+    .digest('hex');
+}
+
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(',')}]`;
+  }
+
+  if (isRecord(value)) {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`)
+      .join(',')}}`;
+  }
+
+  return JSON.stringify(value);
+}
+
+function dropJsonUndefined<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+async function copyProofPackArtifacts(
+  runDirectory: string,
+  exportDirectory: string,
+  events: FlightRecorderEvent[],
+): Promise<void> {
+  const artifacts = new Map<string, FlightRecorderArtifact>();
+  for (const event of events) {
+    for (const artifact of getEventArtifacts(event)) {
+      artifacts.set(artifact.relativePath, artifact);
+    }
+  }
+
+  await Promise.all(
+    [...artifacts.values()].map(async (artifact) => {
+      const sourcePath = resolveInside(runDirectory, artifact.relativePath);
+      const exportRelativePath = getProofPackArtifactPath(
+        artifact.relativePath,
+      );
+      const destinationPath = resolveInside(
+        exportDirectory,
+        exportRelativePath,
+      );
+      await mkdir(path.dirname(destinationPath), { recursive: true });
+      await copyFile(sourcePath, destinationPath);
+    }),
+  );
+}
+
+function getEventArtifacts(
+  event: FlightRecorderEvent,
+): FlightRecorderArtifact[] {
+  return [event.payload.screenshot, event.payload.somScreenshot].filter(
+    isArtifact,
+  );
+}
+
+function getProofPackArtifactPath(relativePath: string): string {
+  return path.join('artifacts', relativePath);
+}
+
+function getProofPackArtifactUrl(relativePath: string): string {
+  return getProofPackArtifactPath(relativePath).split(path.sep).join('/');
+}
+
+function stripPreviewData(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(stripPreviewData);
+  }
+
+  if (isRecord(value)) {
+    return Object.fromEntries(
+      Object.entries(value)
+        .filter(([, entryValue]) => entryValue !== undefined)
+        .filter(([key]) => key !== 'dataUrl')
+        .map(([key, entryValue]) => [key, stripPreviewData(entryValue)]),
+    );
+  }
+
+  return value;
+}
+
+function createWorkflowCapsule(
+  detail: FlightRecorderRunDetail,
+  generatedAt: string,
+): WorkflowCapsule {
+  let lastConversation: FlightRecorderEvent | undefined;
+  const steps: WorkflowCapsuleStep[] = [];
+
+  for (const event of detail.events) {
+    if (event.type === 'conversation_added') {
+      lastConversation = event;
+      continue;
+    }
+
+    if (event.type !== 'action_planned') {
+      continue;
+    }
+
+    const stepNumber = steps.length + 1;
+    steps.push({
+      id: `step_${String(stepNumber).padStart(3, '0')}`,
+      sourceEventId: event.id,
+      sourceSequence: event.sequence,
+      sourceEventHash: event.eventHash,
+      actionType: readOptionalString(event.payload.actionType) ?? 'unknown',
+      actionInputs: event.payload.actionInputs,
+      thought: readOptionalString(event.payload.thought),
+      reflection: readOptionalString(event.payload.reflection),
+      sourceConversation: lastConversation
+        ? {
+            eventId: lastConversation.id,
+            sequence: lastConversation.sequence,
+            timestamp: lastConversation.timestamp,
+            from: readOptionalString(lastConversation.payload.from),
+            message: readOptionalString(lastConversation.payload.value),
+            screenshot: lastConversation.payload.screenshot,
+            somScreenshot: lastConversation.payload.somScreenshot,
+          }
+        : undefined,
+    });
+  }
+
+  return {
+    version: 1,
+    generatedAt,
+    status: 'draft',
+    sourceRun: {
+      runId: detail.runId,
+      mode: detail.mode,
+      instruction: detail.instruction,
+      operator: detail.operator,
+      modelName: detail.modelName,
+      modelProvider: detail.modelProvider,
+      startedAt: detail.startedAt,
+      finishedAt: detail.finishedAt,
+      recordingHash: detail.integrity.recordingHash,
+      integrity: detail.integrity,
+    },
+    stepCount: steps.length,
+    steps,
+  };
+}
+
+function createCompiledWorkflow(
+  detail: FlightRecorderRunDetail,
+  generatedAt: string,
+): CompiledWorkflow {
+  const capsule = createWorkflowCapsule(detail, generatedAt);
+  const workflowId = createWorkflowId(detail, capsule.steps);
+  const steps = capsule.steps.map((step, index) =>
+    compileWorkflowStep(step, index),
+  );
+
+  return {
+    version: 1,
+    kind: 'proofpilot.workflow',
+    workflowId,
+    name: createWorkflowName(detail.instruction),
+    generatedAt,
+    status: 'ready_for_simulation',
+    sourceRun: capsule.sourceRun,
+    inputs: [
+      {
+        key: 'task',
+        label: 'Task',
+        type: 'text',
+        required: true,
+        defaultValue: detail.instruction,
+      },
+    ],
+    guardrails: {
+      defaultRunMode: 'simulation',
+      requireIntegrityVerification: true,
+      requireApprovalForRiskyActions: true,
+      stopConditions: [
+        'Source integrity check fails before execution.',
+        'Screen state does not match the expected workflow context.',
+        'A risky action is denied or left unapproved.',
+        'The agent requests human input.',
+      ],
+    },
+    stepCount: steps.length,
+    steps,
+  };
+}
+
+function compileWorkflowStep(
+  step: WorkflowCapsuleStep,
+  index: number,
+): CompiledWorkflowStep {
+  const actionType = step.actionType || 'unknown';
+  return {
+    id: step.id,
+    order: index + 1,
+    title: createStepTitle(actionType, index + 1),
+    instruction:
+      step.thought ||
+      step.sourceConversation?.message ||
+      `Perform ${actionType}.`,
+    actionType,
+    actionInputs: step.actionInputs,
+    requiresApproval: isRiskyWorkflowAction(actionType, step.actionInputs),
+    retryPolicy: {
+      maxAttempts: 1,
+      onFailure: 'request_human_review',
+    },
+    evidence: {
+      sourceEventId: step.sourceEventId,
+      sourceSequence: step.sourceSequence,
+      sourceEventHash: step.sourceEventHash,
+      screenshot: step.sourceConversation?.screenshot,
+      somScreenshot: step.sourceConversation?.somScreenshot,
+    },
+  };
+}
+
+function renderCompiledWorkflowMarkdown(workflow: CompiledWorkflow): string {
+  const stepsMarkdown = workflow.steps
+    .map((step) =>
+      [
+        `## ${step.order}. ${step.title}`,
+        '',
+        `- Instruction: ${step.instruction}`,
+        `- Action: ${step.actionType}`,
+        `- Approval required: ${step.requiresApproval ? 'yes' : 'no'}`,
+        `- Source event: ${step.evidence.sourceSequence}`,
+        step.evidence.sourceEventHash
+          ? `- Event hash: ${step.evidence.sourceEventHash}`
+          : undefined,
+        '- Inputs:',
+        codeFence(formatUnknown(step.actionInputs) ?? '{}', 'json'),
+      ]
+        .filter(isDefined)
+        .join('\n'),
+    )
+    .join('\n\n');
+
+  return [
+    `# ${workflow.name}`,
+    '',
+    `Workflow ID: ${workflow.workflowId}`,
+    `Generated: ${workflow.generatedAt}`,
+    `Source run: ${workflow.sourceRun.runId}`,
+    `Integrity: ${workflow.sourceRun.integrity.status}`,
+    '',
+    '## Guardrails',
+    '',
+    `- Default run mode: ${workflow.guardrails.defaultRunMode}`,
+    `- Integrity verification: ${workflow.guardrails.requireIntegrityVerification ? 'required' : 'optional'}`,
+    `- Approval for risky actions: ${workflow.guardrails.requireApprovalForRiskyActions ? 'required' : 'optional'}`,
+    ...workflow.guardrails.stopConditions.map((condition) => `- ${condition}`),
+    '',
+    stepsMarkdown || 'No executable steps were found in this run.',
+    '',
+  ].join('\n');
+}
+
+function createWorkflowId(
+  detail: FlightRecorderRunDetail,
+  steps: WorkflowCapsuleStep[],
+): string {
+  return createHash('sha256')
+    .update(
+      stableStringify({
+        runId: detail.runId,
+        recordingHash: detail.integrity.recordingHash,
+        steps: steps.map((step) => step.sourceEventHash ?? step.sourceEventId),
+      }),
+    )
+    .digest('hex')
+    .slice(0, 16);
+}
+
+function createWorkflowName(instruction: string): string {
+  const normalized = instruction.trim().replace(/\s+/g, ' ');
+  if (!normalized) {
+    return 'Untitled workflow';
+  }
+
+  return normalized.length > 80
+    ? `${normalized.slice(0, 77).trimEnd()}...`
+    : normalized;
+}
+
+function createStepTitle(actionType: string, order: number): string {
+  const label = actionType.replace(/_/g, ' ');
+  return `Step ${order}: ${label}`;
+}
+
+function isRiskyWorkflowAction(actionType: string, inputs: unknown): boolean {
+  const action = actionType.toLowerCase();
+  const serializedInputs = formatUnknown(inputs)?.toLowerCase() ?? '';
+
+  return (
+    action.includes('click') ||
+    action.includes('drag') ||
+    action.includes('type') ||
+    action.includes('key') ||
+    serializedInputs.includes('delete') ||
+    serializedInputs.includes('submit') ||
+    serializedInputs.includes('send') ||
+    serializedInputs.includes('pay') ||
+    serializedInputs.includes('purchase')
+  );
+}
+
+function codeFence(value: string, language: string): string {
+  return `\`\`\`${language}\n${value}\n\`\`\``;
+}
+
+function renderProofPackHtml(
+  detail: FlightRecorderRunDetail,
+  generatedAt: string,
+): string {
+  const eventsHtml = detail.events.map(renderProofPackEventHtml).join('\n');
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>ProofPilot Proof Pack - ${escapeHtml(detail.runId)}</title>
+  <style>
+    :root { color-scheme: light; font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: #111827; background: #f8fafc; }
+    body { margin: 0; }
+    main { max-width: 1120px; margin: 0 auto; padding: 32px 24px 56px; }
+    header { border: 1px solid #e5e7eb; background: #ffffff; border-radius: 8px; padding: 24px; }
+    h1 { margin: 0; font-size: 24px; line-height: 1.25; }
+    h2 { margin: 0 0 12px; font-size: 16px; }
+    .muted { color: #64748b; }
+    .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 12px; margin-top: 20px; }
+    .metric { border: 1px solid #e5e7eb; border-radius: 8px; padding: 12px; background: #f8fafc; }
+    .metric span { display: block; font-size: 12px; color: #64748b; margin-bottom: 6px; }
+    .metric strong { font-size: 14px; overflow-wrap: anywhere; }
+    .badge { display: inline-flex; align-items: center; border-radius: 999px; border: 1px solid #d1d5db; padding: 4px 10px; font-size: 12px; font-weight: 600; }
+    .badge.verified { color: #047857; background: #ecfdf5; border-color: #a7f3d0; }
+    .badge.failed { color: #b91c1c; background: #fef2f2; border-color: #fecaca; }
+    .badge.legacy { color: #92400e; background: #fffbeb; border-color: #fde68a; }
+    .timeline { margin-top: 20px; display: grid; gap: 14px; }
+    .event { border: 1px solid #e5e7eb; background: #ffffff; border-radius: 8px; padding: 18px; }
+    .event-title { display: flex; justify-content: space-between; gap: 16px; align-items: baseline; margin-bottom: 12px; }
+    .rows { display: grid; gap: 8px; }
+    .row { display: grid; grid-template-columns: 132px minmax(0, 1fr); gap: 12px; font-size: 14px; }
+    .row-label { color: #64748b; font-size: 12px; text-transform: uppercase; }
+    .row-value { white-space: pre-wrap; overflow-wrap: anywhere; }
+    .hash { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace; font-size: 12px; }
+    .artifacts { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 12px; margin-top: 14px; }
+    figure { margin: 0; }
+    figcaption { font-size: 12px; color: #64748b; margin-bottom: 6px; }
+    img { max-width: 100%; max-height: 360px; object-fit: contain; background: #020617; border: 1px solid #e5e7eb; border-radius: 8px; }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <div class="event-title">
+        <div>
+          <h1>${escapeHtml(detail.instruction || 'Untitled run')}</h1>
+          <div class="muted">${escapeHtml(detail.mode)} | ${escapeHtml(detail.operator)} | ${escapeHtml(detail.status)} | ${escapeHtml(detail.runId)}</div>
+        </div>
+        ${renderIntegrityBadge(detail.integrity)}
+      </div>
+      <div class="grid">
+        <div class="metric"><span>Started</span><strong>${escapeHtml(detail.startedAt)}</strong></div>
+        <div class="metric"><span>Finished</span><strong>${escapeHtml(detail.finishedAt ?? 'Not finished')}</strong></div>
+        <div class="metric"><span>Generated</span><strong>${escapeHtml(generatedAt)}</strong></div>
+        <div class="metric"><span>Mode</span><strong>${escapeHtml(detail.mode)}</strong></div>
+        <div class="metric"><span>Events</span><strong>${detail.eventCount}</strong></div>
+        <div class="metric"><span>Artifacts</span><strong>${detail.artifactCount}</strong></div>
+        <div class="metric"><span>Recording Hash</span><strong class="hash">${escapeHtml(detail.integrity.recordingHash ?? 'Unavailable')}</strong></div>
+      </div>
+    </header>
+    <section class="timeline">
+      ${eventsHtml}
+    </section>
+  </main>
+</body>
+</html>
+`;
+}
+
+function renderProofPackEventHtml(event: FlightRecorderEvent): string {
+  const rows = getProofPackRows(event)
+    .map(
+      ([label, value]) => `<div class="row">
+        <div class="row-label">${escapeHtml(label)}</div>
+        <div class="row-value${label.includes('Hash') ? ' hash' : ''}">${escapeHtml(value)}</div>
+      </div>`,
+    )
+    .join('\n');
+  const artifacts = getEventArtifacts(event);
+  const artifactsHtml = artifacts.length
+    ? `<div class="artifacts">${artifacts
+        .map(
+          (artifact) => `<figure>
+            <figcaption>${escapeHtml(artifact.kind)} | ${escapeHtml(artifact.relativePath)}</figcaption>
+            <img src="${escapeHtml(getProofPackArtifactUrl(artifact.relativePath))}" alt="${escapeHtml(artifact.kind)}" />
+          </figure>`,
+        )
+        .join('\n')}</div>`
+    : '';
+
+  return `<article class="event">
+    <div class="event-title">
+      <h2>${escapeHtml(getEventTitle(event.type))}</h2>
+      <div class="muted">${escapeHtml(event.timestamp)}</div>
+    </div>
+    <div class="rows">${rows}</div>
+    ${artifactsHtml}
+  </article>`;
+}
+
+function getProofPackRows(event: FlightRecorderEvent): Array<[string, string]> {
+  const payload = event.payload;
+  const rows: Array<[string, string | undefined]> = [
+    ['Sequence', String(event.sequence)],
+    ['Event Hash', event.eventHash],
+    ['Previous Hash', event.previousHash ?? 'Start of chain'],
+  ];
+
+  switch (event.type) {
+    case 'run_started':
+      rows.push(
+        ['Instruction', readOptionalString(payload.instruction)],
+        ['Mode', readOptionalString(payload.mode)],
+        ['Operator', readOptionalString(payload.operator)],
+        ['Model', joinOptionalParts(payload.modelProvider, payload.modelName)],
+      );
+      break;
+    case 'status_changed':
+    case 'run_finished':
+      rows.push(['Status', readOptionalString(payload.status)]);
+      break;
+    case 'conversation_added':
+      rows.push(
+        ['From', readOptionalString(payload.from)],
+        ['Message', readOptionalString(payload.value)],
+        ['Timing', formatUnknown(payload.timing)],
+        ['Action Count', readOptionalString(payload.actionCount)],
+      );
+      break;
+    case 'action_planned':
+    case 'simulation_action_skipped':
+      rows.push(
+        ['Action', readOptionalString(payload.actionType)],
+        ['Thought', readOptionalString(payload.thought)],
+        ['Reflection', readOptionalString(payload.reflection)],
+        ['Inputs', formatUnknown(payload.actionInputs)],
+      );
+      break;
+    case 'run_error':
+      rows.push(['Error', formatUnknown(payload.error)]);
+      break;
+  }
+
+  return rows
+    .filter(([, value]) => value !== undefined && value !== '')
+    .map(([label, value]) => [label, value ?? '']);
+}
+
+function getEventTitle(type: FlightRecorderEventType): string {
+  switch (type) {
+    case 'run_started':
+      return 'Run started';
+    case 'status_changed':
+      return 'Status changed';
+    case 'conversation_added':
+      return 'Conversation captured';
+    case 'action_planned':
+      return 'Action planned';
+    case 'simulation_action_skipped':
+      return 'Simulation action skipped';
+    case 'run_error':
+      return 'Run error';
+    case 'run_finished':
+      return 'Run finished';
+  }
+}
+
+function renderIntegrityBadge(integrity: FlightRecorderIntegrity): string {
+  const label =
+    integrity.status === 'verified'
+      ? 'Verified'
+      : integrity.status === 'legacy'
+        ? 'Legacy'
+        : 'Failed';
+  return `<span class="badge ${integrity.status}">${label}</span>`;
+}
+
+function readOptionalString(value: unknown): string | undefined {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+
+  return String(value);
+}
+
+function joinOptionalParts(...values: unknown[]): string | undefined {
+  const parts = values.map(readOptionalString).filter(Boolean);
+  return parts.length ? parts.join(' / ') : undefined;
+}
+
+function formatUnknown(value: unknown): string | undefined {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  return JSON.stringify(value, null, 2);
+}
+
+function escapeHtml(value: unknown): string {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function resolveInside(root: string, ...segments: string[]): string {
+  const rootPath = path.resolve(root);
+  const resolvedPath = path.resolve(rootPath, ...segments);
+  if (
+    resolvedPath !== rootPath &&
+    !resolvedPath.startsWith(`${rootPath}${path.sep}`)
+  ) {
+    throw new Error('Path escapes ProofPilot storage root');
+  }
+
+  return resolvedPath;
+}
+
+function isArtifact(value: unknown): value is FlightRecorderArtifact {
+  return (
+    isRecord(value) &&
+    typeof value.id === 'string' &&
+    typeof value.relativePath === 'string' &&
+    typeof value.mime === 'string'
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isDefined<T>(value: T | null | undefined): value is T {
+  return value !== null && value !== undefined;
+}
+
+function isNodeError(error: unknown): error is Error & { code?: string } {
+  return error instanceof Error && 'code' in error;
+}
+
+function serializeError(error: unknown): Record<string, unknown> {
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+      stack: error.stack,
+    };
+  }
+
+  return { message: String(error) };
+}
+
+export { FlightRecorder, FlightRecording };
+export type {
+  CompiledWorkflow,
+  CompiledWorkflowExport,
+  CompiledWorkflowInput,
+  CompiledWorkflowStep,
+  FlightRecorderArtifact,
+  FlightRecorderArtifactPreview,
+  FlightRecorderEvent,
+  FlightRecorderIntegrity,
+  FlightRecorderManifest,
+  FlightRecorderRunContext,
+  FlightRecorderRunDetail,
+  FlightRecorderRunMode,
+  FlightRecorderRunSummary,
+  ProofPackExport,
+  WorkflowCapsule,
+  WorkflowCapsuleExport,
+  WorkflowCapsuleStep,
+};

--- a/apps/ui-tars/src/main/services/runAgent.ts
+++ b/apps/ui-tars/src/main/services/runAgent.ts
@@ -35,6 +35,8 @@ import { FREE_MODEL_BASE_URL } from '../remote/shared';
 import { getAuthHeader } from '../remote/auth';
 import { ProxyClient } from '../remote/proxyClient';
 import { UITarsModelConfig } from '@ui-tars/sdk/core';
+import { FlightRecorder, type FlightRecording } from './flightRecorder';
+import { createSimulationOperator } from './simulationOperator';
 
 export const runAgent = async (
   setState: (state: AppState) => void,
@@ -44,6 +46,20 @@ export const runAgent = async (
   const settings = SettingStore.getStore();
   const { instructions, abortController } = getState();
   assert(instructions, 'instructions is required');
+  const activeSessionId = getState().activeSessionId;
+  const runMode = getState().runMode;
+  const isSimulation = runMode === 'simulation';
+  let flightRecording: FlightRecording | null = null;
+
+  const recordFlight = async (
+    operation: () => Promise<void> | undefined,
+  ): Promise<void> => {
+    try {
+      await operation();
+    } catch (error) {
+      logger.warn('[FlightRecorder] failed to record event', error);
+    }
+  };
 
   const language = settings.language ?? 'en';
 
@@ -109,6 +125,13 @@ export const runAgent = async (
     ) {
       showPredictionMarker(predictionParsed, screenshotContext);
     }
+
+    await recordFlight(() =>
+      flightRecording?.recordAgentData({
+        ...data,
+        conversations: conversationsWithSoM,
+      }),
+    );
 
     setState({
       ...getState(),
@@ -193,10 +216,44 @@ export const runAgent = async (
     language,
     operatorType,
   );
+  const effectiveSystemPrompt = isSimulation
+    ? `${systemPrompt}\n\nSimulation mode is active. Plan the workflow normally, but no UI action will be executed and the screen may not change. Stop once the planned workflow is sufficiently represented.`
+    : systemPrompt;
+  const maxLoopCount = isSimulation
+    ? Math.min(settings.maxLoopCount ?? 25, 5)
+    : settings.maxLoopCount;
+
+  try {
+    flightRecording = await FlightRecorder.getInstance().startRun({
+      sessionId: activeSessionId,
+      mode: runMode,
+      instruction: instructions,
+      operator: settings.operator,
+      modelName: modelConfig.model,
+      modelProvider: modelVersion ?? settings.vlmProvider,
+    });
+    logger.info(
+      '[FlightRecorder] started',
+      flightRecording.runId,
+      flightRecording.directory,
+    );
+  } catch (error) {
+    logger.warn('[FlightRecorder] failed to start recording', error);
+  }
+
+  if (isSimulation) {
+    operator = createSimulationOperator(
+      operator!,
+      async ({ parsedPrediction }) =>
+        recordFlight(() =>
+          flightRecording?.recordSimulationActionSkipped(parsedPrediction),
+        ),
+    );
+  }
 
   const guiAgent = new GUIAgent({
     model: modelConfig,
-    systemPrompt: systemPrompt,
+    systemPrompt: effectiveSystemPrompt,
     logger,
     signal: abortController?.signal,
     operator: operator!,
@@ -204,6 +261,7 @@ export const runAgent = async (
     onError: (params) => {
       const { error } = params;
       logger.error('[onGUIAgentError]', settings, error);
+      void recordFlight(() => flightRecording?.recordError(error));
       setState({
         ...getState(),
         status: StatusEnum.ERROR,
@@ -225,7 +283,7 @@ export const runAgent = async (
         maxRetries: 1,
       },
     },
-    maxLoopCount: settings.maxLoopCount,
+    maxLoopCount,
     loopIntervalInMs: settings.loopIntervalInMs,
     uiTarsVersion: modelVersion,
   });
@@ -239,18 +297,27 @@ export const runAgent = async (
 
   const startTime = Date.now();
 
-  await guiAgent
-    .run(instructions, sessionHistoryMessages, modelAuthHdrs)
-    .catch((e) => {
-      logger.error('[runAgentLoop error]', e);
-      setState({
-        ...getState(),
-        status: StatusEnum.ERROR,
-        errorMsg: e.message,
+  try {
+    await guiAgent
+      .run(instructions, sessionHistoryMessages, modelAuthHdrs)
+      .catch((e) => {
+        logger.error('[runAgentLoop error]', e);
+        void recordFlight(() => flightRecording?.recordError(e));
+        setState({
+          ...getState(),
+          status: StatusEnum.ERROR,
+          errorMsg: e.message,
+        });
       });
-    });
+  } finally {
+    await recordFlight(() => flightRecording?.finish(getState().status));
 
-  logger.info('[runAgent Totoal cost]: ', (Date.now() - startTime) / 1000, 's');
+    logger.info(
+      '[runAgent Totoal cost]: ',
+      (Date.now() - startTime) / 1000,
+      's',
+    );
 
-  afterAgentRun(settings.operator);
+    afterAgentRun(settings.operator);
+  }
 };

--- a/apps/ui-tars/src/main/services/simulationOperator.test.ts
+++ b/apps/ui-tars/src/main/services/simulationOperator.test.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { StatusEnum, type ExecuteParams } from '@ui-tars/sdk/core';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createSimulationOperator,
+  isSimulationTerminalAction,
+} from './simulationOperator';
+
+describe('simulationOperator', () => {
+  it('records and skips non-terminal actions without calling the real operator', async () => {
+    const execute = vi.fn(async (_params: ExecuteParams) => ({
+      status: StatusEnum.END,
+    }));
+    const onSimulatedAction = vi.fn();
+    const operator = createSimulationOperator({ execute }, onSimulatedAction);
+
+    const result = await operator.execute(
+      createExecuteParams({
+        action_type: 'left_click',
+        action_inputs: {
+          start_box: '[10,20,30,40]',
+        },
+        reflection: null,
+        thought: 'Click export.',
+      }),
+    );
+
+    expect(execute).not.toHaveBeenCalled();
+    expect(onSimulatedAction).toHaveBeenCalledOnce();
+    expect(result).toMatchObject({
+      status: StatusEnum.RUNNING,
+      simulated: true,
+      actionType: 'left_click',
+      actionInputs: {
+        start_box: '[10,20,30,40]',
+      },
+    });
+  });
+
+  it('ends simulated terminal actions without calling the real operator', async () => {
+    const execute = vi.fn(async (_params: ExecuteParams) => ({
+      status: StatusEnum.ERROR,
+    }));
+    const operator = createSimulationOperator({ execute });
+
+    const result = await operator.execute(
+      createExecuteParams({
+        action_type: 'finished',
+        action_inputs: {
+          content: 'Done',
+        },
+        reflection: null,
+        thought: 'Task is complete.',
+      }),
+    );
+
+    expect(execute).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      status: StatusEnum.END,
+      simulated: true,
+      actionType: 'finished',
+    });
+    expect(isSimulationTerminalAction('call_user')).toBe(true);
+    expect(isSimulationTerminalAction('left_click')).toBe(false);
+  });
+});
+
+function createExecuteParams(
+  parsedPrediction: ExecuteParams['parsedPrediction'],
+): ExecuteParams {
+  return {
+    prediction: '',
+    parsedPrediction,
+    screenWidth: 1280,
+    screenHeight: 720,
+    scaleFactor: 1,
+    factors: [1, 1],
+  };
+}

--- a/apps/ui-tars/src/main/services/simulationOperator.ts
+++ b/apps/ui-tars/src/main/services/simulationOperator.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {
+  StatusEnum,
+  type ExecuteOutput,
+  type ExecuteParams,
+} from '@ui-tars/sdk/core';
+
+type ExecutableOperator = {
+  execute(params: ExecuteParams): Promise<ExecuteOutput>;
+};
+
+type SimulatedActionHandler = (params: ExecuteParams) => Promise<void> | void;
+
+const TERMINAL_ACTION_TYPES = new Set([
+  'finished',
+  'call_user',
+  'error_env',
+  'user_stop',
+]);
+
+function createSimulationOperator<T extends ExecutableOperator>(
+  operator: T,
+  onSimulatedAction: SimulatedActionHandler = () => undefined,
+): T {
+  operator.execute = async (params) => {
+    await onSimulatedAction(params);
+
+    const actionType = params.parsedPrediction.action_type;
+    return {
+      status: isSimulationTerminalAction(actionType)
+        ? StatusEnum.END
+        : StatusEnum.RUNNING,
+      simulated: true,
+      actionType,
+      actionInputs: params.parsedPrediction.action_inputs,
+    };
+  };
+
+  return operator;
+}
+
+function isSimulationTerminalAction(actionType: string): boolean {
+  return TERMINAL_ACTION_TYPES.has(actionType);
+}
+
+export { createSimulationOperator, isSimulationTerminalAction };

--- a/apps/ui-tars/src/main/services/teamWorkspace.test.ts
+++ b/apps/ui-tars/src/main/services/teamWorkspace.test.ts
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { mkdtemp, readFile, stat } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { StatusEnum } from '@ui-tars/shared/types';
+import { Operator } from '@main/store/types';
+import { describe, expect, it } from 'vitest';
+
+import { TeamWorkspaceStore } from './teamWorkspace';
+import type { ApprovalQueueSnapshot } from './approvalQueue';
+import type { FlightRecorderRunSummary } from './flightRecorder';
+
+describe('TeamWorkspaceStore', () => {
+  it('persists workspace settings and members', async () => {
+    const storageRoot = await mkdtemp(
+      path.join(os.tmpdir(), 'proofpilot-team-'),
+    );
+    const store = new TeamWorkspaceStore({
+      storageRoot,
+      now: () => new Date('2026-05-27T00:00:00.000Z'),
+      idFactory: () => 'member-1',
+    });
+
+    const initial = await store.getWorkspace();
+    expect(initial).toMatchObject({
+      workspaceName: 'ProofPilot Workspace',
+      plan: 'solo',
+      policies: {
+        defaultRunMode: 'simulation',
+        proofPackRequired: true,
+      },
+    });
+
+    const updated = await store.updateWorkspace({
+      workspaceName: 'Launch Ops',
+      plan: 'team',
+      seatLimit: 4,
+      policies: {
+        retentionDays: 180,
+        approvalRequiredFor: 'all_live_runs',
+      },
+    });
+    expect(updated).toMatchObject({
+      workspaceName: 'Launch Ops',
+      plan: 'team',
+      seatLimit: 4,
+      policies: {
+        retentionDays: 180,
+        approvalRequiredFor: 'all_live_runs',
+      },
+    });
+
+    const withMember = await store.upsertMember({
+      name: 'Reviewer',
+      email: 'reviewer@example.com',
+      role: 'viewer',
+    });
+    expect(withMember.members).toHaveLength(2);
+    expect(withMember.members[1]).toMatchObject({
+      id: 'member-1',
+      status: 'invited',
+    });
+
+    await expect(store.removeMember('owner-local')).rejects.toThrow(
+      'The workspace owner cannot be removed',
+    );
+
+    const persisted = JSON.parse(
+      await readFile(path.join(storageRoot, 'workspace.json'), 'utf8'),
+    );
+    expect(persisted.workspaceName).toBe('Launch Ops');
+  });
+
+  it('exports a commercial audit report', async () => {
+    const storageRoot = await mkdtemp(
+      path.join(os.tmpdir(), 'proofpilot-team-'),
+    );
+    const store = new TeamWorkspaceStore({
+      storageRoot,
+      now: () => new Date('2026-05-27T00:00:00.000Z'),
+      idFactory: () => 'member-1',
+    });
+    await store.updateWorkspace({
+      workspaceName: 'Launch Ops',
+    });
+
+    const exportResult = await store.exportAuditReport({
+      runs: [createRunSummary('run-1', 'simulation')],
+      approvals: createApprovalSnapshot(),
+    });
+    const json = JSON.parse(await readFile(exportResult.jsonPath, 'utf8'));
+    const html = await readFile(exportResult.htmlPath, 'utf8');
+
+    expect(exportResult.reportId).toMatch(/^[a-f0-9]{16}$/);
+    expect(json).toMatchObject({
+      version: 1,
+      workspace: {
+        workspaceName: 'Launch Ops',
+      },
+      metrics: {
+        totalRuns: 1,
+        simulationRuns: 1,
+        pendingApprovals: 1,
+      },
+    });
+    expect(exportResult.readiness.some((item) => item.status === 'ready')).toBe(
+      true,
+    );
+    expect(html).toContain('Team audit report');
+    await expect(stat(exportResult.htmlPath)).resolves.toBeTruthy();
+  });
+});
+
+function createRunSummary(
+  runId: string,
+  mode: FlightRecorderRunSummary['mode'],
+): FlightRecorderRunSummary {
+  return {
+    version: 1,
+    runId,
+    mode,
+    instruction: 'Compile the workflow',
+    operator: Operator.LocalBrowser,
+    startedAt: '2026-05-27T00:00:00.000Z',
+    updatedAt: '2026-05-27T00:00:00.000Z',
+    finishedAt: '2026-05-27T00:01:00.000Z',
+    status: StatusEnum.END,
+    eventCount: 3,
+    artifactCount: 1,
+    integrityAlgorithm: 'sha256',
+    recordingHash: 'hash',
+    storagePath: '/tmp/run-1',
+  };
+}
+
+function createApprovalSnapshot(): ApprovalQueueSnapshot {
+  return {
+    requests: [],
+    counts: {
+      pending: 1,
+      approved: 2,
+      denied: 0,
+    },
+  };
+}

--- a/apps/ui-tars/src/main/services/teamWorkspace.ts
+++ b/apps/ui-tars/src/main/services/teamWorkspace.ts
@@ -1,0 +1,608 @@
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { createHash, randomUUID } from 'node:crypto';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+
+import type { ApprovalQueueSnapshot } from './approvalQueue';
+import type { FlightRecorderRunSummary } from './flightRecorder';
+
+const require = createRequire(import.meta.url);
+
+type TeamPlan = 'solo' | 'team' | 'business';
+type TeamMemberRole = 'owner' | 'admin' | 'operator' | 'viewer';
+type TeamMemberStatus = 'active' | 'invited';
+type ReadinessStatus = 'ready' | 'needs_attention';
+
+type TeamPolicies = {
+  defaultRunMode: 'simulation' | 'live';
+  approvalRequiredFor: 'none' | 'high_risk' | 'all_live_runs';
+  retentionDays: number;
+  proofPackRequired: boolean;
+  auditExportsEnabled: boolean;
+  allowLiveRuns: boolean;
+};
+
+type TeamMember = {
+  id: string;
+  name: string;
+  email: string;
+  role: TeamMemberRole;
+  status: TeamMemberStatus;
+  joinedAt: string;
+};
+
+type TeamWorkspace = {
+  version: 1;
+  workspaceName: string;
+  plan: TeamPlan;
+  seatLimit: number;
+  members: TeamMember[];
+  policies: TeamPolicies;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type TeamWorkspaceUpdate = Partial<
+  Pick<TeamWorkspace, 'workspaceName' | 'plan' | 'seatLimit'>
+> & {
+  policies?: Partial<TeamPolicies>;
+};
+
+type TeamMemberInput = {
+  id?: string;
+  name: string;
+  email: string;
+  role: TeamMemberRole;
+  status?: TeamMemberStatus;
+};
+
+type TeamAuditReadinessItem = {
+  id: string;
+  label: string;
+  status: ReadinessStatus;
+  detail: string;
+};
+
+type TeamAuditReport = {
+  version: 1;
+  reportId: string;
+  generatedAt: string;
+  workspace: TeamWorkspace;
+  metrics: {
+    totalRuns: number;
+    liveRuns: number;
+    simulationRuns: number;
+    verifiedRuns: number;
+    failedIntegrityRuns: number;
+    pendingApprovals: number;
+    approvedRequests: number;
+    deniedRequests: number;
+  };
+  readiness: TeamAuditReadinessItem[];
+  recentRuns: Array<{
+    runId: string;
+    mode: string;
+    status: string;
+    startedAt: string;
+    eventCount: number;
+    artifactCount: number;
+  }>;
+};
+
+type TeamAuditExport = {
+  reportId: string;
+  auditDirectory: string;
+  jsonPath: string;
+  htmlPath: string;
+  generatedAt: string;
+  readiness: TeamAuditReadinessItem[];
+};
+
+type TeamAuditInput = {
+  runs: FlightRecorderRunSummary[];
+  approvals: ApprovalQueueSnapshot;
+};
+
+type TeamWorkspaceOptions = {
+  storageRoot?: string;
+  now?: () => Date;
+  idFactory?: () => string;
+};
+
+class TeamWorkspaceStore {
+  private static instance?: TeamWorkspaceStore;
+
+  private readonly storageRoot: string;
+  private readonly workspacePath: string;
+  private readonly now: () => Date;
+  private readonly idFactory: () => string;
+  private workspace?: TeamWorkspace;
+
+  constructor(options: TeamWorkspaceOptions = {}) {
+    this.storageRoot = options.storageRoot ?? getDefaultStorageRoot();
+    this.workspacePath = path.join(this.storageRoot, 'workspace.json');
+    this.now = options.now ?? (() => new Date());
+    this.idFactory = options.idFactory ?? (() => randomUUID());
+  }
+
+  static getInstance(): TeamWorkspaceStore {
+    if (!TeamWorkspaceStore.instance) {
+      TeamWorkspaceStore.instance = new TeamWorkspaceStore();
+    }
+    return TeamWorkspaceStore.instance;
+  }
+
+  async getWorkspace(): Promise<TeamWorkspace> {
+    return this.loadWorkspace();
+  }
+
+  async updateWorkspace(input: TeamWorkspaceUpdate): Promise<TeamWorkspace> {
+    const workspace = await this.loadWorkspace();
+    const updated: TeamWorkspace = {
+      ...workspace,
+      workspaceName: input.workspaceName?.trim() || workspace.workspaceName,
+      plan: input.plan ?? workspace.plan,
+      seatLimit: normalizeSeatLimit(input.seatLimit, workspace.seatLimit),
+      policies: {
+        ...workspace.policies,
+        ...input.policies,
+        retentionDays: normalizeRetentionDays(
+          input.policies?.retentionDays,
+          workspace.policies.retentionDays,
+        ),
+      },
+      updatedAt: this.now().toISOString(),
+    };
+
+    this.workspace = updated;
+    await this.persistWorkspace(updated);
+    return updated;
+  }
+
+  async upsertMember(input: TeamMemberInput): Promise<TeamWorkspace> {
+    const workspace = await this.loadWorkspace();
+    const now = this.now().toISOString();
+    const member: TeamMember = {
+      id: input.id ?? this.idFactory(),
+      name: input.name.trim(),
+      email: input.email.trim(),
+      role: input.role,
+      status: input.status ?? 'invited',
+      joinedAt:
+        workspace.members.find((item) => item.id === input.id)?.joinedAt ?? now,
+    };
+
+    if (!member.name || !member.email) {
+      throw new Error('Team member name and email are required');
+    }
+
+    const members = workspace.members.some((item) => item.id === member.id)
+      ? workspace.members.map((item) => (item.id === member.id ? member : item))
+      : [...workspace.members, member];
+
+    const updated: TeamWorkspace = {
+      ...workspace,
+      members,
+      updatedAt: now,
+    };
+    this.workspace = updated;
+    await this.persistWorkspace(updated);
+    return updated;
+  }
+
+  async removeMember(memberId: string): Promise<TeamWorkspace> {
+    const workspace = await this.loadWorkspace();
+    const member = workspace.members.find((item) => item.id === memberId);
+    if (!member) {
+      return workspace;
+    }
+    if (member.role === 'owner') {
+      throw new Error('The workspace owner cannot be removed');
+    }
+
+    const updated: TeamWorkspace = {
+      ...workspace,
+      members: workspace.members.filter((item) => item.id !== memberId),
+      updatedAt: this.now().toISOString(),
+    };
+    this.workspace = updated;
+    await this.persistWorkspace(updated);
+    return updated;
+  }
+
+  async exportAuditReport(input: TeamAuditInput): Promise<TeamAuditExport> {
+    const workspace = await this.loadWorkspace();
+    const generatedAt = this.now().toISOString();
+    const report = createAuditReport(workspace, input, generatedAt);
+    const auditDirectory = path.join(
+      this.storageRoot,
+      'audit-reports',
+      report.reportId,
+    );
+    const jsonPath = path.join(auditDirectory, 'team-audit.json');
+    const htmlPath = path.join(auditDirectory, 'team-audit.html');
+
+    await mkdir(auditDirectory, { recursive: true });
+    await writeFile(jsonPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+    await writeFile(htmlPath, renderAuditReportHtml(report), 'utf8');
+
+    return {
+      reportId: report.reportId,
+      auditDirectory,
+      jsonPath,
+      htmlPath,
+      generatedAt,
+      readiness: report.readiness,
+    };
+  }
+
+  private async loadWorkspace(): Promise<TeamWorkspace> {
+    if (this.workspace) {
+      return this.workspace;
+    }
+
+    try {
+      const json = await readFile(this.workspacePath, 'utf8');
+      this.workspace = normalizeWorkspace(JSON.parse(json), this.now);
+      return this.workspace;
+    } catch (error) {
+      if (isNodeError(error) && error.code === 'ENOENT') {
+        this.workspace = createDefaultWorkspace(this.now().toISOString());
+        await this.persistWorkspace(this.workspace);
+        return this.workspace;
+      }
+
+      throw error;
+    }
+  }
+
+  private async persistWorkspace(workspace: TeamWorkspace): Promise<void> {
+    await mkdir(path.dirname(this.workspacePath), { recursive: true });
+    await writeFile(
+      this.workspacePath,
+      `${JSON.stringify(workspace, null, 2)}\n`,
+      'utf8',
+    );
+  }
+}
+
+function createDefaultWorkspace(now: string): TeamWorkspace {
+  return {
+    version: 1,
+    workspaceName: 'ProofPilot Workspace',
+    plan: 'solo',
+    seatLimit: 1,
+    members: [
+      {
+        id: 'owner-local',
+        name: 'Workspace Owner',
+        email: 'owner@local',
+        role: 'owner',
+        status: 'active',
+        joinedAt: now,
+      },
+    ],
+    policies: {
+      defaultRunMode: 'simulation',
+      approvalRequiredFor: 'high_risk',
+      retentionDays: 90,
+      proofPackRequired: true,
+      auditExportsEnabled: true,
+      allowLiveRuns: true,
+    },
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function normalizeWorkspace(value: unknown, now: () => Date): TeamWorkspace {
+  if (!isRecord(value)) {
+    return createDefaultWorkspace(now().toISOString());
+  }
+
+  const fallback = createDefaultWorkspace(now().toISOString());
+  return {
+    ...fallback,
+    ...value,
+    version: 1,
+    workspaceName:
+      typeof value.workspaceName === 'string'
+        ? value.workspaceName
+        : fallback.workspaceName,
+    plan: isTeamPlan(value.plan) ? value.plan : fallback.plan,
+    seatLimit: normalizeSeatLimit(value.seatLimit, fallback.seatLimit),
+    members: Array.isArray(value.members)
+      ? value.members.filter(isTeamMember)
+      : fallback.members,
+    policies: {
+      ...fallback.policies,
+      ...(isRecord(value.policies) ? value.policies : {}),
+      retentionDays: normalizeRetentionDays(
+        isRecord(value.policies) ? value.policies.retentionDays : undefined,
+        fallback.policies.retentionDays,
+      ),
+    },
+  };
+}
+
+function createAuditReport(
+  workspace: TeamWorkspace,
+  input: TeamAuditInput,
+  generatedAt: string,
+): TeamAuditReport {
+  const metrics = {
+    totalRuns: input.runs.length,
+    liveRuns: input.runs.filter((run) => run.mode === 'live').length,
+    simulationRuns: input.runs.filter((run) => run.mode === 'simulation')
+      .length,
+    verifiedRuns: input.runs.filter((run) => Boolean(run.recordingHash)).length,
+    failedIntegrityRuns: 0,
+    pendingApprovals: input.approvals.counts.pending,
+    approvedRequests: input.approvals.counts.approved,
+    deniedRequests: input.approvals.counts.denied,
+  };
+  const reportId = createHash('sha256')
+    .update(
+      JSON.stringify({
+        workspaceName: workspace.workspaceName,
+        generatedAt,
+        metrics,
+      }),
+    )
+    .digest('hex')
+    .slice(0, 16);
+
+  return {
+    version: 1,
+    reportId,
+    generatedAt,
+    workspace,
+    metrics,
+    readiness: createReadinessItems(workspace, metrics),
+    recentRuns: input.runs.slice(0, 10).map((run) => ({
+      runId: run.runId,
+      mode: run.mode,
+      status: run.status,
+      startedAt: run.startedAt,
+      eventCount: run.eventCount,
+      artifactCount: run.artifactCount,
+    })),
+  };
+}
+
+function createReadinessItems(
+  workspace: TeamWorkspace,
+  metrics: TeamAuditReport['metrics'],
+): TeamAuditReadinessItem[] {
+  return [
+    {
+      id: 'simulation-default',
+      label: 'Simulation default',
+      status:
+        workspace.policies.defaultRunMode === 'simulation'
+          ? 'ready'
+          : 'needs_attention',
+      detail:
+        workspace.policies.defaultRunMode === 'simulation'
+          ? 'New workflows default to simulation before live execution.'
+          : 'New workflows default to live execution.',
+    },
+    {
+      id: 'approval-policy',
+      label: 'Approval policy',
+      status:
+        workspace.policies.approvalRequiredFor === 'none'
+          ? 'needs_attention'
+          : 'ready',
+      detail: `Approval mode is ${workspace.policies.approvalRequiredFor}.`,
+    },
+    {
+      id: 'proof-pack-policy',
+      label: 'Proof pack policy',
+      status: workspace.policies.proofPackRequired
+        ? 'ready'
+        : 'needs_attention',
+      detail: workspace.policies.proofPackRequired
+        ? 'Proof packs are required for customer-facing workflows.'
+        : 'Proof packs are optional.',
+    },
+    {
+      id: 'audit-export',
+      label: 'Audit export',
+      status: workspace.policies.auditExportsEnabled
+        ? 'ready'
+        : 'needs_attention',
+      detail: workspace.policies.auditExportsEnabled
+        ? 'Audit exports are enabled.'
+        : 'Audit exports are disabled.',
+    },
+    {
+      id: 'team-roster',
+      label: 'Team roster',
+      status:
+        workspace.members.length <= workspace.seatLimit
+          ? 'ready'
+          : 'needs_attention',
+      detail: `${workspace.members.length} member(s) configured for ${workspace.seatLimit} seat(s).`,
+    },
+    {
+      id: 'run-evidence',
+      label: 'Run evidence',
+      status:
+        metrics.totalRuns === 0 || metrics.verifiedRuns > 0
+          ? 'ready'
+          : 'needs_attention',
+      detail:
+        metrics.totalRuns === 0
+          ? 'No runs have been recorded yet.'
+          : `${metrics.verifiedRuns} run(s) have tamper-evident hashes.`,
+    },
+  ];
+}
+
+function renderAuditReportHtml(report: TeamAuditReport): string {
+  const readinessRows = report.readiness
+    .map(
+      (item) => `<tr>
+        <td>${escapeHtml(item.label)}</td>
+        <td><span class="badge ${item.status}">${escapeHtml(item.status.replace('_', ' '))}</span></td>
+        <td>${escapeHtml(item.detail)}</td>
+      </tr>`,
+    )
+    .join('\n');
+  const runRows = report.recentRuns
+    .map(
+      (run) => `<tr>
+        <td class="hash">${escapeHtml(run.runId)}</td>
+        <td>${escapeHtml(run.mode)}</td>
+        <td>${escapeHtml(run.status)}</td>
+        <td>${escapeHtml(run.startedAt)}</td>
+        <td>${run.eventCount}</td>
+        <td>${run.artifactCount}</td>
+      </tr>`,
+    )
+    .join('\n');
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Team Audit - ${escapeHtml(report.workspace.workspaceName)}</title>
+  <style>
+    :root { color-scheme: light; font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: #111827; background: #f8fafc; }
+    body { margin: 0; }
+    main { max-width: 1120px; margin: 0 auto; padding: 32px 24px 56px; }
+    header, section { border: 1px solid #e5e7eb; background: #fff; border-radius: 8px; padding: 24px; margin-bottom: 16px; }
+    h1 { margin: 0; font-size: 24px; }
+    h2 { margin: 0 0 12px; font-size: 16px; }
+    .muted { color: #64748b; }
+    .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 12px; margin-top: 20px; }
+    .metric { border: 1px solid #e5e7eb; border-radius: 8px; padding: 12px; background: #f8fafc; }
+    .metric span { display: block; font-size: 12px; color: #64748b; margin-bottom: 6px; }
+    .metric strong { font-size: 18px; }
+    table { width: 100%; border-collapse: collapse; font-size: 14px; }
+    th, td { text-align: left; border-top: 1px solid #e5e7eb; padding: 10px 8px; vertical-align: top; }
+    th { color: #64748b; font-size: 12px; text-transform: uppercase; }
+    .badge { display: inline-flex; border-radius: 999px; border: 1px solid #d1d5db; padding: 3px 8px; font-size: 12px; font-weight: 600; }
+    .badge.ready { color: #047857; background: #ecfdf5; border-color: #a7f3d0; }
+    .badge.needs_attention { color: #92400e; background: #fffbeb; border-color: #fde68a; }
+    .hash { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace; font-size: 12px; word-break: break-all; }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <h1>${escapeHtml(report.workspace.workspaceName)}</h1>
+      <div class="muted">Team audit report | ${escapeHtml(report.generatedAt)} | ${escapeHtml(report.reportId)}</div>
+      <div class="grid">
+        <div class="metric"><span>Plan</span><strong>${escapeHtml(report.workspace.plan)}</strong></div>
+        <div class="metric"><span>Members</span><strong>${report.workspace.members.length}/${report.workspace.seatLimit}</strong></div>
+        <div class="metric"><span>Total runs</span><strong>${report.metrics.totalRuns}</strong></div>
+        <div class="metric"><span>Pending approvals</span><strong>${report.metrics.pendingApprovals}</strong></div>
+      </div>
+    </header>
+    <section>
+      <h2>Commercial readiness</h2>
+      <table><thead><tr><th>Control</th><th>Status</th><th>Detail</th></tr></thead><tbody>${readinessRows}</tbody></table>
+    </section>
+    <section>
+      <h2>Recent runs</h2>
+      <table><thead><tr><th>Run</th><th>Mode</th><th>Status</th><th>Started</th><th>Events</th><th>Files</th></tr></thead><tbody>${runRows}</tbody></table>
+    </section>
+  </main>
+</body>
+</html>
+`;
+}
+
+function getDefaultStorageRoot(): string {
+  const { app } = require('electron') as typeof import('electron');
+  return path.join(app.getPath('userData'), 'proofpilot', 'team');
+}
+
+function normalizeSeatLimit(value: unknown, fallback: number): number {
+  return normalizePositiveInteger(value, fallback, 1, 500);
+}
+
+function normalizeRetentionDays(value: unknown, fallback: number): number {
+  return normalizePositiveInteger(value, fallback, 1, 3650);
+}
+
+function normalizePositiveInteger(
+  value: unknown,
+  fallback: number,
+  min: number,
+  max: number,
+): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return fallback;
+  }
+
+  return Math.min(max, Math.max(min, Math.round(value)));
+}
+
+function isTeamPlan(value: unknown): value is TeamPlan {
+  return value === 'solo' || value === 'team' || value === 'business';
+}
+
+function isTeamMember(value: unknown): value is TeamMember {
+  return (
+    isRecord(value) &&
+    typeof value.id === 'string' &&
+    typeof value.name === 'string' &&
+    typeof value.email === 'string' &&
+    isTeamMemberRole(value.role) &&
+    isTeamMemberStatus(value.status) &&
+    typeof value.joinedAt === 'string'
+  );
+}
+
+function isTeamMemberRole(value: unknown): value is TeamMemberRole {
+  return (
+    value === 'owner' ||
+    value === 'admin' ||
+    value === 'operator' ||
+    value === 'viewer'
+  );
+}
+
+function isTeamMemberStatus(value: unknown): value is TeamMemberStatus {
+  return value === 'active' || value === 'invited';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isNodeError(error: unknown): error is Error & { code?: string } {
+  return error instanceof Error && 'code' in error;
+}
+
+function escapeHtml(value: unknown): string {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+export { TeamWorkspaceStore };
+export type {
+  TeamAuditExport,
+  TeamAuditReadinessItem,
+  TeamAuditReport,
+  TeamMember,
+  TeamMemberInput,
+  TeamMemberRole,
+  TeamMemberStatus,
+  TeamPlan,
+  TeamPolicies,
+  TeamWorkspace,
+  TeamWorkspaceUpdate,
+};

--- a/apps/ui-tars/src/main/store/create.ts
+++ b/apps/ui-tars/src/main/store/create.ts
@@ -15,6 +15,8 @@ export const store = createStore<AppState>(
       restUserData: null,
       instructions: '',
       status: StatusEnum.INIT,
+      activeSessionId: null,
+      runMode: 'live',
       sessionHistoryMessages: [],
       messages: [],
       errorMsg: null,

--- a/apps/ui-tars/src/main/store/types.ts
+++ b/apps/ui-tars/src/main/store/types.ts
@@ -21,6 +21,8 @@ export type NextAction =
   | { type: 'finish' }
   | { type: 'error'; message: string };
 
+export type AgentRunMode = 'live' | 'simulation';
+
 export type AppState = {
   theme: 'dark' | 'light';
   ensurePermissions: { screenCapture?: boolean; accessibility?: boolean };
@@ -28,6 +30,8 @@ export type AppState = {
   restUserData: Omit<GUIAgentData, 'status' | 'conversations'> | null;
   status: GUIAgentData['status'];
   errorMsg: string | null;
+  activeSessionId: string | null;
+  runMode: AgentRunMode;
   sessionHistoryMessages: Message[];
   messages: ConversationWithSoM[];
   abortController: AbortController | null;

--- a/apps/ui-tars/src/renderer/src/App.tsx
+++ b/apps/ui-tars/src/renderer/src/App.tsx
@@ -14,6 +14,9 @@ const Home = lazy(() => import('./pages/home'));
 const LocalOperator = lazy(() => import('./pages/local'));
 const FreeRemoteOperator = lazy(() => import('./pages/remote/free'));
 // const PaidRemoteOperator = lazy(() => import('./pages/remote/paid'));
+const ProofPilot = lazy(() => import('./pages/proofpilot'));
+const Approvals = lazy(() => import('./pages/approvals'));
+const TeamConsole = lazy(() => import('./pages/team'));
 
 const Widget = lazy(() => import('./pages/widget'));
 
@@ -33,6 +36,9 @@ export default function App() {
             <Route path="/local" element={<LocalOperator />} />
             <Route path="/free-remote" element={<FreeRemoteOperator />} />
             {/* <Route path="/paid-remote" element={<PaidRemoteOperator />} /> */}
+            <Route path="/proofpilot" element={<ProofPilot />} />
+            <Route path="/approvals" element={<Approvals />} />
+            <Route path="/team" element={<TeamConsole />} />
           </Route>
 
           <Route path="/widget" element={<Widget />} />

--- a/apps/ui-tars/src/renderer/src/components/ChatInput/index.tsx
+++ b/apps/ui-tars/src/renderer/src/components/ChatInput/index.tsx
@@ -17,10 +17,11 @@ import {
   TooltipTrigger,
 } from '@renderer/components/ui/tooltip';
 import { Button } from '@renderer/components/ui/button';
+import { Switch } from '@renderer/components/ui/switch';
 // import { useScreenRecord } from '@renderer/hooks/useScreenRecord';
 import { api } from '@renderer/api';
 
-import { Play, Send, Square, Loader2 } from 'lucide-react';
+import { FlaskConical, Play, Send, Square, Loader2 } from 'lucide-react';
 import { Textarea } from '@renderer/components/ui/textarea';
 import { useSession } from '@renderer/hooks/useSession';
 
@@ -45,6 +46,7 @@ const ChatInput = ({
     restUserData,
   } = useStore();
   const [localInstructions, setLocalInstructions] = useState('');
+  const [simulationMode, setSimulationMode] = useState(false);
   const { run, stopAgentRuning } = useRunAgent();
   const { getSession, updateSession, chatMessages } = useSession();
   const { settings, updateSetting } = useSetting();
@@ -119,9 +121,15 @@ const ChatInput = ({
       },
     });
 
-    run(instructions, history, () => {
-      setLocalInstructions('');
-    });
+    run(
+      instructions,
+      history,
+      () => {
+        setLocalInstructions('');
+      },
+      sessionId,
+      simulationMode ? 'simulation' : 'live',
+    );
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -235,6 +243,15 @@ const ChatInput = ({
             )}
             {renderButton()}
           </div>
+          <label className="absolute bottom-4 left-4 flex items-center gap-2 rounded-md border bg-background/90 px-2 py-1 text-xs text-muted-foreground shadow-sm">
+            <FlaskConical className="size-3.5" />
+            <span>Simulate</span>
+            <Switch
+              checked={simulationMode}
+              disabled={running || disabled}
+              onCheckedChange={setSimulationMode}
+            />
+          </label>
         </div>
       </div>
     </div>

--- a/apps/ui-tars/src/renderer/src/components/SideBar/app-sidebar.tsx
+++ b/apps/ui-tars/src/renderer/src/components/SideBar/app-sidebar.tsx
@@ -4,7 +4,7 @@
  */
 import { useCallback, useState, type ComponentProps } from 'react';
 import { useNavigate, useLocation } from 'react-router';
-import { Home } from 'lucide-react';
+import { Building2, FileClock, Home, ShieldAlert } from 'lucide-react';
 
 import {
   Sidebar,
@@ -42,7 +42,12 @@ export function AppSidebar({ ...props }: ComponentProps<typeof Sidebar>) {
   const { status } = useStore();
   const [isNavDialogOpen, setNavDialogOpen] = useState(false);
   const [pendingAction, setPendingAction] = useState<
-    'home' | { type: 'session'; id: string } | null
+    | 'home'
+    | 'proofpilot'
+    | 'approvals'
+    | 'team'
+    | { type: 'session'; id: string }
+    | null
   >(null);
 
   const needsConfirm =
@@ -54,6 +59,18 @@ export function AppSidebar({ ...props }: ComponentProps<typeof Sidebar>) {
     await navigate('/');
     await setActiveSession('');
   }, [navigate, setActiveSession]);
+
+  const goProofPilot = useCallback(async () => {
+    await navigate('/proofpilot');
+  }, [navigate]);
+
+  const goApprovals = useCallback(async () => {
+    await navigate('/approvals');
+  }, [navigate]);
+
+  const goTeam = useCallback(async () => {
+    await navigate('/team');
+  }, [navigate]);
 
   const onSessionClick = useCallback(
     async (sessionId: string) => {
@@ -96,7 +113,34 @@ export function AppSidebar({ ...props }: ComponentProps<typeof Sidebar>) {
     } else {
       goHome();
     }
-  }, [needsConfirm]);
+  }, [goHome, needsConfirm]);
+
+  const handleProofPilotClick = useCallback(() => {
+    if (needsConfirm) {
+      setPendingAction('proofpilot');
+      setNavDialogOpen(true);
+    } else {
+      goProofPilot();
+    }
+  }, [goProofPilot, needsConfirm]);
+
+  const handleApprovalsClick = useCallback(() => {
+    if (needsConfirm) {
+      setPendingAction('approvals');
+      setNavDialogOpen(true);
+    } else {
+      goApprovals();
+    }
+  }, [goApprovals, needsConfirm]);
+
+  const handleTeamClick = useCallback(() => {
+    if (needsConfirm) {
+      setPendingAction('team');
+      setNavDialogOpen(true);
+    } else {
+      goTeam();
+    }
+  }, [goTeam, needsConfirm]);
 
   const handleSessionClick = useCallback(
     (sessionId: string) => {
@@ -107,7 +151,7 @@ export function AppSidebar({ ...props }: ComponentProps<typeof Sidebar>) {
         onSessionClick(sessionId);
       }
     },
-    [needsConfirm],
+    [needsConfirm, onSessionClick],
   );
 
   const onConfirm = useCallback(async () => {
@@ -116,12 +160,25 @@ export function AppSidebar({ ...props }: ComponentProps<typeof Sidebar>) {
 
     if (pendingAction === 'home') {
       await goHome();
+    } else if (pendingAction === 'proofpilot') {
+      await goProofPilot();
+    } else if (pendingAction === 'approvals') {
+      await goApprovals();
+    } else if (pendingAction === 'team') {
+      await goTeam();
     } else if (pendingAction?.type === 'session') {
       await onSessionClick(pendingAction.id);
     }
     setPendingAction(null);
     setNavDialogOpen(false);
-  }, [pendingAction, goHome, onSessionClick]);
+  }, [
+    pendingAction,
+    goHome,
+    goProofPilot,
+    goApprovals,
+    goTeam,
+    onSessionClick,
+  ]);
 
   const onCancel = useCallback(() => {
     setPendingAction(null);
@@ -147,10 +204,35 @@ export function AppSidebar({ ...props }: ComponentProps<typeof Sidebar>) {
           <SidebarMenu className="items-center">
             <SidebarMenuButton
               className="font-medium"
+              isActive={location.pathname === '/'}
               onClick={handleHomeClick}
             >
               <Home />
               Home
+            </SidebarMenuButton>
+            <SidebarMenuButton
+              className="font-medium"
+              isActive={location.pathname === '/proofpilot'}
+              onClick={handleProofPilotClick}
+            >
+              <FileClock />
+              ProofPilot
+            </SidebarMenuButton>
+            <SidebarMenuButton
+              className="font-medium"
+              isActive={location.pathname === '/approvals'}
+              onClick={handleApprovalsClick}
+            >
+              <ShieldAlert />
+              Approvals
+            </SidebarMenuButton>
+            <SidebarMenuButton
+              className="font-medium"
+              isActive={location.pathname === '/team'}
+              onClick={handleTeamClick}
+            >
+              <Building2 />
+              Team
             </SidebarMenuButton>
           </SidebarMenu>
         </SidebarHeader>

--- a/apps/ui-tars/src/renderer/src/hooks/useRunAgent.ts
+++ b/apps/ui-tars/src/renderer/src/hooks/useRunAgent.ts
@@ -12,7 +12,7 @@ import { useSetting } from './useSetting';
 import { api } from '@renderer/api';
 import { ConversationWithSoM } from '@/main/shared/types';
 import { Message } from '@ui-tars/shared/types';
-import { Operator } from '@/main/store/types';
+import { type AgentRunMode, Operator } from '@/main/store/types';
 
 const filterAndTransformWithMap = (
   history: ConversationWithSoM[],
@@ -61,10 +61,13 @@ export const useRunAgent = () => {
     value: string,
     history: ConversationWithSoM[],
     callback: () => void = () => {},
+    sessionId?: string,
+    mode: AgentRunMode = 'live',
   ) => {
     const operator = settings.operator;
     if (
-      (operator === Operator.LocalBrowser || Operator.LocalComputer) &&
+      (operator === Operator.LocalBrowser ||
+        operator === Operator.LocalComputer) &&
       !(ensurePermissions?.accessibility && ensurePermissions?.screenCapture)
     ) {
       const permissionsText = [
@@ -102,7 +105,7 @@ export const useRunAgent = () => {
       }),
     ]);
 
-    await api.runAgent();
+    await api.runAgent({ sessionId, mode });
 
     callback();
   };

--- a/apps/ui-tars/src/renderer/src/pages/approvals/index.tsx
+++ b/apps/ui-tars/src/renderer/src/pages/approvals/index.tsx
@@ -1,0 +1,506 @@
+/**
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Clock3,
+  RefreshCw,
+  ShieldAlert,
+  Trash2,
+  XCircle,
+} from 'lucide-react';
+
+import { api } from '@renderer/api';
+import { Badge } from '@renderer/components/ui/badge';
+import { Button } from '@renderer/components/ui/button';
+import { ScrollArea } from '@renderer/components/ui/scroll-area';
+import { SidebarTrigger } from '@renderer/components/ui/sidebar';
+import { Textarea } from '@renderer/components/ui/textarea';
+import { cn } from '@renderer/utils';
+
+type ApprovalQueueSnapshot = Awaited<
+  ReturnType<typeof api.listApprovalRequests>
+>;
+type ApprovalRequest = ApprovalQueueSnapshot['requests'][number];
+
+export default function Approvals() {
+  const [snapshot, setSnapshot] = useState<ApprovalQueueSnapshot>({
+    requests: [],
+    counts: {
+      pending: 0,
+      approved: 0,
+      denied: 0,
+    },
+  });
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [decisionReason, setDecisionReason] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [resolvingId, setResolvingId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const selectedRequest = useMemo(
+    () =>
+      snapshot.requests.find((request) => request.id === selectedId) ??
+      snapshot.requests[0] ??
+      null,
+    [selectedId, snapshot.requests],
+  );
+
+  const loadQueue = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const nextSnapshot = await api.listApprovalRequests();
+      setSnapshot(nextSnapshot);
+      setSelectedId((currentId) => {
+        if (
+          currentId &&
+          nextSnapshot.requests.some((request) => request.id === currentId)
+        ) {
+          return currentId;
+        }
+
+        return nextSnapshot.requests[0]?.id ?? null;
+      });
+    } catch (loadError) {
+      setError(readErrorMessage(loadError));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadQueue();
+  }, [loadQueue]);
+
+  useEffect(() => {
+    setDecisionReason('');
+  }, [selectedRequest?.id]);
+
+  const resolveRequest = useCallback(
+    async (status: 'approved' | 'denied') => {
+      if (!selectedRequest) {
+        return;
+      }
+
+      setResolvingId(selectedRequest.id);
+      setError(null);
+
+      try {
+        await api.resolveApprovalRequest({
+          id: selectedRequest.id,
+          status,
+          decisionReason: decisionReason.trim() || undefined,
+        });
+        await loadQueue();
+      } catch (resolveError) {
+        setError(readErrorMessage(resolveError));
+      } finally {
+        setResolvingId(null);
+      }
+    },
+    [decisionReason, loadQueue, selectedRequest],
+  );
+
+  const clearResolved = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const nextSnapshot = await api.clearResolvedApprovalRequests();
+      setSnapshot(nextSnapshot);
+      setSelectedId(nextSnapshot.requests[0]?.id ?? null);
+    } catch (clearError) {
+      setError(readErrorMessage(clearError));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return (
+    <div className="flex h-full min-h-0 w-full flex-col bg-background">
+      <header className="flex h-16 shrink-0 items-center justify-between border-b px-5">
+        <div className="flex min-w-0 items-center gap-3">
+          <SidebarTrigger variant="secondary" className="size-8" />
+          <div className="flex size-9 shrink-0 items-center justify-center rounded-md border bg-muted text-foreground">
+            <ShieldAlert className="size-5" />
+          </div>
+          <div className="min-w-0">
+            <h1 className="truncate text-base font-semibold">Approval Queue</h1>
+            <p className="truncate text-xs text-muted-foreground">
+              Review high-risk agent actions before they continue
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={clearResolved}
+            disabled={
+              loading || snapshot.requests.length === snapshot.counts.pending
+            }
+          >
+            <Trash2 className="size-4" />
+            Clear Resolved
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={loadQueue}
+            disabled={loading}
+          >
+            <RefreshCw className={cn('size-4', loading && 'animate-spin')} />
+            Refresh
+          </Button>
+        </div>
+      </header>
+
+      {error && (
+        <div className="border-b border-red-200 bg-red-50 px-5 py-2 text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
+      <div className="grid min-h-0 flex-1 grid-cols-1 lg:grid-cols-[360px_minmax(0,1fr)]">
+        <aside className="flex min-h-0 flex-col border-b lg:border-b-0 lg:border-r">
+          <div className="grid grid-cols-3 gap-2 border-b p-3">
+            <Metric label="Pending" value={snapshot.counts.pending} />
+            <Metric label="Approved" value={snapshot.counts.approved} />
+            <Metric label="Denied" value={snapshot.counts.denied} />
+          </div>
+
+          <ScrollArea className="min-h-0 flex-1">
+            <div className="space-y-2 p-3">
+              {loading && snapshot.requests.length === 0 ? (
+                <QueueSkeleton />
+              ) : snapshot.requests.length === 0 ? (
+                <EmptyState />
+              ) : (
+                snapshot.requests.map((request) => (
+                  <ApprovalListItem
+                    key={request.id}
+                    request={request}
+                    selected={request.id === selectedRequest?.id}
+                    onSelect={() => setSelectedId(request.id)}
+                  />
+                ))
+              )}
+            </div>
+          </ScrollArea>
+        </aside>
+
+        <main className="min-h-0">
+          {selectedRequest ? (
+            <ApprovalDetail
+              request={selectedRequest}
+              decisionReason={decisionReason}
+              onDecisionReasonChange={setDecisionReason}
+              resolving={resolvingId === selectedRequest.id}
+              onApprove={() => resolveRequest('approved')}
+              onDeny={() => resolveRequest('denied')}
+            />
+          ) : (
+            <NoSelectionState />
+          )}
+        </main>
+      </div>
+    </div>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-md border bg-muted/30 px-3 py-2">
+      <div className="text-lg font-semibold leading-none tabular-nums">
+        {value}
+      </div>
+      <div className="mt-1 text-[11px] uppercase tracking-normal text-muted-foreground">
+        {label}
+      </div>
+    </div>
+  );
+}
+
+function ApprovalListItem({
+  request,
+  selected,
+  onSelect,
+}: {
+  request: ApprovalRequest;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      className={cn(
+        'w-full rounded-md border p-3 text-left transition-colors hover:bg-muted/60',
+        selected && 'border-primary bg-primary/5',
+      )}
+      onClick={onSelect}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <div className="line-clamp-2 text-sm font-medium leading-snug">
+            {request.title}
+          </div>
+          <div className="mt-1 flex items-center gap-1 text-xs text-muted-foreground">
+            <Clock3 className="size-3.5" />
+            <span className="truncate">{formatDate(request.createdAt)}</span>
+          </div>
+        </div>
+        <StatusBadge status={request.status} />
+      </div>
+      <div className="mt-3 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+        <RiskBadge riskLevel={request.riskLevel} />
+        <span>{request.source}</span>
+        {request.ruleId && <span>{request.ruleId}</span>}
+      </div>
+    </button>
+  );
+}
+
+function ApprovalDetail({
+  request,
+  decisionReason,
+  onDecisionReasonChange,
+  resolving,
+  onApprove,
+  onDeny,
+}: {
+  request: ApprovalRequest;
+  decisionReason: string;
+  onDecisionReasonChange: (value: string) => void;
+  resolving: boolean;
+  onApprove: () => void;
+  onDeny: () => void;
+}) {
+  const isPending = request.status === 'pending';
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="border-b px-5 py-4">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-center gap-2">
+              <h2 className="truncate text-lg font-semibold">
+                {request.title}
+              </h2>
+              <StatusBadge status={request.status} />
+              <RiskBadge riskLevel={request.riskLevel} />
+            </div>
+            <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+              <span>{request.source}</span>
+              <span>{formatDate(request.createdAt)}</span>
+              {request.ruleId && <span>{request.ruleId}</span>}
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={onDeny}
+              disabled={!isPending || resolving}
+            >
+              <XCircle className="size-4" />
+              Deny
+            </Button>
+            <Button
+              size="sm"
+              onClick={onApprove}
+              disabled={!isPending || resolving}
+            >
+              <CheckCircle2 className="size-4" />
+              Approve
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      <ScrollArea className="min-h-0 flex-1">
+        <div className="grid gap-5 p-5">
+          <section className="rounded-md border p-4">
+            <h3 className="text-sm font-semibold">Reason</h3>
+            <p className="mt-2 whitespace-pre-wrap text-sm text-muted-foreground">
+              {request.reason}
+            </p>
+          </section>
+
+          <section className="rounded-md border p-4">
+            <h3 className="text-sm font-semibold">Request Subject</h3>
+            <div className="mt-3 grid gap-3">
+              {formatSubjectRows(request).map((row) => (
+                <div
+                  key={row.label}
+                  className="grid gap-1 text-sm md:grid-cols-[8rem_minmax(0,1fr)]"
+                >
+                  <div className="text-xs font-medium uppercase tracking-normal text-muted-foreground">
+                    {row.label}
+                  </div>
+                  <div className="min-w-0 whitespace-pre-wrap break-words font-mono text-xs text-foreground">
+                    {row.value}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section className="rounded-md border p-4">
+            <h3 className="text-sm font-semibold">Decision Note</h3>
+            {isPending ? (
+              <Textarea
+                value={decisionReason}
+                onChange={(event) =>
+                  onDecisionReasonChange(event.currentTarget.value)
+                }
+                className="mt-3 min-h-24 resize-none"
+                placeholder="Optional context for why this was approved or denied."
+              />
+            ) : (
+              <p className="mt-2 whitespace-pre-wrap text-sm text-muted-foreground">
+                {request.decisionReason || 'No decision note recorded.'}
+              </p>
+            )}
+            {request.decidedAt && (
+              <div className="mt-2 text-xs text-muted-foreground">
+                Decided {formatDate(request.decidedAt)}
+              </div>
+            )}
+          </section>
+        </div>
+      </ScrollArea>
+    </div>
+  );
+}
+
+function StatusBadge({ status }: { status: ApprovalRequest['status'] }) {
+  const Icon =
+    status === 'approved'
+      ? CheckCircle2
+      : status === 'denied'
+        ? XCircle
+        : AlertTriangle;
+
+  return (
+    <Badge
+      variant="outline"
+      className={cn('capitalize', getStatusClass(status))}
+    >
+      <Icon className="size-3" />
+      {status}
+    </Badge>
+  );
+}
+
+function RiskBadge({ riskLevel }: { riskLevel: ApprovalRequest['riskLevel'] }) {
+  return (
+    <Badge
+      variant="outline"
+      className={cn('capitalize', getRiskClass(riskLevel))}
+    >
+      {riskLevel}
+    </Badge>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div className="flex min-h-52 flex-col items-center justify-center rounded-md border border-dashed px-6 text-center">
+      <ShieldAlert className="size-8 text-muted-foreground" />
+      <div className="mt-3 text-sm font-medium">No approval requests</div>
+      <div className="mt-1 text-xs text-muted-foreground">
+        High-risk actions will appear here before they continue.
+      </div>
+    </div>
+  );
+}
+
+function NoSelectionState() {
+  return (
+    <div className="flex h-full min-h-80 flex-col items-center justify-center px-6 text-center">
+      <ShieldAlert className="size-9 text-muted-foreground" />
+      <div className="mt-3 text-sm font-medium">Select an approval request</div>
+      <div className="mt-1 text-xs text-muted-foreground">
+        Review the request details and approve or deny the action.
+      </div>
+    </div>
+  );
+}
+
+function QueueSkeleton() {
+  return (
+    <>
+      {[0, 1, 2].map((index) => (
+        <div
+          key={index}
+          className="h-28 animate-pulse rounded-md border bg-muted"
+        />
+      ))}
+    </>
+  );
+}
+
+function formatSubjectRows(request: ApprovalRequest) {
+  const subject = request.subject ?? {};
+  return [
+    ['Request ID', request.id],
+    ['Tool', subject.toolName],
+    ['Command', subject.command],
+    ['Interpreter', subject.interpreter],
+    ['Script', subject.script],
+    ['Working Dir', subject.cwd],
+    ['Session', subject.sessionId],
+    ['Run', subject.runId],
+    ['Summary', subject.summary],
+  ]
+    .filter(([, value]) => Boolean(value))
+    .map(([label, value]) => ({
+      label: label ?? '',
+      value: String(value),
+    }));
+}
+
+function formatDate(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return date.toLocaleString();
+}
+
+function getStatusClass(status: ApprovalRequest['status']) {
+  switch (status) {
+    case 'approved':
+      return 'border-emerald-200 bg-emerald-50 text-emerald-700';
+    case 'denied':
+      return 'border-red-200 bg-red-50 text-red-700';
+    case 'pending':
+      return 'border-amber-200 bg-amber-50 text-amber-700';
+  }
+}
+
+function getRiskClass(riskLevel: ApprovalRequest['riskLevel']) {
+  switch (riskLevel) {
+    case 'critical':
+      return 'border-red-300 bg-red-50 text-red-700';
+    case 'high':
+      return 'border-orange-300 bg-orange-50 text-orange-700';
+    case 'medium':
+      return 'border-amber-200 bg-amber-50 text-amber-700';
+    case 'low':
+      return 'border-muted-foreground/20 bg-muted text-muted-foreground';
+  }
+}
+
+function readErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error);
+}

--- a/apps/ui-tars/src/renderer/src/pages/proofpilot/index.tsx
+++ b/apps/ui-tars/src/renderer/src/pages/proofpilot/index.tsx
@@ -1,0 +1,1061 @@
+/**
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Activity,
+  AlertTriangle,
+  Bot,
+  Camera,
+  CheckCircle2,
+  ChevronLeft,
+  ChevronRight,
+  CircleDot,
+  Clock3,
+  Download,
+  FileClock,
+  FlaskConical,
+  MousePointerClick,
+  PackageCheck,
+  RefreshCw,
+  ShieldCheck,
+  Workflow,
+} from 'lucide-react';
+
+import { api } from '@renderer/api';
+import { Badge } from '@renderer/components/ui/badge';
+import { Button } from '@renderer/components/ui/button';
+import { ScrollArea } from '@renderer/components/ui/scroll-area';
+import { SidebarTrigger } from '@renderer/components/ui/sidebar';
+import { cn } from '@renderer/utils';
+import { StatusEnum } from '@ui-tars/shared/types';
+
+type ProofPilotRunSummary = Awaited<
+  ReturnType<typeof api.listProofPilotRuns>
+>[number];
+type ProofPilotRunDetail = NonNullable<
+  Awaited<ReturnType<typeof api.getProofPilotRun>>
+>;
+type ProofPilotEvent = ProofPilotRunDetail['events'][number];
+type ProofPackExportResult = Awaited<
+  ReturnType<typeof api.exportProofPilotRun>
+>;
+type WorkflowCapsuleExportResult = Awaited<
+  ReturnType<typeof api.exportProofPilotWorkflowCapsule>
+>;
+type CompiledWorkflowExportResult = Awaited<
+  ReturnType<typeof api.compileProofPilotWorkflow>
+>;
+
+type PayloadRecord = Record<string, unknown>;
+type ArtifactPreview = {
+  id: string;
+  kind?: string;
+  relativePath: string;
+  mime?: string;
+  bytes?: number;
+  dataUrl?: string;
+  missing?: boolean;
+};
+
+const eventLabels: Record<ProofPilotEvent['type'], string> = {
+  run_started: 'Run started',
+  status_changed: 'Status changed',
+  conversation_added: 'Conversation captured',
+  action_planned: 'Action planned',
+  simulation_action_skipped: 'Simulation action skipped',
+  run_error: 'Run error',
+  run_finished: 'Run finished',
+};
+
+export default function ProofPilot() {
+  const [runs, setRuns] = useState<ProofPilotRunSummary[]>([]);
+  const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
+  const [detail, setDetail] = useState<ProofPilotRunDetail | null>(null);
+  const [runsLoading, setRunsLoading] = useState(false);
+  const [detailLoading, setDetailLoading] = useState(false);
+  const [exportingRunId, setExportingRunId] = useState<string | null>(null);
+  const [exportingCapsuleRunId, setExportingCapsuleRunId] = useState<
+    string | null
+  >(null);
+  const [compilingRunId, setCompilingRunId] = useState<string | null>(null);
+  const [exportResult, setExportResult] =
+    useState<ProofPackExportResult | null>(null);
+  const [capsuleResult, setCapsuleResult] =
+    useState<WorkflowCapsuleExportResult | null>(null);
+  const [compiledWorkflowResult, setCompiledWorkflowResult] =
+    useState<CompiledWorkflowExportResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadRuns = useCallback(async () => {
+    setRunsLoading(true);
+    setError(null);
+
+    try {
+      const nextRuns = await api.listProofPilotRuns();
+      setRuns(nextRuns);
+      setSelectedRunId((currentRunId) => {
+        if (
+          currentRunId &&
+          nextRuns.some((run) => run.runId === currentRunId)
+        ) {
+          return currentRunId;
+        }
+
+        return nextRuns[0]?.runId ?? null;
+      });
+    } catch (loadError) {
+      setError(readErrorMessage(loadError));
+    } finally {
+      setRunsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadRuns();
+  }, [loadRuns]);
+
+  const handleExport = useCallback(async (runId: string) => {
+    setExportingRunId(runId);
+    setError(null);
+
+    try {
+      const result = await api.exportProofPilotRun({ runId, open: true });
+      setExportResult(result);
+    } catch (exportError) {
+      setError(readErrorMessage(exportError));
+    } finally {
+      setExportingRunId(null);
+    }
+  }, []);
+
+  const handleCreateCapsule = useCallback(async (runId: string) => {
+    setExportingCapsuleRunId(runId);
+    setError(null);
+
+    try {
+      const result = await api.exportProofPilotWorkflowCapsule({
+        runId,
+        reveal: true,
+      });
+      setCapsuleResult(result);
+    } catch (exportError) {
+      setError(readErrorMessage(exportError));
+    } finally {
+      setExportingCapsuleRunId(null);
+    }
+  }, []);
+
+  const handleCompileWorkflow = useCallback(async (runId: string) => {
+    setCompilingRunId(runId);
+    setError(null);
+
+    try {
+      const result = await api.compileProofPilotWorkflow({
+        runId,
+        reveal: true,
+      });
+      setCompiledWorkflowResult(result);
+    } catch (compileError) {
+      setError(readErrorMessage(compileError));
+    } finally {
+      setCompilingRunId(null);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!selectedRunId) {
+      setDetail(null);
+      return;
+    }
+
+    let cancelled = false;
+    setDetailLoading(true);
+    setError(null);
+
+    api
+      .getProofPilotRun({ runId: selectedRunId })
+      .then((run) => {
+        if (!cancelled) {
+          setDetail(run);
+        }
+      })
+      .catch((loadError) => {
+        if (!cancelled) {
+          setError(readErrorMessage(loadError));
+          setDetail(null);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setDetailLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedRunId]);
+
+  const totals = useMemo(
+    () => ({
+      runs: runs.length,
+      events: runs.reduce((count, run) => count + run.eventCount, 0),
+      artifacts: runs.reduce((count, run) => count + run.artifactCount, 0),
+    }),
+    [runs],
+  );
+
+  return (
+    <div className="flex h-full min-h-0 w-full flex-col bg-background">
+      <header className="flex h-16 shrink-0 items-center justify-between border-b px-5">
+        <div className="flex min-w-0 items-center gap-3">
+          <SidebarTrigger variant="secondary" className="size-8" />
+          <div className="flex size-9 shrink-0 items-center justify-center rounded-md border bg-muted text-foreground">
+            <ShieldCheck className="size-5" />
+          </div>
+          <div className="min-w-0">
+            <h1 className="truncate text-base font-semibold">ProofPilot</h1>
+            <p className="truncate text-xs text-muted-foreground">
+              Agent flight recorder
+            </p>
+          </div>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={loadRuns}
+          disabled={runsLoading}
+        >
+          <RefreshCw className={cn('size-4', runsLoading && 'animate-spin')} />
+          Refresh
+        </Button>
+      </header>
+
+      <div className="grid min-h-0 flex-1 grid-cols-1 lg:grid-cols-[340px_minmax(0,1fr)]">
+        <aside className="flex min-h-0 flex-col border-b lg:border-b-0 lg:border-r">
+          <div className="grid grid-cols-3 gap-2 border-b p-3">
+            <Metric label="Runs" value={totals.runs} />
+            <Metric label="Events" value={totals.events} />
+            <Metric label="Files" value={totals.artifacts} />
+          </div>
+
+          <ScrollArea className="min-h-0 flex-1">
+            <div className="space-y-2 p-3">
+              {runsLoading && runs.length === 0 ? (
+                <RunListSkeleton />
+              ) : runs.length === 0 ? (
+                <EmptyState />
+              ) : (
+                runs.map((run) => (
+                  <RunListItem
+                    key={run.runId}
+                    run={run}
+                    selected={run.runId === selectedRunId}
+                    onSelect={() => setSelectedRunId(run.runId)}
+                  />
+                ))
+              )}
+            </div>
+          </ScrollArea>
+        </aside>
+
+        <main className="min-h-0">
+          {error ? (
+            <ErrorState message={error} onRetry={loadRuns} />
+          ) : detailLoading && !detail ? (
+            <DetailSkeleton />
+          ) : detail ? (
+            <RunDetail
+              run={detail}
+              exporting={exportingRunId === detail.runId}
+              exportResult={
+                exportResult?.runId === detail.runId ? exportResult : null
+              }
+              capsuleExporting={exportingCapsuleRunId === detail.runId}
+              capsuleResult={
+                capsuleResult?.runId === detail.runId ? capsuleResult : null
+              }
+              compiling={compilingRunId === detail.runId}
+              compiledWorkflowResult={
+                compiledWorkflowResult?.runId === detail.runId
+                  ? compiledWorkflowResult
+                  : null
+              }
+              onExport={() => handleExport(detail.runId)}
+              onCreateCapsule={() => handleCreateCapsule(detail.runId)}
+              onCompileWorkflow={() => handleCompileWorkflow(detail.runId)}
+            />
+          ) : (
+            <NoSelectionState />
+          )}
+        </main>
+      </div>
+    </div>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-md border bg-muted/30 px-3 py-2">
+      <div className="text-lg font-semibold leading-none tabular-nums">
+        {value}
+      </div>
+      <div className="mt-1 text-[11px] uppercase tracking-normal text-muted-foreground">
+        {label}
+      </div>
+    </div>
+  );
+}
+
+function RunListItem({
+  run,
+  selected,
+  onSelect,
+}: {
+  run: ProofPilotRunSummary;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      className={cn(
+        'w-full rounded-md border p-3 text-left transition-colors hover:bg-muted/60',
+        selected && 'border-primary bg-primary/5',
+      )}
+      onClick={onSelect}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <div className="line-clamp-2 text-sm font-medium leading-snug">
+            {run.instruction || 'Untitled run'}
+          </div>
+          <div className="mt-1 flex items-center gap-1 text-xs text-muted-foreground">
+            <Clock3 className="size-3.5" />
+            <span className="truncate">{formatDate(run.startedAt)}</span>
+          </div>
+        </div>
+        <div className="flex shrink-0 flex-col items-end gap-1">
+          <StatusBadge status={run.status} />
+          <ModeBadge mode={run.mode} />
+        </div>
+      </div>
+      <div className="mt-3 flex items-center gap-3 text-xs text-muted-foreground">
+        <span>{run.operator}</span>
+        <span>{run.eventCount} events</span>
+        <span>{run.artifactCount} files</span>
+      </div>
+    </button>
+  );
+}
+
+function RunDetail({
+  run,
+  exporting,
+  exportResult,
+  capsuleExporting,
+  capsuleResult,
+  compiling,
+  compiledWorkflowResult,
+  onExport,
+  onCreateCapsule,
+  onCompileWorkflow,
+}: {
+  run: ProofPilotRunDetail;
+  exporting: boolean;
+  exportResult: ProofPackExportResult | null;
+  capsuleExporting: boolean;
+  capsuleResult: WorkflowCapsuleExportResult | null;
+  compiling: boolean;
+  compiledWorkflowResult: CompiledWorkflowExportResult | null;
+  onExport: () => void;
+  onCreateCapsule: () => void;
+  onCompileWorkflow: () => void;
+}) {
+  const [replayIndex, setReplayIndex] = useState(0);
+
+  useEffect(() => {
+    setReplayIndex(0);
+  }, [run.runId]);
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="border-b px-5 py-4">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="min-w-0">
+            <div className="flex items-center gap-2">
+              <h2 className="truncate text-lg font-semibold">
+                {run.instruction || 'Untitled run'}
+              </h2>
+              <StatusBadge status={run.status} />
+              <ModeBadge mode={run.mode} />
+              <IntegrityBadge integrity={run.integrity} />
+            </div>
+            <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+              <span>{run.operator}</span>
+              <span>{formatDate(run.startedAt)}</span>
+              <span>{formatRunDuration(run)}</span>
+              <span>{run.storagePath}</span>
+            </div>
+          </div>
+          <div className="flex flex-wrap items-start justify-end gap-2">
+            <div className="grid grid-cols-2 gap-2 text-right text-xs">
+              <SummaryNumber label="Events" value={run.eventCount} />
+              <SummaryNumber label="Artifacts" value={run.artifactCount} />
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={onExport}
+              disabled={exporting}
+            >
+              <Download
+                className={cn('size-4', exporting && 'animate-pulse')}
+              />
+              Export Proof Pack
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={onCreateCapsule}
+              disabled={capsuleExporting}
+            >
+              <PackageCheck
+                className={cn('size-4', capsuleExporting && 'animate-pulse')}
+              />
+              Create Capsule
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={onCompileWorkflow}
+              disabled={compiling}
+            >
+              <Workflow
+                className={cn('size-4', compiling && 'animate-pulse')}
+              />
+              Compile Workflow
+            </Button>
+          </div>
+        </div>
+        {run.integrity.failureReason && (
+          <div className="mt-3 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+            {run.integrity.failureReason}
+          </div>
+        )}
+        {exportResult && (
+          <div className="mt-3 rounded-md border bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+            <span className="font-medium text-foreground">Exported: </span>
+            <span className="break-all">{exportResult.htmlPath}</span>
+            {exportResult.openError && (
+              <span className="block pt-1 text-amber-700">
+                Open failed: {exportResult.openError}
+              </span>
+            )}
+          </div>
+        )}
+        {capsuleResult && (
+          <div className="mt-3 rounded-md border bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+            <span className="font-medium text-foreground">Capsule: </span>
+            <span className="break-all">{capsuleResult.capsulePath}</span>
+            <span className="block pt-1">
+              {capsuleResult.stepCount} workflow steps captured.
+            </span>
+          </div>
+        )}
+        {compiledWorkflowResult && (
+          <div className="mt-3 rounded-md border bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+            <span className="font-medium text-foreground">Workflow: </span>
+            <span className="break-all">
+              {compiledWorkflowResult.workflowPath}
+            </span>
+            <span className="block pt-1">
+              {compiledWorkflowResult.stepCount} compiled steps ready for
+              simulation.
+            </span>
+          </div>
+        )}
+      </div>
+
+      <ScrollArea className="min-h-0 flex-1">
+        <div className="p-5">
+          <ReplayPanel
+            events={run.events}
+            currentIndex={replayIndex}
+            onIndexChange={setReplayIndex}
+          />
+          <div className="mt-6 space-y-0">
+            {run.events.map((event) => (
+              <TimelineEvent key={event.id} event={event} />
+            ))}
+          </div>
+        </div>
+      </ScrollArea>
+    </div>
+  );
+}
+
+function ReplayPanel({
+  events,
+  currentIndex,
+  onIndexChange,
+}: {
+  events: ProofPilotEvent[];
+  currentIndex: number;
+  onIndexChange: (index: number) => void;
+}) {
+  const event = events[currentIndex];
+  const eventCount = events.length;
+  const artifacts = event ? getArtifacts(event.payload) : [];
+  const previewArtifact = artifacts[0];
+  const rows = event ? getEventRows(event).slice(0, 6) : [];
+  const progress =
+    eventCount > 1 ? Math.round((currentIndex / (eventCount - 1)) * 100) : 100;
+
+  if (!event) {
+    return (
+      <section className="rounded-md border border-dashed px-4 py-8 text-center text-sm text-muted-foreground">
+        No replay events available.
+      </section>
+    );
+  }
+
+  return (
+    <section className="rounded-md border bg-muted/20 p-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <Badge variant="outline">
+              Step {currentIndex + 1} / {eventCount}
+            </Badge>
+            <span className="text-sm font-medium">
+              {eventLabels[event.type]}
+            </span>
+          </div>
+          <div className="mt-1 text-xs text-muted-foreground">
+            {formatDate(event.timestamp)}
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => onIndexChange(Math.max(0, currentIndex - 1))}
+            disabled={currentIndex === 0}
+          >
+            <ChevronLeft className="size-4" />
+            Previous
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() =>
+              onIndexChange(Math.min(eventCount - 1, currentIndex + 1))
+            }
+            disabled={currentIndex >= eventCount - 1}
+          >
+            Next
+            <ChevronRight className="size-4" />
+          </Button>
+        </div>
+      </div>
+
+      <div className="mt-4 h-2 overflow-hidden rounded-full bg-muted">
+        <div
+          className="h-full bg-primary transition-[width]"
+          style={{ width: `${progress}%` }}
+        />
+      </div>
+
+      <div className="mt-4 grid gap-4 xl:grid-cols-[minmax(0,1fr)_360px]">
+        <div className="grid content-start gap-2">
+          {rows.map((row) => (
+            <div
+              key={row.label}
+              className="grid gap-1 text-sm md:grid-cols-[7rem_minmax(0,1fr)]"
+            >
+              <div className="text-xs font-medium uppercase tracking-normal text-muted-foreground">
+                {row.label}
+              </div>
+              <div
+                className={cn(
+                  'min-w-0 whitespace-pre-wrap break-words text-foreground',
+                  row.label.includes('Hash') && 'break-all font-mono text-xs',
+                )}
+              >
+                {row.value}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="min-w-0">
+          {previewArtifact?.dataUrl ? (
+            <img
+              src={previewArtifact.dataUrl}
+              alt={previewArtifact.kind ?? 'replay frame'}
+              className="max-h-72 w-full rounded-md border bg-black object-contain"
+            />
+          ) : (
+            <div className="flex h-40 items-center justify-center rounded-md border border-dashed bg-background text-sm text-muted-foreground">
+              No visual frame for this step
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function SummaryNumber({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="min-w-20 rounded-md border px-3 py-2">
+      <div className="text-base font-semibold leading-none tabular-nums">
+        {value}
+      </div>
+      <div className="mt-1 text-muted-foreground">{label}</div>
+    </div>
+  );
+}
+
+function TimelineEvent({ event }: { event: ProofPilotEvent }) {
+  const payload = event.payload;
+  const rows = getEventRows(event);
+  const artifacts = getArtifacts(payload);
+  const Icon = getEventIcon(event.type);
+
+  return (
+    <div className="grid grid-cols-[36px_minmax(0,1fr)] gap-3">
+      <div className="flex flex-col items-center">
+        <div className="flex size-8 items-center justify-center rounded-full border bg-background">
+          <Icon className="size-4" />
+        </div>
+        <div className="min-h-6 flex-1 border-l" />
+      </div>
+      <div className="min-w-0 pb-6">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <div className="font-medium">{eventLabels[event.type]}</div>
+          <div className="text-xs text-muted-foreground">
+            {formatDate(event.timestamp)}
+          </div>
+        </div>
+        {rows.length > 0 && (
+          <div className="mt-3 grid gap-2">
+            {rows.map((row) => (
+              <div
+                key={row.label}
+                className="grid gap-1 text-sm md:grid-cols-[7rem_minmax(0,1fr)]"
+              >
+                <div className="text-xs font-medium uppercase tracking-normal text-muted-foreground">
+                  {row.label}
+                </div>
+                <div
+                  className={cn(
+                    'min-w-0 whitespace-pre-wrap break-words text-foreground',
+                    row.label.includes('Hash') && 'break-all font-mono text-xs',
+                  )}
+                >
+                  {row.value}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+        {artifacts.length > 0 && <ArtifactGrid artifacts={artifacts} />}
+      </div>
+    </div>
+  );
+}
+
+function ArtifactGrid({ artifacts }: { artifacts: ArtifactPreview[] }) {
+  return (
+    <div className="mt-4 grid gap-3 md:grid-cols-2">
+      {artifacts.map((artifact) => (
+        <div key={artifact.id} className="min-w-0">
+          <div className="mb-2 flex items-center justify-between gap-2 text-xs text-muted-foreground">
+            <span className="flex items-center gap-1">
+              <Camera className="size-3.5" />
+              {artifact.kind === 'som_screenshot'
+                ? 'SoM screenshot'
+                : 'Screenshot'}
+            </span>
+            <span>{formatBytes(artifact.bytes)}</span>
+          </div>
+          {artifact.dataUrl ? (
+            <img
+              src={artifact.dataUrl}
+              alt={artifact.kind ?? 'screenshot'}
+              className="max-h-72 w-full rounded-md border bg-black object-contain"
+            />
+          ) : (
+            <div className="flex h-32 items-center justify-center rounded-md border bg-muted text-sm text-muted-foreground">
+              {artifact.missing ? 'Artifact missing' : artifact.relativePath}
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function StatusBadge({ status }: { status: StatusEnum }) {
+  return (
+    <Badge
+      variant="outline"
+      className={cn('capitalize', getStatusClass(status))}
+    >
+      {status.replace('_', ' ')}
+    </Badge>
+  );
+}
+
+function ModeBadge({ mode }: { mode?: string }) {
+  if (mode !== 'simulation') {
+    return null;
+  }
+
+  return (
+    <Badge variant="outline" className="border-sky-200 bg-sky-50 text-sky-700">
+      <FlaskConical className="size-3" />
+      Simulation
+    </Badge>
+  );
+}
+
+function IntegrityBadge({
+  integrity,
+}: {
+  integrity: ProofPilotRunDetail['integrity'];
+}) {
+  const label =
+    integrity.status === 'verified'
+      ? 'Verified'
+      : integrity.status === 'legacy'
+        ? 'Legacy'
+        : 'Integrity failed';
+
+  return (
+    <Badge
+      variant="outline"
+      className={cn('capitalize', getIntegrityClass(integrity.status))}
+    >
+      {label}
+    </Badge>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div className="flex min-h-52 flex-col items-center justify-center rounded-md border border-dashed px-6 text-center">
+      <FileClock className="size-8 text-muted-foreground" />
+      <div className="mt-3 text-sm font-medium">No recorded runs</div>
+      <div className="mt-1 text-xs text-muted-foreground">
+        Start an agent run to create a proof trail.
+      </div>
+    </div>
+  );
+}
+
+function NoSelectionState() {
+  return (
+    <div className="flex h-full min-h-80 flex-col items-center justify-center px-6 text-center">
+      <ShieldCheck className="size-9 text-muted-foreground" />
+      <div className="mt-3 text-sm font-medium">Select a recorded run</div>
+      <div className="mt-1 text-xs text-muted-foreground">
+        The timeline will show captured conversations, planned actions, and
+        screenshots.
+      </div>
+    </div>
+  );
+}
+
+function ErrorState({
+  message,
+  onRetry,
+}: {
+  message: string;
+  onRetry: () => void;
+}) {
+  return (
+    <div className="flex h-full min-h-80 flex-col items-center justify-center gap-3 px-6 text-center">
+      <AlertTriangle className="size-9 text-destructive" />
+      <div className="max-w-md text-sm text-muted-foreground">{message}</div>
+      <Button variant="outline" size="sm" onClick={onRetry}>
+        <RefreshCw className="size-4" />
+        Retry
+      </Button>
+    </div>
+  );
+}
+
+function RunListSkeleton() {
+  return (
+    <>
+      {[0, 1, 2].map((index) => (
+        <div
+          key={index}
+          className="h-28 animate-pulse rounded-md border bg-muted"
+        />
+      ))}
+    </>
+  );
+}
+
+function DetailSkeleton() {
+  return (
+    <div className="space-y-4 p-5">
+      <div className="h-20 animate-pulse rounded-md border bg-muted" />
+      <div className="h-24 animate-pulse rounded-md border bg-muted" />
+      <div className="h-24 animate-pulse rounded-md border bg-muted" />
+    </div>
+  );
+}
+
+function getEventRows(event: ProofPilotEvent): Array<{
+  label: string;
+  value: string;
+}> {
+  const payload = event.payload;
+  const integrityRows: Array<[string, string | undefined]> = [
+    ['Event Hash', event.eventHash],
+    [
+      'Previous Hash',
+      event.eventHash ? (event.previousHash ?? 'Start of chain') : undefined,
+    ],
+  ];
+
+  switch (event.type) {
+    case 'run_started':
+      return compactRows([
+        ['Instruction', readString(payload.instruction)],
+        ['Mode', readString(payload.mode)],
+        ['Operator', readString(payload.operator)],
+        ['Model', joinParts(payload.modelProvider, payload.modelName)],
+        ...integrityRows,
+      ]);
+    case 'status_changed':
+      return compactRows([
+        ['Status', readString(payload.status)],
+        ...integrityRows,
+      ]);
+    case 'conversation_added':
+      return compactRows([
+        ['From', formatConversationFrom(payload.from)],
+        ['Message', formatMessageValue(payload.value)],
+        ['Timing', formatTiming(payload.timing)],
+        ['Actions', readString(payload.actionCount)],
+        ...integrityRows,
+      ]);
+    case 'action_planned':
+    case 'simulation_action_skipped':
+      return compactRows([
+        ['Action', readString(payload.actionType)],
+        ['Thought', readString(payload.thought)],
+        ['Reflection', readString(payload.reflection)],
+        ['Inputs', formatJson(payload.actionInputs)],
+        ...integrityRows,
+      ]);
+    case 'run_error':
+      return compactRows([
+        ['Error', formatErrorPayload(payload.error)],
+        ...integrityRows,
+      ]);
+    case 'run_finished':
+      return compactRows([
+        ['Status', readString(payload.status)],
+        ...integrityRows,
+      ]);
+    default:
+      return [];
+  }
+}
+
+function getEventIcon(type: ProofPilotEvent['type']) {
+  switch (type) {
+    case 'run_started':
+      return ShieldCheck;
+    case 'status_changed':
+      return Activity;
+    case 'conversation_added':
+      return Bot;
+    case 'action_planned':
+      return MousePointerClick;
+    case 'simulation_action_skipped':
+      return FlaskConical;
+    case 'run_error':
+      return AlertTriangle;
+    case 'run_finished':
+      return CheckCircle2;
+    default:
+      return CircleDot;
+  }
+}
+
+function getArtifacts(payload: PayloadRecord): ArtifactPreview[] {
+  return [payload.screenshot, payload.somScreenshot].filter(isArtifactPreview);
+}
+
+function isArtifactPreview(value: unknown): value is ArtifactPreview {
+  return (
+    isRecord(value) &&
+    typeof value.id === 'string' &&
+    typeof value.relativePath === 'string'
+  );
+}
+
+function compactRows(rows: Array<[string, string | undefined]>) {
+  return rows
+    .filter(([, value]) => Boolean(value))
+    .map(([label, value]) => ({ label, value: value ?? '' }));
+}
+
+function formatConversationFrom(value: unknown): string | undefined {
+  if (value === 'human') {
+    return 'Human';
+  }
+
+  if (value === 'gpt') {
+    return 'Agent';
+  }
+
+  return readString(value);
+}
+
+function formatMessageValue(value: unknown): string | undefined {
+  const message = readString(value);
+  if (message === '<image>') {
+    return 'Screenshot input';
+  }
+
+  return message;
+}
+
+function formatErrorPayload(value: unknown): string | undefined {
+  if (isRecord(value)) {
+    return readString(value.message) ?? formatJson(value);
+  }
+
+  return readString(value);
+}
+
+function formatTiming(value: unknown): string | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const parts = [
+    value.start !== undefined && `start ${readString(value.start)}`,
+    value.end !== undefined && `end ${readString(value.end)}`,
+    value.cost !== undefined && `cost ${readString(value.cost)}`,
+  ].filter(Boolean);
+
+  return parts.length ? parts.join(' | ') : undefined;
+}
+
+function formatJson(value: unknown): string | undefined {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function joinParts(...values: unknown[]): string | undefined {
+  const parts = values.map(readString).filter(Boolean);
+  return parts.length ? parts.join(' / ') : undefined;
+}
+
+function readString(value: unknown): string | undefined {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+
+  return String(value);
+}
+
+function formatDate(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return date.toLocaleString();
+}
+
+function formatRunDuration(run: ProofPilotRunDetail | ProofPilotRunSummary) {
+  const start = new Date(run.startedAt).getTime();
+  const end = run.finishedAt ? new Date(run.finishedAt).getTime() : Date.now();
+  if (Number.isNaN(start) || Number.isNaN(end)) {
+    return 'Duration unavailable';
+  }
+
+  const seconds = Math.max(0, Math.round((end - start) / 1000));
+  if (seconds < 60) {
+    return `${seconds}s`;
+  }
+
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  return `${minutes}m ${remainingSeconds}s`;
+}
+
+function formatBytes(value: unknown): string {
+  if (typeof value !== 'number') {
+    return '';
+  }
+
+  if (value < 1024) {
+    return `${value} B`;
+  }
+
+  return `${(value / 1024).toFixed(1)} KB`;
+}
+
+function getStatusClass(status: StatusEnum): string {
+  switch (status) {
+    case StatusEnum.END:
+      return 'border-emerald-200 bg-emerald-50 text-emerald-700';
+    case StatusEnum.RUNNING:
+      return 'border-blue-200 bg-blue-50 text-blue-700';
+    case StatusEnum.PAUSE:
+    case StatusEnum.CALL_USER:
+      return 'border-amber-200 bg-amber-50 text-amber-700';
+    case StatusEnum.ERROR:
+    case StatusEnum.MAX_LOOP:
+      return 'border-red-200 bg-red-50 text-red-700';
+    default:
+      return 'border-muted-foreground/20 bg-muted text-muted-foreground';
+  }
+}
+
+function getIntegrityClass(status: ProofPilotRunDetail['integrity']['status']) {
+  switch (status) {
+    case 'verified':
+      return 'border-emerald-200 bg-emerald-50 text-emerald-700';
+    case 'legacy':
+      return 'border-amber-200 bg-amber-50 text-amber-700';
+    case 'failed':
+      return 'border-red-200 bg-red-50 text-red-700';
+  }
+}
+
+function readErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error);
+}
+
+function isRecord(value: unknown): value is PayloadRecord {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}

--- a/apps/ui-tars/src/renderer/src/pages/team/index.tsx
+++ b/apps/ui-tars/src/renderer/src/pages/team/index.tsx
@@ -1,0 +1,622 @@
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+import {
+  AlertTriangle,
+  BarChart3,
+  Building2,
+  Download,
+  RefreshCw,
+  Save,
+  Trash2,
+  UserPlus,
+  Users,
+  type LucideIcon,
+} from 'lucide-react';
+
+import { api } from '@renderer/api';
+import { Badge } from '@renderer/components/ui/badge';
+import { Button } from '@renderer/components/ui/button';
+import { Input } from '@renderer/components/ui/input';
+import { ScrollArea } from '@renderer/components/ui/scroll-area';
+import { SidebarTrigger } from '@renderer/components/ui/sidebar';
+import { Switch } from '@renderer/components/ui/switch';
+import { cn } from '@renderer/utils';
+
+type TeamWorkspace = Awaited<ReturnType<typeof api.getTeamWorkspace>>;
+type TeamMember = TeamWorkspace['members'][number];
+type TeamPlan = TeamWorkspace['plan'];
+type TeamMemberRole = TeamMember['role'];
+type TeamAuditExportResult = Awaited<
+  ReturnType<typeof api.exportTeamAuditReport>
+>;
+
+type WorkspaceForm = {
+  workspaceName: string;
+  plan: TeamPlan;
+  seatLimit: number;
+  defaultRunMode: TeamWorkspace['policies']['defaultRunMode'];
+  approvalRequiredFor: TeamWorkspace['policies']['approvalRequiredFor'];
+  retentionDays: number;
+  proofPackRequired: boolean;
+  auditExportsEnabled: boolean;
+  allowLiveRuns: boolean;
+};
+
+const planOptions: TeamPlan[] = ['solo', 'team', 'business'];
+const roleOptions: TeamMemberRole[] = ['admin', 'operator', 'viewer'];
+
+export default function TeamConsole() {
+  const [workspace, setWorkspace] = useState<TeamWorkspace | null>(null);
+  const [form, setForm] = useState<WorkspaceForm | null>(null);
+  const [memberName, setMemberName] = useState('');
+  const [memberEmail, setMemberEmail] = useState('');
+  const [memberRole, setMemberRole] = useState<TeamMemberRole>('viewer');
+  const [auditResult, setAuditResult] = useState<TeamAuditExportResult | null>(
+    null,
+  );
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [exporting, setExporting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadWorkspace = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const nextWorkspace = await api.getTeamWorkspace();
+      setWorkspace(nextWorkspace);
+      setForm(createWorkspaceForm(nextWorkspace));
+    } catch (loadError) {
+      setError(readErrorMessage(loadError));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadWorkspace();
+  }, [loadWorkspace]);
+
+  const metrics = useMemo(() => {
+    if (!workspace) {
+      return {
+        seats: '0/0',
+        admins: 0,
+        operators: 0,
+        viewers: 0,
+      };
+    }
+
+    return {
+      seats: `${workspace.members.length}/${workspace.seatLimit}`,
+      admins: workspace.members.filter((member) => member.role === 'admin')
+        .length,
+      operators: workspace.members.filter(
+        (member) => member.role === 'operator',
+      ).length,
+      viewers: workspace.members.filter((member) => member.role === 'viewer')
+        .length,
+    };
+  }, [workspace]);
+
+  const handleSave = useCallback(async () => {
+    if (!form) {
+      return;
+    }
+
+    setSaving(true);
+    setError(null);
+
+    try {
+      const updated = await api.updateTeamWorkspace({
+        workspaceName: form.workspaceName,
+        plan: form.plan,
+        seatLimit: form.seatLimit,
+        policies: {
+          defaultRunMode: form.defaultRunMode,
+          approvalRequiredFor: form.approvalRequiredFor,
+          retentionDays: form.retentionDays,
+          proofPackRequired: form.proofPackRequired,
+          auditExportsEnabled: form.auditExportsEnabled,
+          allowLiveRuns: form.allowLiveRuns,
+        },
+      });
+      setWorkspace(updated);
+      setForm(createWorkspaceForm(updated));
+    } catch (saveError) {
+      setError(readErrorMessage(saveError));
+    } finally {
+      setSaving(false);
+    }
+  }, [form]);
+
+  const handleAddMember = useCallback(async () => {
+    setError(null);
+
+    try {
+      const updated = await api.upsertTeamMember({
+        name: memberName,
+        email: memberEmail,
+        role: memberRole,
+      });
+      setWorkspace(updated);
+      setForm(createWorkspaceForm(updated));
+      setMemberName('');
+      setMemberEmail('');
+      setMemberRole('viewer');
+    } catch (memberError) {
+      setError(readErrorMessage(memberError));
+    }
+  }, [memberEmail, memberName, memberRole]);
+
+  const handleRemoveMember = useCallback(async (memberId: string) => {
+    setError(null);
+
+    try {
+      const updated = await api.removeTeamMember({ id: memberId });
+      setWorkspace(updated);
+      setForm(createWorkspaceForm(updated));
+    } catch (removeError) {
+      setError(readErrorMessage(removeError));
+    }
+  }, []);
+
+  const handleExportAudit = useCallback(async () => {
+    setExporting(true);
+    setError(null);
+
+    try {
+      const result = await api.exportTeamAuditReport({ reveal: true });
+      setAuditResult(result);
+    } catch (exportError) {
+      setError(readErrorMessage(exportError));
+    } finally {
+      setExporting(false);
+    }
+  }, []);
+
+  return (
+    <div className="flex h-full min-h-0 w-full flex-col bg-background">
+      <header className="flex h-16 shrink-0 items-center justify-between border-b px-5">
+        <div className="flex min-w-0 items-center gap-3">
+          <SidebarTrigger variant="secondary" className="size-8" />
+          <div className="flex size-9 shrink-0 items-center justify-center rounded-md border bg-muted text-foreground">
+            <Building2 className="size-5" />
+          </div>
+          <div className="min-w-0">
+            <h1 className="truncate text-base font-semibold">Team Workspace</h1>
+            <p className="truncate text-xs text-muted-foreground">
+              Commercial controls
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={loadWorkspace}
+            disabled={loading}
+          >
+            <RefreshCw className={cn('size-4', loading && 'animate-spin')} />
+            Refresh
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleExportAudit}
+            disabled={exporting || !workspace}
+          >
+            <Download className={cn('size-4', exporting && 'animate-pulse')} />
+            Export Audit
+          </Button>
+        </div>
+      </header>
+
+      <ScrollArea className="min-h-0 flex-1">
+        <main className="grid gap-5 p-5 xl:grid-cols-[minmax(0,1fr)_360px]">
+          <div className="min-w-0 space-y-5">
+            {error && (
+              <div className="flex items-start gap-2 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+                <AlertTriangle className="mt-0.5 size-4 shrink-0" />
+                <span>{error}</span>
+              </div>
+            )}
+
+            <section className="rounded-md border">
+              <div className="flex items-center justify-between border-b px-4 py-3">
+                <div>
+                  <h2 className="text-sm font-semibold">Workspace Profile</h2>
+                  <p className="text-xs text-muted-foreground">
+                    Billing-ready identity and seat configuration.
+                  </p>
+                </div>
+                <Button
+                  size="sm"
+                  onClick={handleSave}
+                  disabled={saving || !form}
+                >
+                  <Save className="size-4" />
+                  Save
+                </Button>
+              </div>
+              {form ? (
+                <div className="grid gap-4 p-4 md:grid-cols-3">
+                  <Field label="Workspace">
+                    <Input
+                      value={form.workspaceName}
+                      onChange={(event) =>
+                        setForm({
+                          ...form,
+                          workspaceName: event.target.value,
+                        })
+                      }
+                    />
+                  </Field>
+                  <Field label="Plan">
+                    <select
+                      className="h-9 w-full rounded-md border bg-background px-3 text-sm"
+                      value={form.plan}
+                      onChange={(event) =>
+                        setForm({
+                          ...form,
+                          plan: event.target.value as TeamPlan,
+                        })
+                      }
+                    >
+                      {planOptions.map((plan) => (
+                        <option key={plan} value={plan}>
+                          {formatLabel(plan)}
+                        </option>
+                      ))}
+                    </select>
+                  </Field>
+                  <Field label="Seat Limit">
+                    <Input
+                      type="number"
+                      min={1}
+                      value={form.seatLimit}
+                      onChange={(event) =>
+                        setForm({
+                          ...form,
+                          seatLimit: Number(event.target.value),
+                        })
+                      }
+                    />
+                  </Field>
+                </div>
+              ) : (
+                <div className="p-4 text-sm text-muted-foreground">
+                  Loading workspace...
+                </div>
+              )}
+            </section>
+
+            <section className="rounded-md border">
+              <div className="border-b px-4 py-3">
+                <h2 className="text-sm font-semibold">Governance Policy</h2>
+                <p className="text-xs text-muted-foreground">
+                  Defaults that make the product easier to sell into teams.
+                </p>
+              </div>
+              {form && (
+                <div className="grid gap-4 p-4 md:grid-cols-2">
+                  <Field label="Default Run Mode">
+                    <select
+                      className="h-9 w-full rounded-md border bg-background px-3 text-sm"
+                      value={form.defaultRunMode}
+                      onChange={(event) =>
+                        setForm({
+                          ...form,
+                          defaultRunMode: event.target
+                            .value as WorkspaceForm['defaultRunMode'],
+                        })
+                      }
+                    >
+                      <option value="simulation">Simulation</option>
+                      <option value="live">Live</option>
+                    </select>
+                  </Field>
+                  <Field label="Approval Required For">
+                    <select
+                      className="h-9 w-full rounded-md border bg-background px-3 text-sm"
+                      value={form.approvalRequiredFor}
+                      onChange={(event) =>
+                        setForm({
+                          ...form,
+                          approvalRequiredFor: event.target
+                            .value as WorkspaceForm['approvalRequiredFor'],
+                        })
+                      }
+                    >
+                      <option value="none">None</option>
+                      <option value="high_risk">High Risk</option>
+                      <option value="all_live_runs">All Live Runs</option>
+                    </select>
+                  </Field>
+                  <Field label="Retention Days">
+                    <Input
+                      type="number"
+                      min={1}
+                      value={form.retentionDays}
+                      onChange={(event) =>
+                        setForm({
+                          ...form,
+                          retentionDays: Number(event.target.value),
+                        })
+                      }
+                    />
+                  </Field>
+                  <div className="grid gap-3">
+                    <PolicyToggle
+                      label="Require proof packs"
+                      checked={form.proofPackRequired}
+                      onCheckedChange={(checked) =>
+                        setForm({ ...form, proofPackRequired: checked })
+                      }
+                    />
+                    <PolicyToggle
+                      label="Enable audit exports"
+                      checked={form.auditExportsEnabled}
+                      onCheckedChange={(checked) =>
+                        setForm({ ...form, auditExportsEnabled: checked })
+                      }
+                    />
+                    <PolicyToggle
+                      label="Allow live runs"
+                      checked={form.allowLiveRuns}
+                      onCheckedChange={(checked) =>
+                        setForm({ ...form, allowLiveRuns: checked })
+                      }
+                    />
+                  </div>
+                </div>
+              )}
+            </section>
+
+            <section className="rounded-md border">
+              <div className="border-b px-4 py-3">
+                <h2 className="text-sm font-semibold">Members</h2>
+                <p className="text-xs text-muted-foreground">
+                  Local roster for roles, review ownership, and future billing.
+                </p>
+              </div>
+              <div className="grid gap-3 border-b p-4 md:grid-cols-[1fr_1fr_160px_auto]">
+                <Input
+                  placeholder="Name"
+                  value={memberName}
+                  onChange={(event) => setMemberName(event.target.value)}
+                />
+                <Input
+                  placeholder="Email"
+                  value={memberEmail}
+                  onChange={(event) => setMemberEmail(event.target.value)}
+                />
+                <select
+                  className="h-9 rounded-md border bg-background px-3 text-sm"
+                  value={memberRole}
+                  onChange={(event) =>
+                    setMemberRole(event.target.value as TeamMemberRole)
+                  }
+                >
+                  {roleOptions.map((role) => (
+                    <option key={role} value={role}>
+                      {formatLabel(role)}
+                    </option>
+                  ))}
+                </select>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleAddMember}
+                  disabled={!memberName.trim() || !memberEmail.trim()}
+                >
+                  <UserPlus className="size-4" />
+                  Add
+                </Button>
+              </div>
+              <div className="divide-y">
+                {workspace?.members.map((member) => (
+                  <MemberRow
+                    key={member.id}
+                    member={member}
+                    onRemove={() => handleRemoveMember(member.id)}
+                  />
+                ))}
+              </div>
+            </section>
+          </div>
+
+          <aside className="min-w-0 space-y-5">
+            <section className="rounded-md border">
+              <div className="border-b px-4 py-3">
+                <h2 className="text-sm font-semibold">Readiness Snapshot</h2>
+              </div>
+              <div className="grid grid-cols-2 gap-3 p-4">
+                <Metric icon={Users} label="Seats" value={metrics.seats} />
+                <Metric
+                  icon={BarChart3}
+                  label="Plan"
+                  value={workspace ? formatLabel(workspace.plan) : '-'}
+                />
+                <Metric icon={Users} label="Admins" value={metrics.admins} />
+                <Metric
+                  icon={Users}
+                  label="Operators"
+                  value={metrics.operators}
+                />
+              </div>
+            </section>
+
+            {auditResult && (
+              <section className="rounded-md border">
+                <div className="border-b px-4 py-3">
+                  <h2 className="text-sm font-semibold">Last Audit Export</h2>
+                </div>
+                <div className="space-y-3 p-4 text-xs">
+                  <div>
+                    <div className="text-muted-foreground">Report</div>
+                    <div className="break-all font-mono">
+                      {auditResult.reportId}
+                    </div>
+                  </div>
+                  <div>
+                    <div className="text-muted-foreground">HTML</div>
+                    <div className="break-all">{auditResult.htmlPath}</div>
+                  </div>
+                  <div className="grid gap-2">
+                    {auditResult.readiness.map((item) => (
+                      <div
+                        key={item.id}
+                        className="flex items-center justify-between gap-2"
+                      >
+                        <span>{item.label}</span>
+                        <Badge
+                          variant="outline"
+                          className={cn(
+                            item.status === 'ready'
+                              ? 'border-emerald-200 bg-emerald-50 text-emerald-700'
+                              : 'border-amber-200 bg-amber-50 text-amber-700',
+                          )}
+                        >
+                          {formatLabel(item.status)}
+                        </Badge>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </section>
+            )}
+          </aside>
+        </main>
+      </ScrollArea>
+    </div>
+  );
+}
+
+function Field({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <label className="grid gap-1.5 text-sm">
+      <span className="text-xs font-medium text-muted-foreground">{label}</span>
+      {children}
+    </label>
+  );
+}
+
+function PolicyToggle({
+  label,
+  checked,
+  onCheckedChange,
+}: {
+  label: string;
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+}) {
+  return (
+    <label className="flex h-9 items-center justify-between gap-3 rounded-md border px-3 text-sm">
+      <span>{label}</span>
+      <Switch checked={checked} onCheckedChange={onCheckedChange} />
+    </label>
+  );
+}
+
+function MemberRow({
+  member,
+  onRemove,
+}: {
+  member: TeamMember;
+  onRemove: () => void;
+}) {
+  return (
+    <div className="grid items-center gap-3 px-4 py-3 text-sm md:grid-cols-[minmax(0,1fr)_180px_120px_auto]">
+      <div className="min-w-0">
+        <div className="truncate font-medium">{member.name}</div>
+        <div className="truncate text-xs text-muted-foreground">
+          {member.email}
+        </div>
+      </div>
+      <Badge variant="outline">{formatLabel(member.role)}</Badge>
+      <Badge
+        variant="outline"
+        className={
+          member.status === 'active'
+            ? 'border-emerald-200 bg-emerald-50 text-emerald-700'
+            : 'border-blue-200 bg-blue-50 text-blue-700'
+        }
+      >
+        {formatLabel(member.status)}
+      </Badge>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="size-8"
+        onClick={onRemove}
+        disabled={member.role === 'owner'}
+      >
+        <Trash2 className="size-4" />
+      </Button>
+    </div>
+  );
+}
+
+function Metric({
+  icon: Icon,
+  label,
+  value,
+}: {
+  icon: LucideIcon;
+  label: string;
+  value: string | number;
+}) {
+  return (
+    <div className="rounded-md border bg-muted/30 px-3 py-2">
+      <div className="flex items-center justify-between gap-2">
+        <div className="text-lg font-semibold leading-none tabular-nums">
+          {value}
+        </div>
+        <Icon className="size-4 text-muted-foreground" />
+      </div>
+      <div className="mt-1 text-[11px] uppercase tracking-normal text-muted-foreground">
+        {label}
+      </div>
+    </div>
+  );
+}
+
+function createWorkspaceForm(workspace: TeamWorkspace): WorkspaceForm {
+  return {
+    workspaceName: workspace.workspaceName,
+    plan: workspace.plan,
+    seatLimit: workspace.seatLimit,
+    defaultRunMode: workspace.policies.defaultRunMode,
+    approvalRequiredFor: workspace.policies.approvalRequiredFor,
+    retentionDays: workspace.policies.retentionDays,
+    proofPackRequired: workspace.policies.proofPackRequired,
+    auditExportsEnabled: workspace.policies.auditExportsEnabled,
+    allowLiveRuns: workspace.policies.allowLiveRuns,
+  };
+}
+
+function formatLabel(value: string): string {
+  return value
+    .split('_')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+function readErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error);
+}

--- a/packages/agent-infra/mcp-servers/commands/README.md
+++ b/packages/agent-infra/mcp-servers/commands/README.md
@@ -4,17 +4,14 @@
 
 [![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/install-mcp?name=filesystem&config=eyJjb21tYW5kIjoibnB4IEBhZ2VudC1pbmZyYS9tY3Atc2VydmVyLWNvbW1hbmRzQGxhdGVzdCJ9) [<img src="https://img.shields.io/badge/VS_Code-VS_Code?style=flat-square&label=Install%20Server&color=0098FF" alt="Install in VS Code">](https://insiders.vscode.dev/redirect?url=vscode%253Amcp%252Finstall%253F%257B%2522name%2522%253A%2522commands%2522%252C%2522command%2522%253A%2522npx%2522%252C%2522args%2522%253A%255B%2522%2540agent-infra%252Fmcp-server-commands%2540latest%2522%255D%257D) [<img alt="Install in VS Code Insiders" src="https://img.shields.io/badge/VS_Code_Insiders-VS_Code_Insiders?style=flat-square&label=Install%20Server&color=24bfa5">](https://insiders.vscode.dev/redirect?url=vscode-insiders%253Amcp%252Finstall%253F%257B%2522name%2522%253A%2522commands%2522%252C%2522command%2522%253A%2522npx%2522%252C%2522args%2522%253A%255B%2522%2540agent-infra%252Fmcp-server-commands%2540latest%2522%255D%257D)
 
-
 A Model Context Protocol (MCP) server that provides execuate arbitrary commands.
 
 ![](https://github.com/user-attachments/assets/ee8df75f-04f4-46c8-8b57-0e32e4373c3e)
-
 
 ### Requirements
 
 - Node.js 18 or newer
 - VS Code, Cursor, Windsurf, Claude Desktop or any other MCP client
-
 
 ### Getting started
 
@@ -48,6 +45,7 @@ code --add-mcp '{"name":"commands","command":"npx","args":["@agent-infra/mcp-ser
 ```
 
 After installation, the Commands MCP server will be available for use with your GitHub Copilot agent in VS Code.
+
 </details>
 
 <details>
@@ -68,6 +66,7 @@ Go to `Cursor Settings` -> `MCP` -> `Add new MCP Server`. Name to your liking, u
   }
 }
 ```
+
 </details>
 
 <details>
@@ -88,6 +87,7 @@ Follow Windsuff MCP [documentation](https://docs.windsurf.com/windsurf/cascade/m
   }
 }
 ```
+
 </details>
 
 <details>
@@ -108,6 +108,7 @@ Follow the MCP install [guide](https://modelcontextprotocol.io/quickstart/user),
   }
 }
 ```
+
 </details>
 
 #### Remote (SSE / Streamable HTTP)
@@ -120,9 +121,9 @@ npx @agent-infra/mcp-server-commands --port 8089
 ```
 
 You can use one of the two MCP Server remote endpoint:
+
 - Streamable HTTP(Recommended): `http://127.0.0.1::8089/mcp`
 - SSE: `http://127.0.0.1::8089/sse`
-
 
 And then in MCP client config, set the `url` to the SSE endpoint:
 
@@ -194,6 +195,38 @@ const toolResult = await client.callTool({
 });
 console.log(toolResult);
 ```
+
+### Safety policy
+
+Commands MCP includes a server-side safety policy for high-risk command
+execution. Commands that match the default destructive patterns are not
+executed immediately; the tool returns an `approval_required` result with the
+matched rule id and approval request id.
+
+Default approval-required categories include recursive or forceful deletion,
+disk or partition mutation, shutdown or restart operations, privileged command
+execution, destructive git commands, and remote script execution such as
+`curl | sh`.
+
+In-process callers can customize the policy:
+
+```js
+const server = createServer({
+  safety: {
+    rules: [
+      {
+        id: 'allow-known-cleanup',
+        action: 'allow',
+        reason: 'This cleanup command is handled by the host approval flow.',
+        patterns: [String.raw`git\s+clean\s+-fd\s+build`],
+      },
+    ],
+  },
+});
+```
+
+Set `COMMANDS_SAFETY_ENABLED=false` to disable the policy for trusted,
+externally sandboxed environments.
 
 ### Developement
 

--- a/packages/agent-infra/mcp-servers/commands/src/safety-policy.ts
+++ b/packages/agent-infra/mcp-servers/commands/src/safety-policy.ts
@@ -1,0 +1,222 @@
+import { createHash } from 'node:crypto';
+
+type CommandSafetyAction = 'allow' | 'deny' | 'require_approval';
+
+type CommandSafetyRule = {
+  id: string;
+  action: CommandSafetyAction;
+  reason: string;
+  patterns: string[];
+};
+
+type CommandSafetyPolicyConfig = {
+  enabled?: boolean;
+  defaultAction?: CommandSafetyAction;
+  defaultReason?: string;
+  useDefaultRules?: boolean;
+  rules?: CommandSafetyRule[];
+};
+
+type CommandSafetySubject = {
+  toolName: string;
+  command?: string;
+  interpreter?: string;
+  script?: string;
+  cwd?: string;
+};
+
+type CommandSafetyDecision = {
+  action: CommandSafetyAction;
+  reason?: string;
+  ruleId?: string;
+  approvalRequestId?: string;
+};
+
+const DEFAULT_COMMAND_SAFETY_RULES: CommandSafetyRule[] = [
+  {
+    id: 'destructive-file-removal',
+    action: 'require_approval',
+    reason:
+      'The command appears to recursively or forcefully remove filesystem data.',
+    patterns: [
+      String.raw`(?:^|[;&|]\s*)rm\s+(?:-[^\s]*[rRfF][^\s]*|--recursive|--force)`,
+      String.raw`(?:^|[;&|]\s*)rmdir\s+(?:/s|-[^\s]*r)`,
+      String.raw`(?:^|[;&|]\s*)del(?:ete)?\s+[\s\S]*(?:/s|/q)`,
+      String.raw`\bRemove-Item\b[\s\S]*(?:-Recurse|-Force)`,
+    ],
+  },
+  {
+    id: 'disk-or-partition-mutation',
+    action: 'require_approval',
+    reason: 'The command appears to modify disks, partitions, or filesystems.',
+    patterns: [
+      String.raw`(?:^|[;&|]\s*)(?:format|mkfs(?:\.[a-z0-9]+)?|fdisk|parted|diskpart|diskutil)\b`,
+    ],
+  },
+  {
+    id: 'system-power-action',
+    action: 'require_approval',
+    reason:
+      'The command appears to shut down, restart, or power off the system.',
+    patterns: [
+      String.raw`(?:^|[;&|]\s*)(?:shutdown|reboot|halt|poweroff)\b`,
+      String.raw`\bRestart-Computer\b`,
+      String.raw`\bStop-Computer\b`,
+    ],
+  },
+  {
+    id: 'privileged-or-recursive-permission-change',
+    action: 'require_approval',
+    reason:
+      'The command appears to request elevated privileges or recursively change permissions.',
+    patterns: [
+      String.raw`(?:^|[;&|]\s*)(?:sudo|su)\b`,
+      String.raw`(?:^|[;&|]\s*)(?:chmod|chown)\s+[\s\S]*(?:-R|--recursive)`,
+    ],
+  },
+  {
+    id: 'destructive-git-operation',
+    action: 'require_approval',
+    reason:
+      'The command appears to destructively modify git working tree state.',
+    patterns: [
+      String.raw`(?:^|[;&|]\s*)git\s+reset\s+--hard\b`,
+      String.raw`(?:^|[;&|]\s*)git\s+clean\s+-[^\s]*f`,
+    ],
+  },
+  {
+    id: 'remote-script-execution',
+    action: 'require_approval',
+    reason:
+      'The command appears to download remote content and pipe it into a shell or evaluator.',
+    patterns: [
+      String.raw`\b(?:curl|wget)\b[\s\S]*\|[\s\S]*(?:sh|bash|zsh|fish|powershell|pwsh)\b`,
+      String.raw`\b(?:Invoke-WebRequest|Invoke-RestMethod|iwr|irm)\b[\s\S]*(?:Invoke-Expression|\biex\b)`,
+    ],
+  },
+];
+
+function resolveSafetyPolicy(policy?: CommandSafetyPolicyConfig): Required<
+  Pick<CommandSafetyPolicyConfig, 'enabled' | 'defaultAction' | 'rules'>
+> & {
+  defaultReason?: string;
+} {
+  const useDefaultRules = policy?.useDefaultRules ?? true;
+  return {
+    enabled: policy?.enabled ?? process.env.COMMANDS_SAFETY_ENABLED !== 'false',
+    defaultAction: policy?.defaultAction ?? 'allow',
+    defaultReason: policy?.defaultReason,
+    rules: [
+      ...(policy?.rules ?? []),
+      ...(useDefaultRules ? DEFAULT_COMMAND_SAFETY_RULES : []),
+    ],
+  };
+}
+
+function evaluateCommandSafety(
+  subject: CommandSafetySubject,
+  policy?: CommandSafetyPolicyConfig,
+): CommandSafetyDecision {
+  const resolvedPolicy = resolveSafetyPolicy(policy);
+
+  if (!resolvedPolicy.enabled) {
+    return { action: 'allow' };
+  }
+
+  const executableText = getExecutableText(subject);
+
+  for (const rule of resolvedPolicy.rules) {
+    if (
+      rule.patterns.some((pattern) => matchesPattern(pattern, executableText))
+    ) {
+      if (rule.action === 'allow') {
+        return { action: 'allow' };
+      }
+      return decisionForAction(rule.action, subject, rule.reason, rule.id);
+    }
+  }
+
+  if (resolvedPolicy.defaultAction !== 'allow') {
+    return decisionForAction(
+      resolvedPolicy.defaultAction,
+      subject,
+      resolvedPolicy.defaultReason ?? 'The command requires explicit approval.',
+    );
+  }
+
+  return { action: 'allow' };
+}
+
+function formatSafetyDecision(decision: CommandSafetyDecision): string {
+  const status =
+    decision.action === 'require_approval'
+      ? 'approval_required'
+      : decision.action;
+
+  const lines = [
+    `Command safety policy: ${status}`,
+    'No command was executed.',
+  ];
+
+  if (decision.ruleId) {
+    lines.push(`Rule: ${decision.ruleId}`);
+  }
+  if (decision.reason) {
+    lines.push(`Reason: ${decision.reason}`);
+  }
+  if (decision.approvalRequestId) {
+    lines.push(`Approval request: ${decision.approvalRequestId}`);
+  }
+
+  return lines.join('\n');
+}
+
+function getExecutableText(subject: CommandSafetySubject): string {
+  return [subject.command, subject.interpreter, subject.script]
+    .filter((part): part is string => Boolean(part))
+    .join('\n');
+}
+
+function matchesPattern(pattern: string, value: string): boolean {
+  return new RegExp(pattern, 'im').test(value);
+}
+
+function decisionForAction(
+  action: Exclude<CommandSafetyAction, 'allow'>,
+  subject: CommandSafetySubject,
+  reason?: string,
+  ruleId?: string,
+): CommandSafetyDecision {
+  return {
+    action,
+    reason,
+    ruleId,
+    approvalRequestId:
+      action === 'require_approval'
+        ? createApprovalRequestId(subject, ruleId)
+        : undefined,
+  };
+}
+
+function createApprovalRequestId(
+  subject: CommandSafetySubject,
+  ruleId?: string,
+): string {
+  return createHash('sha256')
+    .update(JSON.stringify({ ...subject, ruleId }))
+    .digest('hex')
+    .slice(0, 16);
+}
+
+export {
+  DEFAULT_COMMAND_SAFETY_RULES,
+  evaluateCommandSafety,
+  formatSafetyDecision,
+};
+export type {
+  CommandSafetyAction,
+  CommandSafetyDecision,
+  CommandSafetyPolicyConfig,
+  CommandSafetyRule,
+  CommandSafetySubject,
+};

--- a/packages/agent-infra/mcp-servers/commands/src/safety-policy.ts
+++ b/packages/agent-infra/mcp-servers/commands/src/safety-policy.ts
@@ -32,6 +32,19 @@ type CommandSafetyDecision = {
   approvalRequestId?: string;
 };
 
+type CommandApprovalRiskLevel = 'low' | 'medium' | 'high' | 'critical';
+
+type CommandApprovalRequest = {
+  id: string;
+  title: string;
+  reason: string;
+  source: 'commands';
+  riskLevel: CommandApprovalRiskLevel;
+  ruleId?: string;
+  subject: CommandSafetySubject;
+  createdAt: string;
+};
+
 const DEFAULT_COMMAND_SAFETY_RULES: CommandSafetyRule[] = [
   {
     id: 'destructive-file-removal',
@@ -171,10 +184,67 @@ function formatSafetyDecision(decision: CommandSafetyDecision): string {
   return lines.join('\n');
 }
 
+function createCommandApprovalRequest(
+  decision: CommandSafetyDecision,
+  subject: CommandSafetySubject,
+  createdAt = new Date().toISOString(),
+): CommandApprovalRequest | undefined {
+  if (decision.action !== 'require_approval' || !decision.approvalRequestId) {
+    return undefined;
+  }
+
+  return {
+    id: decision.approvalRequestId,
+    title: createApprovalTitle(subject),
+    reason: decision.reason ?? 'The command requires explicit approval.',
+    source: 'commands',
+    riskLevel: getApprovalRiskLevel(decision.ruleId),
+    ruleId: decision.ruleId,
+    subject,
+    createdAt,
+  };
+}
+
 function getExecutableText(subject: CommandSafetySubject): string {
   return [subject.command, subject.interpreter, subject.script]
     .filter((part): part is string => Boolean(part))
     .join('\n');
+}
+
+function createApprovalTitle(subject: CommandSafetySubject): string {
+  if (subject.toolName === 'run_script') {
+    return `Approve script execution: ${subject.interpreter ?? 'unknown interpreter'}`;
+  }
+
+  if (subject.toolName === 'prompt/run_command') {
+    return `Approve command prompt: ${truncate(subject.command ?? 'unknown command')}`;
+  }
+
+  return `Approve command: ${truncate(subject.command ?? 'unknown command')}`;
+}
+
+function getApprovalRiskLevel(ruleId?: string): CommandApprovalRiskLevel {
+  switch (ruleId) {
+    case 'destructive-file-removal':
+    case 'disk-or-partition-mutation':
+    case 'system-power-action':
+      return 'critical';
+    case 'destructive-git-operation':
+    case 'privileged-or-recursive-permission-change':
+    case 'remote-script-execution':
+      return 'high';
+    default:
+      return 'medium';
+  }
+}
+
+function truncate(value: string): string {
+  const normalized = value.replace(/\s+/g, ' ').trim();
+  if (normalized.length <= 80) {
+    return normalized;
+  }
+
+  return `${normalized.slice(0, 77)}...`;
 }
 
 function matchesPattern(pattern: string, value: string): boolean {
@@ -210,10 +280,13 @@ function createApprovalRequestId(
 
 export {
   DEFAULT_COMMAND_SAFETY_RULES,
+  createCommandApprovalRequest,
   evaluateCommandSafety,
   formatSafetyDecision,
 };
 export type {
+  CommandApprovalRequest,
+  CommandApprovalRiskLevel,
   CommandSafetyAction,
   CommandSafetyDecision,
   CommandSafetyPolicyConfig,

--- a/packages/agent-infra/mcp-servers/commands/src/server.ts
+++ b/packages/agent-infra/mcp-servers/commands/src/server.ts
@@ -24,9 +24,13 @@ import {
   always_log,
 } from './exec-utils.js';
 import {
+  createCommandApprovalRequest,
   evaluateCommandSafety,
   formatSafetyDecision,
+  type CommandApprovalRequest,
   type CommandSafetyPolicyConfig,
+  type CommandSafetyDecision,
+  type CommandSafetySubject,
 } from './safety-policy.js';
 
 // TODO use .promises? in node api
@@ -35,6 +39,22 @@ const execAsync = promisify(exec);
 type CommandServerConfig = {
   cwd?: string;
   safety?: CommandSafetyPolicyConfig;
+  approvals?: CommandApprovalHooks;
+};
+
+type CommandApprovalDecision = 'pending' | 'approved' | 'denied';
+
+type CommandApprovalHooks = {
+  onApprovalRequired?: (
+    request: CommandApprovalRequest,
+  ) => void | Promise<void>;
+  getDecision?: (
+    approvalRequestId: string,
+  ) =>
+    | CommandApprovalDecision
+    | undefined
+    | Promise<CommandApprovalDecision | undefined>;
+  now?: () => Date;
 };
 
 function createServer(serverConfig?: CommandServerConfig): McpServer {
@@ -43,6 +63,7 @@ function createServer(serverConfig?: CommandServerConfig): McpServer {
     version: process.env.VERSION || '0.0.1',
   });
   const safetyPolicy = serverConfig?.safety;
+  const approvalHooks = serverConfig?.approvals;
 
   // === Tools ===
   // @ts-ignore
@@ -59,7 +80,7 @@ function createServer(serverConfig?: CommandServerConfig): McpServer {
           .describe('Current working directory, leave empty in most cases'),
       },
     },
-    async (args) => await runCommand(args, safetyPolicy),
+    async (args) => await runCommand(args, safetyPolicy, approvalHooks),
   );
 
   server.registerTool(
@@ -81,7 +102,7 @@ function createServer(serverConfig?: CommandServerConfig): McpServer {
           .describe('Current working directory, leave empty in most cases'),
       },
     },
-    async (args) => await runScript(args, safetyPolicy),
+    async (args) => await runScript(args, safetyPolicy, approvalHooks),
   );
 
   // ==== Prompts ====
@@ -96,12 +117,14 @@ function createServer(serverConfig?: CommandServerConfig): McpServer {
       },
     },
     async ({ command }) => {
-      const safetyDecision = evaluateCommandSafety(
-        {
-          toolName: 'prompt/run_command',
-          command,
-        },
+      const subject = {
+        toolName: 'prompt/run_command',
+        command,
+      };
+      const safetyDecision = await evaluateSafetyWithApprovals(
+        subject,
         safetyPolicy,
+        approvalHooks,
       );
       if (safetyDecision.action !== 'allow') {
         const messages: PromptMessage[] = [
@@ -164,6 +187,7 @@ function createServer(serverConfig?: CommandServerConfig): McpServer {
 async function runCommand(
   args: Record<string, unknown> | undefined,
   safetyPolicy?: CommandSafetyPolicyConfig,
+  approvalHooks?: CommandApprovalHooks,
 ): Promise<CallToolResult> {
   const command = stringArg(args?.command);
   if (!command?.trim()) {
@@ -171,13 +195,15 @@ async function runCommand(
   }
 
   const cwd = stringArg(args?.cwd);
-  const safetyDecision = evaluateCommandSafety(
-    {
-      toolName: 'run_command',
-      command,
-      cwd,
-    },
+  const subject = {
+    toolName: 'run_command',
+    command,
+    cwd,
+  };
+  const safetyDecision = await evaluateSafetyWithApprovals(
+    subject,
     safetyPolicy,
+    approvalHooks,
   );
   if (safetyDecision.action !== 'allow') {
     return blockedToolResult(safetyDecision);
@@ -211,6 +237,7 @@ async function runCommand(
 async function runScript(
   args: Record<string, unknown> | undefined,
   safetyPolicy?: CommandSafetyPolicyConfig,
+  approvalHooks?: CommandApprovalHooks,
 ): Promise<CallToolResult> {
   const interpreter = stringArg(args?.interpreter);
   if (!interpreter?.trim()) {
@@ -233,14 +260,16 @@ async function runScript(
     throw new Error('Script is required');
   }
 
-  const safetyDecision = evaluateCommandSafety(
-    {
-      toolName: 'run_script',
-      interpreter,
-      script,
-      cwd,
-    },
+  const subject = {
+    toolName: 'run_script',
+    interpreter,
+    script,
+    cwd,
+  };
+  const safetyDecision = await evaluateSafetyWithApprovals(
+    subject,
     safetyPolicy,
+    approvalHooks,
   );
   if (safetyDecision.action !== 'allow') {
     return blockedToolResult(safetyDecision);
@@ -262,8 +291,79 @@ async function runScript(
   }
 }
 
+async function evaluateSafetyWithApprovals(
+  subject: CommandSafetySubject,
+  safetyPolicy?: CommandSafetyPolicyConfig,
+  approvalHooks?: CommandApprovalHooks,
+): Promise<CommandSafetyDecision> {
+  const safetyDecision = evaluateCommandSafety(subject, safetyPolicy);
+  if (
+    safetyDecision.action !== 'require_approval' ||
+    !safetyDecision.approvalRequestId
+  ) {
+    return safetyDecision;
+  }
+
+  const approvalDecision = await approvalHooks?.getDecision?.(
+    safetyDecision.approvalRequestId,
+  );
+
+  if (approvalDecision === 'approved') {
+    always_log('INFO: command safety approval accepted', {
+      approvalRequestId: safetyDecision.approvalRequestId,
+      ruleId: safetyDecision.ruleId,
+    });
+    return {
+      action: 'allow',
+      reason: 'The approval request was approved.',
+      ruleId: safetyDecision.ruleId,
+      approvalRequestId: safetyDecision.approvalRequestId,
+    };
+  }
+
+  if (approvalDecision === 'denied') {
+    return {
+      ...safetyDecision,
+      action: 'deny',
+      reason: 'The approval request was denied.',
+    };
+  }
+
+  await publishApprovalRequired(safetyDecision, subject, approvalHooks);
+
+  return safetyDecision;
+}
+
+async function publishApprovalRequired(
+  safetyDecision: CommandSafetyDecision,
+  subject: CommandSafetySubject,
+  approvalHooks?: CommandApprovalHooks,
+): Promise<void> {
+  if (!approvalHooks?.onApprovalRequired) {
+    return;
+  }
+
+  const request = createCommandApprovalRequest(
+    safetyDecision,
+    subject,
+    approvalHooks.now?.().toISOString(),
+  );
+  if (!request) {
+    return;
+  }
+
+  try {
+    await approvalHooks.onApprovalRequired(request);
+  } catch (error) {
+    always_log('ERROR: approval producer failed', {
+      error: error instanceof Error ? error.message : String(error),
+      approvalRequestId: safetyDecision.approvalRequestId,
+    });
+  }
+}
+
 function blockedToolResult(
-  safetyDecision: ReturnType<typeof evaluateCommandSafety>,
+  safetyDecision: CommandSafetyDecision,
 ): CallToolResult {
   const response = {
     isError: true,
@@ -291,9 +391,12 @@ export { createServer };
 export {
   evaluateCommandSafety,
   formatSafetyDecision,
+  createCommandApprovalRequest,
   DEFAULT_COMMAND_SAFETY_RULES,
 } from './safety-policy.js';
 export type {
+  CommandApprovalRequest,
+  CommandApprovalRiskLevel,
   CommandSafetyAction,
   CommandSafetyDecision,
   CommandSafetyPolicyConfig,

--- a/packages/agent-infra/mcp-servers/commands/src/server.ts
+++ b/packages/agent-infra/mcp-servers/commands/src/server.ts
@@ -23,15 +23,26 @@ import {
   messagesFor,
   always_log,
 } from './exec-utils.js';
+import {
+  evaluateCommandSafety,
+  formatSafetyDecision,
+  type CommandSafetyPolicyConfig,
+} from './safety-policy.js';
 
 // TODO use .promises? in node api
 const execAsync = promisify(exec);
 
-function createServer(serverConfig?: { cwd?: string }): McpServer {
+type CommandServerConfig = {
+  cwd?: string;
+  safety?: CommandSafetyPolicyConfig;
+};
+
+function createServer(serverConfig?: CommandServerConfig): McpServer {
   const server = new McpServer({
     name: 'Run Commands',
     version: process.env.VERSION || '0.0.1',
   });
+  const safetyPolicy = serverConfig?.safety;
 
   // === Tools ===
   // @ts-ignore
@@ -48,7 +59,7 @@ function createServer(serverConfig?: { cwd?: string }): McpServer {
           .describe('Current working directory, leave empty in most cases'),
       },
     },
-    async (args) => await runCommand(args),
+    async (args) => await runCommand(args, safetyPolicy),
   );
 
   server.registerTool(
@@ -70,7 +81,7 @@ function createServer(serverConfig?: { cwd?: string }): McpServer {
           .describe('Current working directory, leave empty in most cases'),
       },
     },
-    async (args) => await runScript(args),
+    async (args) => await runScript(args, safetyPolicy),
   );
 
   // ==== Prompts ====
@@ -85,6 +96,31 @@ function createServer(serverConfig?: { cwd?: string }): McpServer {
       },
     },
     async ({ command }) => {
+      const safetyDecision = evaluateCommandSafety(
+        {
+          toolName: 'prompt/run_command',
+          command,
+        },
+        safetyPolicy,
+      );
+      if (safetyDecision.action !== 'allow') {
+        const messages: PromptMessage[] = [
+          {
+            role: 'user',
+            content: {
+              type: 'text',
+              text: formatSafetyDecision(safetyDecision),
+            },
+          },
+        ];
+        always_log('WARN: run_command prompt blocked by safety policy', {
+          action: safetyDecision.action,
+          ruleId: safetyDecision.ruleId,
+          approvalRequestId: safetyDecision.approvalRequestId,
+        });
+        return { messages };
+      }
+
       const { stdout, stderr } = await execAsync(command);
       // TODO gracefully handle errors and turn them into a prompt message that can be used by LLM to troubleshoot the issue, currently errors result in nothing inserted into the prompt and instead it shows the Zed's chat panel as a failure
 
@@ -127,15 +163,29 @@ function createServer(serverConfig?: { cwd?: string }): McpServer {
 
 async function runCommand(
   args: Record<string, unknown> | undefined,
+  safetyPolicy?: CommandSafetyPolicyConfig,
 ): Promise<CallToolResult> {
-  const command = String(args?.command);
-  if (!command) {
+  const command = stringArg(args?.command);
+  if (!command?.trim()) {
     throw new Error('Command is required');
   }
 
+  const cwd = stringArg(args?.cwd);
+  const safetyDecision = evaluateCommandSafety(
+    {
+      toolName: 'run_command',
+      command,
+      cwd,
+    },
+    safetyPolicy,
+  );
+  if (safetyDecision.action !== 'allow') {
+    return blockedToolResult(safetyDecision);
+  }
+
   const options: ExecOptions = {};
-  if (args?.cwd) {
-    options.cwd = String(args.cwd);
+  if (cwd) {
+    options.cwd = cwd;
     // ENOENT is thrown if the cwd doesn't exist, and I think LLMs can understand that?
   }
 
@@ -160,9 +210,10 @@ async function runCommand(
 
 async function runScript(
   args: Record<string, unknown> | undefined,
+  safetyPolicy?: CommandSafetyPolicyConfig,
 ): Promise<CallToolResult> {
-  const interpreter = String(args?.interpreter);
-  if (!interpreter) {
+  const interpreter = stringArg(args?.interpreter);
+  if (!interpreter?.trim()) {
     throw new Error('Interpreter is required');
   }
 
@@ -171,14 +222,28 @@ async function runScript(
     // constrains typescript too, to string based overload
     encoding: 'utf8',
   };
-  if (args?.cwd) {
-    options.cwd = String(args.cwd);
+  const cwd = stringArg(args?.cwd);
+  if (cwd) {
+    options.cwd = cwd;
     // ENOENT is thrown if the cwd doesn't exist, and I think LLMs can understand that?
   }
 
-  const script = String(args?.script);
-  if (!script) {
+  const script = stringArg(args?.script);
+  if (!script?.trim()) {
     throw new Error('Script is required');
+  }
+
+  const safetyDecision = evaluateCommandSafety(
+    {
+      toolName: 'run_script',
+      interpreter,
+      script,
+      cwd,
+    },
+    safetyPolicy,
+  );
+  if (safetyDecision.action !== 'allow') {
+    return blockedToolResult(safetyDecision);
   }
 
   try {
@@ -197,4 +262,42 @@ async function runScript(
   }
 }
 
+function blockedToolResult(
+  safetyDecision: ReturnType<typeof evaluateCommandSafety>,
+): CallToolResult {
+  const response = {
+    isError: true,
+    content: [
+      {
+        type: 'text' as const,
+        name: 'SAFETY_POLICY',
+        text: formatSafetyDecision(safetyDecision),
+      },
+    ],
+  };
+  always_log('WARN: command blocked by safety policy', {
+    action: safetyDecision.action,
+    ruleId: safetyDecision.ruleId,
+    approvalRequestId: safetyDecision.approvalRequestId,
+  });
+  return response;
+}
+
+function stringArg(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
 export { createServer };
+export {
+  evaluateCommandSafety,
+  formatSafetyDecision,
+  DEFAULT_COMMAND_SAFETY_RULES,
+} from './safety-policy.js';
+export type {
+  CommandSafetyAction,
+  CommandSafetyDecision,
+  CommandSafetyPolicyConfig,
+  CommandSafetyRule,
+  CommandSafetySubject,
+} from './safety-policy.js';
+export type { CommandServerConfig };

--- a/packages/agent-infra/mcp-servers/commands/tests/integration/exec-utils.test.ts
+++ b/packages/agent-infra/mcp-servers/commands/tests/integration/exec-utils.test.ts
@@ -6,7 +6,7 @@
  * Copyright (c) 2025 g0t4
  * https://github.com/g0t4/mcp-server-commands/blob/master/LICENSE
  */
-import os from 'os';
+import { spawnSync } from 'node:child_process';
 import { execFileWithInput } from '../../src/exec-utils.js';
 import { describe, test, expect } from 'vitest';
 
@@ -14,15 +14,17 @@ import { describe, test, expect } from 'vitest';
 // I am going to keep asking Claude to add new tests to see how I feel about that workflow
 
 describe('execFileWithInput integration tests', () => {
+  const bashTest = isCommandAvailable('bash') ? test : test.skip;
+
   // ok, impressive choice of "seam" to add testing of the most critical part, executing the command! this is EXACTLY what I had in mind and didn't even tell Claude I wanted.
 
-  test('should execute a simple bash command', async () => {
+  bashTest('should execute a simple bash command', async () => {
     const result = await execFileWithInput('bash', 'echo "Hello World"', {});
     expect(result.stdout.trim()).toBe('Hello World');
     expect(result.stderr).toBe('');
   });
 
-  test('should handle command errors properly in bash', async () => {
+  bashTest('should handle command errors properly in bash', async () => {
     try {
       await execFileWithInput('bash', 'nonexistentcommand', {});
       expect.fail('Should have thrown an error');
@@ -88,7 +90,7 @@ Number 3
 `);
   });
 
-  test('should respect working directory option', async () => {
+  bashTest('should respect working directory option', async () => {
     // FYI best to pick a path that is common on both macOS and Linux
     //  unfortunately, on macOS /tmp is a symlink to /private/tmp so that can cause issues
     // TODO make sure cwd is not already / in the test?
@@ -97,7 +99,7 @@ Number 3
     expect(result.stdout.trim()).toBe('/');
   });
 
-  test('should handle bash multiline scripts', async () => {
+  bashTest('should handle bash multiline scripts', async () => {
     const script = `
       echo "Line 1"
       echo "Line 2"
@@ -110,6 +112,11 @@ Line 2
 Line 3`);
   });
 });
+
+function isCommandAvailable(command: string): boolean {
+  const result = spawnSync(command, ['--version'], { stdio: 'ignore' });
+  return result.status === 0;
+}
 
 // TODO add testing of try/catch in runScript block
 //   just make sure I cover failure cases through the catch blocks

--- a/packages/agent-infra/mcp-servers/commands/tests/server-in-memory.test.ts
+++ b/packages/agent-infra/mcp-servers/commands/tests/server-in-memory.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
@@ -137,6 +137,85 @@ describe('MCP Server in memory', () => {
     expect(serialized).toContain('approval_required');
     expect(serialized).toContain('test-command-approval');
     expect(serialized).not.toContain('EXECUTED_COMMAND');
+  });
+
+  test('run_command should publish approval requests to the producer hook', async () => {
+    const onApprovalRequired = vi.fn();
+    const server = createServer({
+      safety: {
+        rules: [
+          {
+            id: 'test-command-approval',
+            action: 'require_approval',
+            reason: 'Test command requires user approval.',
+            patterns: [String.raw`node\s+-e`],
+          },
+        ],
+      },
+      approvals: {
+        onApprovalRequired,
+        now: () => new Date('2026-05-26T00:00:00.000Z'),
+      },
+    });
+    const client = await createConnectedClient(server);
+
+    const result = await client.callTool({
+      name: 'run_command',
+      arguments: {
+        command: `node -e "console.log('EXECUTED_COMMAND')"`,
+        cwd: '/repo',
+      },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(onApprovalRequired).toHaveBeenCalledTimes(1);
+    expect(onApprovalRequired).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Approve command: node -e "console.log(\'EXECUTED_COMMAND\')"',
+        reason: 'Test command requires user approval.',
+        source: 'commands',
+        riskLevel: 'medium',
+        ruleId: 'test-command-approval',
+        createdAt: '2026-05-26T00:00:00.000Z',
+        subject: expect.objectContaining({
+          toolName: 'run_command',
+          command: `node -e "console.log('EXECUTED_COMMAND')"`,
+          cwd: '/repo',
+        }),
+      }),
+    );
+  });
+
+  test('approved approval requests should execute on retry', async () => {
+    const onApprovalRequired = vi.fn();
+    const server = createServer({
+      safety: {
+        rules: [
+          {
+            id: 'test-command-approval',
+            action: 'require_approval',
+            reason: 'Test command requires user approval.',
+            patterns: [String.raw`APPROVED_COMMAND`],
+          },
+        ],
+      },
+      approvals: {
+        getDecision: () => 'approved',
+        onApprovalRequired,
+      },
+    });
+    const client = await createConnectedClient(server);
+
+    const result = await client.callTool({
+      name: 'run_command',
+      arguments: {
+        command: `node -e "console.log('APPROVED_COMMAND')"`,
+      },
+    });
+
+    expect(result.isError).toBe(false);
+    expect(JSON.stringify(result)).toContain('APPROVED_COMMAND');
+    expect(onApprovalRequired).not.toHaveBeenCalled();
   });
 
   test('run_script should return an approval request without executing', async () => {

--- a/packages/agent-infra/mcp-servers/commands/tests/server-in-memory.test.ts
+++ b/packages/agent-infra/mcp-servers/commands/tests/server-in-memory.test.ts
@@ -1,33 +1,40 @@
 import { describe, expect, test } from 'vitest';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
-import { createServer } from '../src/server.js';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { createServer, evaluateCommandSafety } from '../src/server.js';
 import path from 'path';
+
+async function createConnectedClient(server: McpServer): Promise<Client> {
+  const client = new Client(
+    {
+      name: 'test client',
+      version: '1.0',
+    },
+    {
+      capabilities: {
+        roots: {
+          listChanged: true,
+        },
+      },
+    },
+  );
+
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+
+  await Promise.all([
+    client.connect(clientTransport),
+    server.connect(serverTransport),
+  ]);
+
+  return client;
+}
 
 describe('MCP Server in memory', () => {
   test('listTools should return a list of tools', async () => {
-    const client = new Client(
-      {
-        name: 'test client',
-        version: '1.0',
-      },
-      {
-        capabilities: {
-          roots: {
-            listChanged: true,
-          },
-        },
-      },
-    );
-
     const server = createServer();
-    const [clientTransport, serverTransport] =
-      InMemoryTransport.createLinkedPair();
-
-    await Promise.all([
-      client.connect(clientTransport),
-      server.connect(serverTransport),
-    ]);
+    const client = await createConnectedClient(server);
 
     const result = await client.listTools();
 
@@ -35,44 +42,22 @@ describe('MCP Server in memory', () => {
   });
 
   test('callTool run_command should return a result', async () => {
-    const client = new Client({
-      name: 'test client',
-      version: '1.0',
-    });
-
     const server = createServer();
-    const [clientTransport, serverTransport] =
-      InMemoryTransport.createLinkedPair();
+    const client = await createConnectedClient(server);
 
-    await Promise.all([
-      client.connect(clientTransport),
-      server.connect(serverTransport),
-    ]);
-
+    const currentFileName = path.basename(__filename);
     const result = await client.callTool({
       name: 'run_command',
       arguments: {
-        command: `ls ${__dirname}`,
+        command: `node -e "console.log('${currentFileName}')"`,
       },
     });
-    const currentFileName = path.basename(__filename);
     expect(JSON.stringify(result)).toMatch(currentFileName);
   });
 
   test('callTool run_script should return a result', async () => {
-    const client = new Client({
-      name: 'test client',
-      version: '1.0',
-    });
-
     const server = createServer();
-    const [clientTransport, serverTransport] =
-      InMemoryTransport.createLinkedPair();
-
-    await Promise.all([
-      client.connect(clientTransport),
-      server.connect(serverTransport),
-    ]);
+    const client = await createConnectedClient(server);
 
     const result = await client.callTool({
       name: 'run_script',
@@ -91,5 +76,112 @@ describe('MCP Server in memory', () => {
       ],
       isError: false,
     });
+  });
+
+  test('safety policy should require approval for destructive default rules', () => {
+    const decision = evaluateCommandSafety({
+      toolName: 'run_command',
+      command: 'git reset --hard HEAD',
+    });
+
+    expect(decision.action).toBe('require_approval');
+    expect(decision.ruleId).toBe('destructive-git-operation');
+    expect(decision.approvalRequestId).toBeTruthy();
+  });
+
+  test('custom allow rules should run before destructive default rules', () => {
+    const decision = evaluateCommandSafety(
+      {
+        toolName: 'run_command',
+        command: 'git reset --hard HEAD',
+      },
+      {
+        rules: [
+          {
+            id: 'allow-known-git-reset',
+            action: 'allow',
+            reason: 'The caller already approved this exact operation.',
+            patterns: [String.raw`git\s+reset\s+--hard\s+HEAD`],
+          },
+        ],
+      },
+    );
+
+    expect(decision.action).toBe('allow');
+  });
+
+  test('run_command should return an approval request without executing', async () => {
+    const server = createServer({
+      safety: {
+        rules: [
+          {
+            id: 'test-command-approval',
+            action: 'require_approval',
+            reason: 'Test command requires user approval.',
+            patterns: [String.raw`node\s+-e`],
+          },
+        ],
+      },
+    });
+    const client = await createConnectedClient(server);
+
+    const result = await client.callTool({
+      name: 'run_command',
+      arguments: {
+        command: `node -e "console.log('EXECUTED_COMMAND')"`,
+      },
+    });
+
+    const serialized = JSON.stringify(result);
+    expect(result.isError).toBe(true);
+    expect(serialized).toContain('approval_required');
+    expect(serialized).toContain('test-command-approval');
+    expect(serialized).not.toContain('EXECUTED_COMMAND');
+  });
+
+  test('run_script should return an approval request without executing', async () => {
+    const server = createServer({
+      safety: {
+        rules: [
+          {
+            id: 'test-script-approval',
+            action: 'require_approval',
+            reason: 'Test script requires user approval.',
+            patterns: [String.raw`EXECUTED_SCRIPT`],
+          },
+        ],
+      },
+    });
+    const client = await createConnectedClient(server);
+
+    const result = await client.callTool({
+      name: 'run_script',
+      arguments: {
+        interpreter: 'node',
+        script: "console.log('EXECUTED_SCRIPT');",
+      },
+    });
+
+    const serialized = JSON.stringify(result);
+    expect(result.isError).toBe(true);
+    expect(serialized).toContain('approval_required');
+    expect(serialized).toContain('test-script-approval');
+    expect(serialized).not.toContain('EXECUTED_SCRIPT');
+  });
+
+  test('run_command prompt should return an approval request without executing', async () => {
+    const server = createServer();
+    const client = await createConnectedClient(server);
+
+    const result = await client.getPrompt({
+      name: 'run_command',
+      arguments: {
+        command: 'git reset --hard HEAD',
+      },
+    });
+
+    const serialized = JSON.stringify(result);
+    expect(serialized).toContain('approval_required');
+    expect(serialized).toContain('destructive-git-operation');
   });
 });

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,0 +1,1 @@
+module.exports = {};


### PR DESCRIPTION
## Summary

This PR introduces **ProofPilot** — a product layer on top of UI-TARS Desktop focused on **safer, auditable, and reproducible agent execution**. As GUI agents take real actions on a user's machine, teams increasingly need to *prove what the agent did*, *gate risky actions behind a human*, *dry-run before going live*, and *turn a proven run into a reusable workflow*. ProofPilot adds exactly those capabilities, plus an org-level governance foundation, while keeping everything **fully local** (no data leaves the machine).

It is additive and opt-in: live-mode behavior is unchanged apart from best-effort recording, and recording failures can never break an agent run.

## Motivation

Today UI-TARS Desktop renders conversations and screenshots in-session, but there is:

- no **tamper-evident** record of what happened (for audit, debugging, or sharing),
- no way to **require human approval** before a risky action executes,
- no **simulation / dry-run** mode to plan a workflow without touching the real UI,
- no way to **export** a run as evidence or convert it into a **reusable workflow**,
- no **team-level policy** surface for governing how agents are allowed to run.

ProofPilot fills these gaps so the agent can be used for work where mistakes are expensive and accountability matters.

## What's included

**1. Command safety gate + approval producer hook** — `packages/agent-infra/mcp-servers/commands`
A safety policy evaluates `run_command` / `run_script` against rules (destructive file removal, disk/partition mutation, system power actions, privileged/recursive permission changes, destructive git operations, remote `curl | sh` execution). Risky commands resolve to `require_approval`, which now emits a `CommandApprovalRequest` via a producer hook (`onApprovalRequired`) and consults `getDecision` before executing — a clean seam any host can wire an approval UI into.

**2. ProofPilot Flight Recorder** — `apps/ui-tars/src/main/services/flightRecorder.ts`
Records every agent run as an append-only, **SHA-256 hash-chained** event log (`run_started`, `status_changed`, `conversation_added`, `action_planned`, `simulation_action_skipped`, `run_error`, `run_finished`). Each event carries `previousHash` + `eventHash`; the manifest holds a rolling `recordingHash`. Integrity is re-verified on read and reported as `verified` / `failed` / `legacy`. Screenshots and Set-of-Marks screenshots are persisted as content-addressed artifacts (deduplicated by SHA-256).

**3. Proof Pack export** — self-contained `index.html` + stripped `proof-pack.json`, with an embedded timeline, integrity badge, and inline screenshots — shareable as evidence of what the agent did.

**4. Workflow Capsule export** — converts a recorded run into a portable `workflow-capsule.json`, pairing each planned action with its source conversation and source event hash.

**5. Workflow Compiler** — compiles a run into `workflow.json` + human-readable `workflow.md` with **guardrails** (simulation-first default, integrity verification required, approval required for risky actions, explicit stop conditions), per-step retry policy, and source-hash evidence.

**6. Approval Queue** — `apps/ui-tars/src/main/services/approvalQueue.ts`
Persistent, idempotent queue (`list` / `submit` / `resolve` / `clearResolved`) — the consumer side of the command safety gate's producer hook.

**7. Sandbox / Simulation mode** — `apps/ui-tars/src/main/services/simulationOperator.ts`
Wraps the operator to **record-and-skip**: the agent observes and plans normally, but no real UI action executes and skipped actions are recorded. The system prompt is annotated and loop count is capped in simulation.

**8. Team Workspace** — `apps/ui-tars/src/main/services/teamWorkspace.ts`
Plan/seats, member roles (owner/admin/operator/viewer), governance policies (default run mode, approval policy, retention, proof-pack requirement, audit exports), and an exportable HTML/JSON **audit report** with a commercial-readiness checklist computed from recorded runs and approvals.

**9. UI** — `apps/ui-tars/src/renderer/src/pages/{proofpilot,approvals,team}`
New ProofPilot timeline/replay, Approval Queue, and Team console pages; sidebar navigation; and a **Simulate** toggle on the chat input that dispatches runs in `live` or `simulation` mode (run dispatch is now session-aware).

**10. Build/config** — made the private-key bytecode plugin optional so local builds without `UI_TARS_APP_PRIVATE_KEY_BASE64` don't crash (no effect on official signed builds); added a root `postcss.config.cjs` and a Vitest setup file for main-process service tests.

## How it works

- The Flight Recorder hooks into the agent run loop (`runAgent`) via the existing `onData` / `onError` callbacks; recording is wrapped so a recorder error is logged and swallowed, never breaking the run.
- Simulation mode wraps the selected operator's `execute` to record the planned action and return a non-executing result.
- The command safety gate (producer) and the Approval Queue (consumer) communicate through a small hook contract, so approval is enforced before a gated command runs.
- All renderer↔main calls use the existing type-safe `@ui-tars/electron-ipc` layer; three new routers (`proofPilot`, `approval`, `team`) are merged into the shared `Router`.
- All state is persisted locally under `userData/proofpilot/`:

```
proofpilot/
├── flight-records/<runId>/
│   ├── manifest.json          # run metadata + rolling recordingHash
│   ├── events.jsonl           # append-only, hash-chained event log
│   ├── screenshots/           # content-addressed artifacts (sha256)
│   ├── proof-pack/            # exported HTML + JSON evidence
│   ├── workflow-capsule/      # exported reusable capsule
│   └── compiled-workflow/     # workflow.json + workflow.md
├── approval-queue.json
└── team/{workspace.json, audit-reports/<id>/...}
```

## Backward compatibility

Fully additive and opt-in. Simulation is off by default; live-mode agent behavior is unchanged apart from best-effort recording. No changes to existing operator or agent control flow. The bytecode-plugin change is a no-op for official signed builds (where the key env var is set).

## Testing

- **commands-MCP suite:** 10 passed (full safety-gate + approval-hook coverage: approval-without-execute, producer-hook publish, approve-on-retry, `run_script` gate, prompt gate), 9 integration tests skipped by design.
- **ProofPilot service suites** (`flightRecorder`, `approvalQueue`, `simulationOperator`, `teamWorkspace`): 9 passed.
- **Typecheck:** `typecheck:node` + `typecheck:web` clean.
- **Production build:** `electron-vite build` (main / preload / renderer) succeeds; only the pre-existing third-party `eval` / chunk-size / empty-private-chunk warnings remain.

> Note: the broader app test suite includes cases that require a live Electron runtime / platform-native modules and are not runnable headless; those are unrelated to and unchanged by this PR.

## Notes for reviewers

- ~6.4k LOC across 9 focused commits — reviewing commit-by-commit is recommended.
- New code is isolated under `apps/ui-tars/src/main/services`, `apps/ui-tars/src/main/ipcRoutes`, `apps/ui-tars/src/renderer/src/pages`, plus the `commands` MCP safety hook.
- Privacy by design: all recording, approval, and team state is stored locally; nothing is transmitted off-device.

> _Screenshots of the ProofPilot timeline, Approval Queue, and Team console can be attached here._
