### PR TITLE
fix(agent-server): dedupe models by provider and id, not id alone

### DIFF
--- a/multimodal/tarko/agent-server/src/utils/model-utils.ts
+++ b/multimodal/tarko/agent-server/src/utils/model-utils.ts
@@ -17,9 +17,12 @@ export function getAvailableModels(appConfig: AgentAppConfig): AgentModel[] {
     ...(appConfig.server?.models || []),
   ];
 
-  // Deduplicate by model.id, keeping the first occurrence
+  // Deduplicate by (provider, id), keeping the first occurrence. Model identity
+  // is the provider+id pair (see isModelConfigValid), so the same model id under
+  // two different providers must be kept as distinct entries.
   const uniqueModels = allModels.filter(
-    (model, index, arr) => arr.findIndex((m) => m.id === model.id) === index,
+    (model, index, arr) =>
+      arr.findIndex((m) => m.id === model.id && m.provider === model.provider) === index,
   );
 
   return uniqueModels;

--- a/multimodal/tarko/agent-server/tests/utils/model-utils.test.ts
+++ b/multimodal/tarko/agent-server/tests/utils/model-utils.test.ts
@@ -76,6 +76,30 @@ describe('model-utils', () => {
       const result = getAvailableModels(config);
       expect(result).toEqual([mockModel1]);
     });
+
+    it('should keep the same model id configured under different providers', () => {
+      const openaiGpt4o: AgentModel = { provider: 'openai', id: 'gpt-4o', displayName: 'GPT-4o (OpenAI)' };
+      const azureGpt4o: AgentModel = {
+        provider: 'azure-openai',
+        id: 'gpt-4o',
+        displayName: 'GPT-4o (Azure)',
+      };
+      const config: AgentAppConfig = {
+        model: openaiGpt4o,
+        server: { models: [azureGpt4o] },
+      };
+      const result = getAvailableModels(config);
+      expect(result).toEqual([openaiGpt4o, azureGpt4o]);
+    });
+
+    it('should collapse genuine duplicates (same provider and id)', () => {
+      const config: AgentAppConfig = {
+        model: mockModel1,
+        server: { models: [{ ...mockModel1 }] },
+      };
+      const result = getAvailableModels(config);
+      expect(result).toEqual([mockModel1]);
+    });
   });
 
   describe('getDefaultModel', () => {
@@ -158,6 +182,17 @@ describe('model-utils', () => {
       const result2 = isModelConfigValid(config, 'openai', 'GPT-4');
       expect(result1).toBe(false);
       expect(result2).toBe(false);
+    });
+
+    it('should validate a model id shared across providers for each provider', () => {
+      const sharedIdConfig: AgentAppConfig = {
+        model: { provider: 'openai', id: 'gpt-4o', displayName: 'GPT-4o (OpenAI)' },
+        server: {
+          models: [{ provider: 'azure-openai', id: 'gpt-4o', displayName: 'GPT-4o (Azure)' }],
+        },
+      };
+      expect(isModelConfigValid(sharedIdConfig, 'openai', 'gpt-4o')).toBe(true);
+      expect(isModelConfigValid(sharedIdConfig, 'azure-openai', 'gpt-4o')).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Problem

`getAvailableModels` in `multimodal/tarko/agent-server/src/utils/model-utils.ts` deduplicates by `model.id` **alone**:

```ts
const uniqueModels = allModels.filter(
  (model, index, arr) => arr.findIndex((m) => m.id === model.id) === index,
);
```

But everywhere else in the same module, model identity is the **`(provider, id)` pair** — `isModelConfigValid` matches on `model.provider === provider && model.id === modelId`. The dedup key and the validation key disagree.

So when the same model id is configured under two different providers — a common multi-provider setup, e.g. `gpt-4o` via both `openai` and `azure-openai`, or `claude-3-5-sonnet` via `anthropic` and `bedrock` — the second entry is silently dropped.

## Impact (live server code)

- `GET /api/v1/models` (`src/api/routes/system.ts`) → `getPublicAvailableModels` → the second provider's model is **missing from the model picker** served to the UI.
- `updateSessionModel` (`src/api/controllers/system.ts`) → `isModelConfigValid` → switching to the shared-id model under the second provider returns **HTTP 400 "Invalid model configuration"** even though it is configured.
- `AgentSession` uses it for model resolution.

## Reproduction

```ts
const config = {
  model: { provider: 'openai', id: 'gpt-4o' },
  server: { models: [{ provider: 'azure-openai', id: 'gpt-4o' }] },
};
```

| | before | after |
|---|---|---|
| `getAvailableModels(config)` | `['openai/gpt-4o']` (azure dropped) | `['openai/gpt-4o', 'azure-openai/gpt-4o']` |
| `isModelConfigValid(config, 'azure-openai', 'gpt-4o')` | `false` | `true` |

Genuine duplicates (same `provider` **and** `id`) still collapse to one entry.

## Fix

Include `provider` in the dedup key:

```ts
const uniqueModels = allModels.filter(
  (model, index, arr) =>
    arr.findIndex((m) => m.id === model.id && m.provider === model.provider) === index,
);
```

## Tests

Added to `tests/utils/model-utils.test.ts`:
- `getAvailableModels` keeps the same id under different providers, and still collapses genuine duplicates.
- `isModelConfigValid` validates a shared id for each provider.

Before the fix, the two new positive cases fail; after, the full `model-utils` suite passes (18 tests). Verified by running the suite against the real module (`vitest run tests/utils/model-utils.test.ts`).
