### PR TITLE
test: include all VLM providers

### DIFF
--- a/apps/ui-tars/src/main/store/types.test.ts
+++ b/apps/ui-tars/src/main/store/types.test.ts
@@ -11,6 +11,10 @@ describe('VLMProviderV2', () => {
       [VLMProviderV2.ui_tars_1_0, 'Hugging Face for UI-TARS-1.0'],
       [VLMProviderV2.ui_tars_1_5, 'Hugging Face for UI-TARS-1.5'],
       [VLMProviderV2.doubao_1_5, 'VolcEngine Ark for Doubao-1.5-UI-TARS'],
+      [
+        VLMProviderV2.doubao_1_5_vl,
+        'VolcEngine Ark for Doubao-1.5-thinking-vision-pro',
+      ],
     ];
 
     cases.forEach(([provider, expected]) => {
@@ -23,8 +27,8 @@ describe('VLMProviderV2', () => {
     );
   });
 
-  it('should contain exactly three providers', () => {
+  it('should contain exactly four providers', () => {
     const providerCount = Object.keys(VLMProviderV2).length;
-    expect(providerCount).toBe(3);
+    expect(providerCount).toBe(4);
   });
 });


### PR DESCRIPTION
## Summary

- add the missing `VLMProviderV2.doubao_1_5_vl` assertion
- update the provider count expectation from 3 to 4

The enum already has four values, so the existing test fails on current `main`.

## Tests

- `corepack pnpm exec vitest run src/main/store/types.test.ts` from `apps/ui-tars`
- `corepack pnpm exec prettier --check apps/ui-tars/src/main/store/types.test.ts`
- `git diff --check`
