### PR TITLE
docs: add mcpindex screened badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![mcpindex](https://mcpindex.ai/api/v1/badge/io-github-bytedance-mcp-server-browser)](https://mcpindex.ai/server/io-github-bytedance-mcp-server-browser)
+
 <picture>
   <img alt="Agent TARS Banner" src="./images/tars.png">
 </picture>


### PR DESCRIPTION
Hey, ran the mcp-server-browser package in this repo through mcpindex's screening (description-level check for injection/manipulation patterns, nothing deeper). Came back clean, so added the badge to your README. It's advisory, not a security certification. Note this repo also registers a mcp-server-search package separately, happy to badge that one too if useful. Close this if it's not a fit. 