### PR TITLE
feat(model-provider): add MiniMax provider

### DIFF
--- a/multimodal/tarko/llm-client/src/handlers/anthropic.ts
+++ b/multimodal/tarko/llm-client/src/handlers/anthropic.ts
@@ -543,8 +543,9 @@ export class AnthropicHandler extends BaseHandler<AnthropicModel> {
 
     const stream = typeof body.stream === 'boolean' ? body.stream : undefined;
     const maxTokens = body.max_tokens ?? getDefaultMaxTokens(body.model);
-    const client = new Anthropic({ 
+    const client = new Anthropic({
       apiKey: getApiKey(this.opts.apiKey)!,
+      baseURL: this.opts.baseURL,
       defaultHeaders: this.opts.defaultHeaders,
     });
     const stopSequences = convertStopSequences(body.stop);

--- a/multimodal/tarko/model-provider/README.md
+++ b/multimodal/tarko/model-provider/README.md
@@ -10,7 +10,7 @@ npm install @tarko/model-provider
 
 ## Features
 
-- 🔌 **Multi-Provider Support**: OpenAI, Ollama, LM Studio, Volcengine, DeepSeek, and more
+- 🔌 **Multi-Provider Support**: OpenAI, Ollama, LM Studio, Volcengine, DeepSeek, MiniMax, and more
 - 🎯 **Unified Interface**: Single API for all providers with OpenAI-compatible interface
 - ⚙️ **Smart Resolution**: Automatic model configuration resolution with fallbacks
 - 🔧 **Extensible**: Easy to add new providers through configuration
@@ -52,6 +52,27 @@ const response = await client.chat.completions.create({
 | `lm-studio` | http://127.0.0.1:1234/v1 | 1234 |
 | `volcengine` | https://ark.cn-beijing.volces.com/api/v3 | - |
 | `deepseek` | https://api.deepseek.com/v1 | - |
+| `minimax` | https://api.minimax.io/v1 | - |
+
+### MiniMax Configuration
+
+The `minimax` provider supports `MiniMax-M3` and `MiniMax-M2.7`. It defaults to the global OpenAI-compatible endpoint. Override `baseURL` when using the China endpoint or the Anthropic-compatible protocol:
+
+| Protocol             | Global                             | China                                |
+| -------------------- | ---------------------------------- | ------------------------------------ |
+| OpenAI-compatible    | `https://api.minimax.io/v1`        | `https://api.minimaxi.com/v1`        |
+| Anthropic-compatible | `https://api.minimax.io/anthropic` | `https://api.minimaxi.com/anthropic` |
+
+Use `provider: 'minimax'` with the OpenAI-compatible endpoints. For Anthropic-compatible requests, use `provider: 'anthropic'` and one of the Anthropic base URLs above. The Anthropic SDK appends `/v1/messages` to that base URL.
+
+```typescript
+const model = resolveModel({
+  provider: 'anthropic',
+  id: 'MiniMax-M3',
+  baseURL: 'https://api.minimax.io/anthropic',
+  apiKey: 'your-api-key',
+});
+```
 
 ### Advanced Configuration
 
@@ -126,7 +147,7 @@ interface AgentModel {
 ```typescript
 type ModelProviderName = 
   | 'openai' | 'anthropic' | 'azure-openai'
-  | 'ollama' | 'lm-studio' | 'volcengine' | 'deepseek';
+  | 'ollama' | 'lm-studio' | 'volcengine' | 'deepseek' | 'minimax';
 ```
 
 ### Functions

--- a/multimodal/tarko/model-provider/src/constants.ts
+++ b/multimodal/tarko/model-provider/src/constants.ts
@@ -32,4 +32,9 @@ export const HIGH_LEVEL_MODEL_PROVIDER_CONFIGS: readonly ProviderConfig[] = [
     extends: 'openai',
     baseURL: 'https://api.deepseek.com/v1',
   },
+  {
+    name: 'minimax',
+    extends: 'openai',
+    baseURL: 'https://api.minimax.io/v1',
+  },
 ] as const;

--- a/multimodal/tarko/model-provider/src/types.ts
+++ b/multimodal/tarko/model-provider/src/types.ts
@@ -22,7 +22,8 @@ export type ModelProviderName =
   | 'ollama'
   | 'lm-studio'
   | 'volcengine'
-  | 'deepseek';
+  | 'deepseek'
+  | 'minimax';
 
 /**
  * Basic Model configuration

--- a/multimodal/tarko/model-provider/tests/minimax-anthropic.test.ts
+++ b/multimodal/tarko/model-provider/tests/minimax-anthropic.test.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { createServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { describe, expect, it } from 'vitest';
+import { createLLMClient } from '../src/llm-client';
+import { resolveModel } from '../src/model-resolver';
+
+describe('MiniMax Anthropic-compatible endpoints', () => {
+  it.each(['global', 'cn'])(
+    'appends /v1/messages exactly once for the %s SDK base URL',
+    async (region) => {
+      const requestPaths: string[] = [];
+      const server = createServer((request, response) => {
+        requestPaths.push(request.url ?? '');
+        response.writeHead(200, { 'Content-Type': 'application/json' });
+        response.end(
+          JSON.stringify({
+            id: 'msg_test',
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'text', text: 'ok' }],
+            model: 'MiniMax-M3',
+            stop_reason: 'end_turn',
+            stop_sequence: null,
+            usage: { input_tokens: 1, output_tokens: 1 },
+          }),
+        );
+      });
+
+      await new Promise<void>((resolve, reject) => {
+        server.listen(0, '127.0.0.1', resolve);
+        server.once('error', reject);
+      });
+
+      try {
+        const { port } = server.address() as AddressInfo;
+        const baseURL = `http://127.0.0.1:${port}/${region}/anthropic`;
+        const model = resolveModel({
+          provider: 'anthropic',
+          id: 'MiniMax-M3',
+          apiKey: 'minimax-key',
+          baseURL,
+        });
+        const client = createLLMClient(model);
+
+        await client.chat.completions.create({
+          model: model.id,
+          messages: [{ role: 'user', content: 'Hello' }],
+        });
+
+        expect(requestPaths).toEqual([`/${region}/anthropic/v1/messages`]);
+      } finally {
+        await new Promise<void>((resolve, reject) => {
+          server.close((error) => (error ? reject(error) : resolve()));
+        });
+      }
+    },
+  );
+});

--- a/multimodal/tarko/model-provider/tests/model-resolver.test.ts
+++ b/multimodal/tarko/model-provider/tests/model-resolver.test.ts
@@ -142,6 +142,27 @@ describe('resolveModel', () => {
     });
   });
 
+  it('should handle minimax provider correctly', () => {
+    const agentModel: AgentModel = {
+      provider: 'minimax',
+      id: 'MiniMax-M3',
+      apiKey: 'minimax-key',
+    };
+
+    const result = resolveModel(agentModel);
+
+    expect(result).toEqual({
+      provider: 'minimax',
+      id: 'MiniMax-M3',
+      displayName: undefined,
+      baseURL: 'https://api.minimax.io/v1',
+      apiKey: 'minimax-key',
+      headers: {},
+      params: undefined,
+      baseProvider: 'openai',
+    });
+  });
+
   it('should add anthropic_beta params for azure-openai provider with gcp-claude4-sonnet model', () => {
     const agentModel: AgentModel = {
       provider: 'azure-openai',

--- a/multimodal/tarko/model-provider/tests/model-resolver.test.ts
+++ b/multimodal/tarko/model-provider/tests/model-resolver.test.ts
@@ -142,10 +142,10 @@ describe('resolveModel', () => {
     });
   });
 
-  it('should handle minimax provider correctly', () => {
+  it.each(['MiniMax-M3', 'MiniMax-M2.7'])('should resolve minimax model %s', (modelId) => {
     const agentModel: AgentModel = {
       provider: 'minimax',
-      id: 'MiniMax-M3',
+      id: modelId,
       apiKey: 'minimax-key',
     };
 
@@ -153,7 +153,7 @@ describe('resolveModel', () => {
 
     expect(result).toEqual({
       provider: 'minimax',
-      id: 'MiniMax-M3',
+      id: modelId,
       displayName: undefined,
       baseURL: 'https://api.minimax.io/v1',
       apiKey: 'minimax-key',
@@ -161,6 +161,33 @@ describe('resolveModel', () => {
       params: undefined,
       baseProvider: 'openai',
     });
+  });
+
+  it('should preserve the MiniMax China OpenAI-compatible endpoint', () => {
+    const result = resolveModel({
+      provider: 'minimax',
+      id: 'MiniMax-M3',
+      apiKey: 'minimax-key',
+      baseURL: 'https://api.minimaxi.com/v1',
+    });
+
+    expect(result.baseURL).toBe('https://api.minimaxi.com/v1');
+    expect(result.baseProvider).toBe('openai');
+  });
+
+  it.each([
+    ['global', 'https://api.minimax.io/anthropic'],
+    ['China', 'https://api.minimaxi.com/anthropic'],
+  ])('should preserve the MiniMax %s Anthropic SDK base URL', (_, baseURL) => {
+    const result = resolveModel({
+      provider: 'anthropic',
+      id: 'MiniMax-M3',
+      apiKey: 'minimax-key',
+      baseURL,
+    });
+
+    expect(result.baseURL).toBe(baseURL);
+    expect(result.baseProvider).toBe('anthropic');
   });
 
   it('should add anthropic_beta params for azure-openai provider with gcp-claude4-sonnet model', () => {


### PR DESCRIPTION
Reason: add target provider/model to existing provider registry

## Summary
- Register MiniMax as an OpenAI-compatible high-level model provider.
- Add MiniMax-M3 resolver coverage with the default MiniMax OpenAI-compatible base URL.

## Test plan
- Secret scan on changed files passed.
- `pnpm --dir /root/octopatch-4/work/repos/bytedance_UI-TARS-desktop/multimodal --filter "@tarko/model-provider" test` (fails: local node_modules missing; vitest not found; environment Node v20.20.2 is below required >=22).

Generated by Octopatch.