### PR TITLE
chore: add mcp client license metadata

### DIFF
--- a/packages/agent-infra/mcp-client/package.json
+++ b/packages/agent-infra/mcp-client/package.json
@@ -2,6 +2,7 @@
   "name": "@agent-infra/mcp-client",
   "version": "1.2.29",
   "description": "An MCP Client to run servers for Electron apps, support same-process approaching",
+  "license": "MIT",
   "types": "./dist/index.d.ts",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
## Summary
- Add missing `license` metadata to `@agent-infra/mcp-client`.
- Match the existing `MIT` license metadata used by neighboring Agent Infra packages such as `@agent-infra/mcp-shared` and `mcp-http-server`.
- No runtime, dependency, or build output changes.

## Validation
- `node` metadata assertion for `packages/agent-infra/mcp-client/package.json`
- `npm pack --dry-run --json --ignore-scripts` from `packages/agent-infra/mcp-client`
- `git diff --check`