### PR TITLE
fix: operator permission check always triggering + typos

### DIFF
--- a/apps/ui-tars/package.json
+++ b/apps/ui-tars/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "main": "./dist/main/main.js",
   "packageManager": "pnpm@9.10.0",
-  "description": "A GUI Agent application based on UI-TARS(Vision-Lanuage Model) that allows you to control your computer using natural language.",
+  "description": "A GUI Agent application based on UI-TARS(Vision-Language Model) that allows you to control your computer using natural language.",
   "author": "ByteDance",
   "scripts": {
     "format": "prettier --write .",

--- a/apps/ui-tars/src/renderer/src/components/Settings/local.tsx
+++ b/apps/ui-tars/src/renderer/src/components/Settings/local.tsx
@@ -59,7 +59,7 @@ export const LocalSettingsDialog = ({
         </DialogHeader>
         <VLMSettings ref={vlmSettingsRef} />
         <Button className="mt-8 mx-8" onClick={handleGetStart}>
-          Get Start
+          Get Started
         </Button>
       </DialogContent>
     </Dialog>

--- a/apps/ui-tars/src/renderer/src/hooks/useRunAgent.ts
+++ b/apps/ui-tars/src/renderer/src/hooks/useRunAgent.ts
@@ -64,7 +64,7 @@ export const useRunAgent = () => {
   ) => {
     const operator = settings.operator;
     if (
-      (operator === Operator.LocalBrowser || Operator.LocalComputer) &&
+      (operator === Operator.LocalBrowser || operator === Operator.LocalComputer) &&
       !(ensurePermissions?.accessibility && ensurePermissions?.screenCapture)
     ) {
       const permissionsText = [

--- a/apps/ui-tars/src/renderer/src/pages/settings/Settings.tsx
+++ b/apps/ui-tars/src/renderer/src/pages/settings/Settings.tsx
@@ -131,7 +131,7 @@ export default function Settings() {
     },
   });
   useEffect(() => {
-    if (Object.keys(settings)) {
+    if (Object.keys(settings).length > 0) {
       form.reset({
         language: settings.language,
         vlmProvider: settings.vlmProvider,

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "packageManager": "pnpm@9.10.0",
-  "description": "A GUI Agent application based on UI-TARS(Vision-Lanuage Model) that allows you to control your computer using natural language.",
+  "description": "A GUI Agent application based on UI-TARS(Vision-Language Model) that allows you to control your computer using natural language.",
   "main": "./dist/main/main.js",
   "author": "ByteDance",
   "scripts": {

--- a/packages/agent-infra/browser/src/base-browser.ts
+++ b/packages/agent-infra/browser/src/base-browser.ts
@@ -262,7 +262,7 @@ export abstract class BaseBrowser implements BrowserInterface {
 
     // Get all pages and find the last active page
     const pages = await this.browser.pages();
-    this.logger.info('getActivePage: all of pages lenght:', pages.length);
+    this.logger.info('getActivePage: all of pages length:', pages.length);
 
     if (pages.length === 0) {
       this.activePage = await this.createPage();


### PR DESCRIPTION
Found a logic bug in the operator permission check — the condition was:

\`\`\`js
if (operator === Operator.LocalBrowser || Operator.LocalComputer)
\`\`\`

This always evaluates to true because \`Operator.LocalComputer\` is a non-empty string on its own. So the permission dialog was firing for every operator type, not just local ones. Added the missing \`operator ===\` comparison.

Also fixed a few other things while I was in there:
- \`Object.keys(settings)\` check in Settings was always truthy since arrays are truthy — added \`.length > 0\`
- "Vision-Lanuage Model" → "Vision-Language Model" in both package.json files
- "lenght" → "length" in a browser debug log
- "Get Start" → "Get Started" in the settings UI button