### PR TITLE
fix(mcp-shared): emit client and server subpath builds

### DIFF
--- a/packages/agent-infra/mcp-shared/rslib.config.ts
+++ b/packages/agent-infra/mcp-shared/rslib.config.ts
@@ -12,8 +12,7 @@ const BANNER = `/**
 export default defineConfig({
   source: {
     entry: {
-      client: ['src/client/**/*.ts'],
-      server: ['src/server/**/*.ts'],
+      index: ['./src/**'],
     },
   },
   lib: [


### PR DESCRIPTION
## Summary

- Build `@agent-infra/mcp-shared` from the full `src/**` tree in bundleless mode.
- Restore the JS outputs advertised by the package exports for `./client` and `./server`.

## Why

The published `@agent-infra/mcp-shared@1.2.29` package exports `./client` and `./server` to `dist/client/index.{mjs,js}` and `dist/server/index.{mjs,js}`, but the npm tarball only contains declaration files for those subpaths. Clean consumers currently fail with `ERR_MODULE_NOT_FOUND` when importing either subpath.

## Published package reproduction

```sh
tmp="$(mktemp -d)"
cd "$tmp"
npm init -y >/dev/null
npm install @agent-infra/mcp-shared@1.2.29 --ignore-scripts --no-audit --no-fund >/dev/null
node --input-type=module -e "await import('@agent-infra/mcp-shared/client')"
```

Observed result:

```text
ERR_MODULE_NOT_FOUND: Cannot find module '.../node_modules/@agent-infra/mcp-shared/dist/client/index.mjs'
```

## Validation after this change

Using an isolated `@rslib/core@0.10.0` build for this package:

```sh
rslib build
npm pack --ignore-scripts --json --pack-destination /tmp/mcp-shared-fixed-pack
```

The packed tarball now includes:

```text
dist/client/index.d.ts
dist/client/index.js
dist/client/index.mjs
dist/server/index.d.ts
dist/server/index.js
dist/server/index.mjs
```

Clean packed-tarball consumer checks:

```sh
npm install /tmp/mcp-shared-fixed-pack/agent-infra-mcp-shared-1.2.29.tgz --ignore-scripts --no-audit --no-fund
node --input-type=module -e "await import('@agent-infra/mcp-shared/client'); await import('@agent-infra/mcp-shared/server'); await import('@agent-infra/mcp-shared'); console.log('packed esm imports ok')"
node -e "require('@agent-infra/mcp-shared/client'); require('@agent-infra/mcp-shared/server'); require('@agent-infra/mcp-shared'); console.log('packed cjs requires ok')"
```

Both packed ESM imports and CJS requires pass.
