### PR TITLE
fix(ci): replace invalid Actions pin with the commit SHA it resolves to

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -59,6 +59,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@59c2c1ca13dff455ab22ad8157d6ab220447da29  # v4
+        uses: github/codeql-action/upload-sarif@45cbd0c69e560cd9e7cd7f8c32362050c9b7ded2  # v4
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Problem

These workflow `uses:` pins are invalid as written. Each item below shows the current value, why it is wrong, and the correct ref that must be used instead.

### 1. `.github/workflows/scorecard.yml`

**Current (invalid):**

```yaml
uses: github/codeql-action/upload-sarif@59c2c1ca13dff455ab22ad8157d6ab220447da29 # v4
```

**Why this is wrong:**

- `59c2c1ca13dff455ab22ad8157d6ab220447da29` is **not a commit SHA**. It is the Git object SHA of an **annotated tag** (`v4`).
- GitHub Actions does not accept annotated tag *object* SHAs in `uses:` pins (Commits API returns `No commit found for SHA`).
- The correct pin is the **commit SHA that tag `v4` points to**: `45cbd0c69e560cd9e7cd7f8c32362050c9b7ded2`.

**Correct pin:**

```yaml
uses: github/codeql-action/upload-sarif@45cbd0c69e560cd9e7cd7f8c32362050c9b7ded2 # v4
```

## Test plan

- [ ] Each updated `uses:` ref resolves as a commit via the GitHub Commits API
- [ ] Relevant CI jobs on this branch look healthy
