### PR TITLE
fix(agent-ui): stop html previews from escaping their iframe sandbox

### DIFF
--- a/multimodal/tarko/agent-ui/src/common/constants/iframeSandbox.ts
+++ b/multimodal/tarko/agent-ui/src/common/constants/iframeSandbox.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Sandbox policies for frames that carry content the UI does not author.
+ *
+ * `allow-same-origin` lets a framed document keep its own origin. Whether that is safe
+ * depends entirely on what "its own origin" resolves to:
+ *
+ * - `srcdoc` documents inherit the embedder's origin, so granting it there hands the UI's
+ *   origin to the framed content. Combined with `allow-scripts` the sandbox is void and the
+ *   content can reach `parent.document`, storage and same-origin APIs.
+ * - A document loaded from a cross-origin URL keeps that remote origin, which the embedder is
+ *   already walled off from, so the flag buys the framed app its own storage without giving it
+ *   any reach into the UI.
+ */
+
+/** Preview of agent-authored HTML, always handed over through `srcDoc`: opaque origin only. */
+export const HTML_PREVIEW_SANDBOX = 'allow-scripts';
+
+/** Embedded tools (code-server, VNC) drive their own forms, popups and dialogs. */
+const EMBED_FRAME_SANDBOX = 'allow-scripts allow-forms allow-popups allow-modals';
+
+/**
+ * Sandbox for an embedded tool, decided per URL.
+ *
+ * Cross-origin `http(s)` targets keep `allow-same-origin`, because losing their origin also
+ * loses their cookies, `localStorage` and same-origin requests. Anything that could end up
+ * sharing this page's origin — a relative or same-origin URL, an unparsable one, or a scheme
+ * such as `javascript:` or `data:` that inherits or opaques the origin — gets the strict policy.
+ */
+export function resolveEmbedFrameSandbox(src: string): string {
+  try {
+    const target = new URL(src, window.location.href);
+    const isRemoteHttpOrigin =
+      (target.protocol === 'https:' || target.protocol === 'http:') &&
+      target.origin !== window.location.origin;
+
+    if (isRemoteHttpOrigin) {
+      return `${EMBED_FRAME_SANDBOX} allow-same-origin`;
+    }
+  } catch {
+    // Unparsable URL: fall through to the strict policy
+  }
+
+  return EMBED_FRAME_SANDBOX;
+}

--- a/multimodal/tarko/agent-ui/src/standalone/workspace/components/FullscreenModal.tsx
+++ b/multimodal/tarko/agent-ui/src/standalone/workspace/components/FullscreenModal.tsx
@@ -5,6 +5,7 @@ import { MarkdownRenderer } from '@tarko/ui';
 import { MessageContent } from './shared';
 import { FullscreenFileData } from '../types/panelContent';
 import { normalizeFilePath } from '@tarko/ui';
+import { HTML_PREVIEW_SANDBOX } from '@/common/constants/iframeSandbox';
 
 interface FullscreenModalProps {
   data: FullscreenFileData | null;
@@ -85,7 +86,7 @@ export const FullscreenModal: React.FC<FullscreenModalProps> = ({ data, onClose 
                 srcDoc={data.content}
                 className="w-full h-full border-0"
                 title="HTML Preview"
-                sandbox="allow-scripts allow-same-origin"
+                sandbox={HTML_PREVIEW_SANDBOX}
                 style={{ backgroundColor: 'white' }}
               />
             </div>

--- a/multimodal/tarko/agent-ui/src/standalone/workspace/components/ThrottledHtmlRenderer.tsx
+++ b/multimodal/tarko/agent-ui/src/standalone/workspace/components/ThrottledHtmlRenderer.tsx
@@ -1,5 +1,6 @@
 import React, { useRef, useEffect, useState } from 'react';
 import { useStableValue } from '@/common/hooks/useStableValue';
+import { HTML_PREVIEW_SANDBOX } from '@/common/constants/iframeSandbox';
 
 interface ThrottledHtmlRendererProps {
   content: string;
@@ -7,113 +8,90 @@ interface ThrottledHtmlRendererProps {
   className?: string;
 }
 
+/** Minimum gap between two document swaps while content is still streaming in. */
+const STREAMING_UPDATE_INTERVAL = 200;
+
+const FRAME_INDEXES = [0, 1] as const;
+
 /**
- * ThrottledHtmlRenderer - A component that renders HTML content with throttling to prevent flickering
+ * ThrottledHtmlRenderer - renders HTML content in a sandboxed iframe
  *
- * Features:
- * - Throttled updates during streaming to reduce flickering
- * - Smooth DOM replacement instead of full rebuild
- * - Automatic iframe sizing and content injection
+ * The frame is sandboxed without `allow-same-origin`, so its document lives in an opaque
+ * origin and is unreachable from here: content can only be handed over through `srcDoc`.
+ * To keep streaming updates smooth without touching the frame's DOM, two frames alternate —
+ * the next document is parsed in the hidden one and swapped in once it has loaded, so the
+ * viewer never sees a blank frame mid-stream.
  */
 export const ThrottledHtmlRenderer: React.FC<ThrottledHtmlRendererProps> = ({
   content,
   isStreaming = false,
   className = '',
 }) => {
-  const iframeRef = useRef<HTMLIFrameElement>(null);
-  const [lastRenderedContent, setLastRenderedContent] = useState('');
-  const renderTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const [frameContents, setFrameContents] = useState<[string, string]>(['', '']);
+  const [visibleIndex, setVisibleIndex] = useState(0);
+
+  const frameContentsRef = useRef<[string, string]>(['', '']);
+  const visibleIndexRef = useRef(0);
+  const pendingIndexRef = useRef<number | null>(null);
+  const renderedContentRef = useRef('');
+  const lastRenderAtRef = useRef(0);
+  const renderTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Use stable content to reduce unnecessary updates
   const stableContent = useStableValue(content, (a, b) => a === b);
 
+  const showFrame = (index: number) => {
+    visibleIndexRef.current = index;
+    setVisibleIndex(index);
+  };
+
   // Throttling logic for streaming updates
   useEffect(() => {
-    if (!iframeRef.current) return;
-
-    // Clear any pending render
-    if (renderTimeoutRef.current) {
-      clearTimeout(renderTimeoutRef.current);
-    }
-
-    const shouldRender = () => {
-      if (stableContent === lastRenderedContent) return false;
-
-      // If not streaming, render immediately
-      if (!isStreaming) return true;
-
-      // During streaming, throttle updates to reduce flickering
-      const contentDelta = Math.abs(stableContent.length - lastRenderedContent.length);
-      const shouldThrottle = contentDelta < 100; // Only throttle small changes
-
-      return !shouldThrottle;
-    };
+    if (stableContent === renderedContentRef.current) return;
 
     const renderContent = () => {
-      if (!iframeRef.current || stableContent === lastRenderedContent) return;
+      renderTimeoutRef.current = null;
+      renderedContentRef.current = stableContent;
+      lastRenderAtRef.current = Date.now();
 
-      try {
-        const iframe = iframeRef.current;
-        const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
+      const targetIndex = visibleIndexRef.current === 0 ? 1 : 0;
 
-        if (!iframeDoc) return;
-
-        // For streaming, try to update content smoothly
-        if (isStreaming && lastRenderedContent) {
-          // Check if we can do partial update
-          if (stableContent.startsWith(lastRenderedContent)) {
-            // Content is appended, try to append to existing DOM
-            const additionalContent = stableContent.slice(lastRenderedContent.length);
-            if (additionalContent.trim()) {
-              // Create a temporary container to parse new content
-              const tempDiv = iframeDoc.createElement('div');
-              tempDiv.innerHTML = additionalContent;
-
-              // Append new nodes to body
-              while (tempDiv.firstChild) {
-                iframeDoc.body.appendChild(tempDiv.firstChild);
-              }
-
-              setLastRenderedContent(stableContent);
-              return;
-            }
-          }
-        }
-
-        // Full content replacement for non-streaming or significant changes
-        iframeDoc.open();
-        iframeDoc.write(stableContent);
-        iframeDoc.close();
-
-        // Ensure white background for HTML content
-        if (iframeDoc.body) {
-          iframeDoc.body.style.backgroundColor = 'white';
-        }
-
-        setLastRenderedContent(stableContent);
-      } catch (error) {
-        console.warn('Failed to update iframe content:', error);
-        // Fallback to srcDoc update
-        if (iframeRef.current) {
-          iframeRef.current.srcDoc = stableContent;
-          setLastRenderedContent(stableContent);
-        }
+      // An unchanged srcDoc fires no load event, so nothing would trigger the swap
+      if (frameContentsRef.current[targetIndex] === stableContent) {
+        pendingIndexRef.current = null;
+        showFrame(targetIndex);
+        return;
       }
+
+      frameContentsRef.current =
+        targetIndex === 0
+          ? [stableContent, frameContentsRef.current[1]]
+          : [frameContentsRef.current[0], stableContent];
+      pendingIndexRef.current = targetIndex;
+      setFrameContents(frameContentsRef.current);
     };
 
-    if (shouldRender()) {
+    // Outside streaming every change is final, so render it right away
+    if (!isStreaming) {
       renderContent();
-    } else if (isStreaming) {
-      // Schedule throttled update during streaming
-      renderTimeoutRef.current = setTimeout(renderContent, 200);
+      return;
     }
+
+    const elapsed = Date.now() - lastRenderAtRef.current;
+    if (elapsed >= STREAMING_UPDATE_INTERVAL) {
+      renderContent();
+      return;
+    }
+
+    renderTimeoutRef.current = setTimeout(renderContent, STREAMING_UPDATE_INTERVAL - elapsed);
 
     return () => {
       if (renderTimeoutRef.current) {
         clearTimeout(renderTimeoutRef.current);
+        renderTimeoutRef.current = null;
       }
     };
-  }, [stableContent, isStreaming, lastRenderedContent]);
+  }, [stableContent, isStreaming]);
 
   // Cleanup on unmount
   useEffect(() => {
@@ -124,18 +102,28 @@ export const ThrottledHtmlRenderer: React.FC<ThrottledHtmlRendererProps> = ({
     };
   }, []);
 
+  const handleFrameLoad = (index: number) => {
+    if (pendingIndexRef.current !== index) return;
+    pendingIndexRef.current = null;
+    showFrame(index);
+  };
+
   return (
     <div
-      className={`border border-gray-200/50 dark:border-gray-700/30 rounded-lg overflow-hidden bg-white ${className}`}
+      className={`relative min-h-[100vh] border border-gray-200/50 dark:border-gray-700/30 rounded-lg overflow-hidden bg-white ${className}`}
     >
-      <iframe
-        ref={iframeRef}
-        className="w-full border-0 min-h-[100vh]"
-        title="HTML Preview"
-        sandbox="allow-scripts allow-same-origin"
-        // Don't use srcDoc for streaming content to allow manual DOM updates
-        srcDoc={!isStreaming ? stableContent : undefined}
-      />
+      {FRAME_INDEXES.map((index) => (
+        <iframe
+          key={index}
+          className={`absolute inset-0 w-full h-full border-0 ${
+            index === visibleIndex ? '' : 'invisible pointer-events-none'
+          }`}
+          title="HTML Preview"
+          sandbox={HTML_PREVIEW_SANDBOX}
+          srcDoc={frameContents[index]}
+          onLoad={() => handleFrameLoad(index)}
+        />
+      ))}
     </div>
   );
 };

--- a/multimodal/tarko/agent-ui/src/standalone/workspace/renderers/EmbedFrameRenderer.tsx
+++ b/multimodal/tarko/agent-ui/src/standalone/workspace/renderers/EmbedFrameRenderer.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, useEffect, useState } from 'react';
 import type { StandardPanelContent } from '../types/panelContent';
 import { FileDisplayMode } from '../types';
+import { resolveEmbedFrameSandbox } from '@/common/constants/iframeSandbox';
 
 interface EmbedFrameRendererProps {
   panelContent: StandardPanelContent;
@@ -18,6 +19,8 @@ export const EmbedFrameRenderer: React.FC<EmbedFrameRendererProps> = ({
 
   const src =
     typeof panelContent.source === 'string' ? panelContent.source : panelContent.link || '';
+
+  const sandbox = resolveEmbedFrameSandbox(src);
 
   const handleOpenInNewTab = () => {
     if (src) {
@@ -136,7 +139,7 @@ export const EmbedFrameRenderer: React.FC<EmbedFrameRendererProps> = ({
               className="border-0"
               style={{ width: '1280px', height: '958px' }}
               title={panelContent.title}
-              sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals"
+              sandbox={sandbox}
               loading="lazy"
             />
           </div>
@@ -161,7 +164,7 @@ export const EmbedFrameRenderer: React.FC<EmbedFrameRendererProps> = ({
             className="border-0"
             style={{ width: '1280px', height: '958px' }}
             title={panelContent.title}
-            sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals"
+            sandbox={sandbox}
             loading="lazy"
           />
         </div>


### PR DESCRIPTION
## Problem

`multimodal/tarko/agent-ui` renders model-authored HTML into iframes whose `sandbox` attribute contained both `allow-scripts` and `allow-same-origin`. Per the HTML spec that combination is not a sandbox at all whenever the framed content's origin resolves to the embedder's own origin — and `srcdoc` documents inherit the embedder's origin by definition. Chromium says so itself:

> An iframe which has both allow-scripts and allow-same-origin for its sandbox attribute can escape its sandboxing.

Four frames were affected: the streaming HTML preview, the fullscreen HTML preview, and the two embed frames.

The preview path needs no user interaction. A file-writing tool call whose path ends in `.html` opens the workspace panel, and the panel switches itself to `rendered` mode, which hands the file's contents straight to the preview frame. Shared/replay pages are a second delivery surface.

## Impact

Script inside such a frame is same-origin with the UI, so it can read and write `parent.document`, read the UI's `localStorage`, and issue same-origin requests to the agent server that serves the UI — using the victim's own browser context. Because the agent exposes tools that run commands, driving that API is the escalation path, which is why this is treated as a code-execution issue rather than "just" DOM access.

Measured in Chromium against a real HTTP origin, a `srcDoc` frame with the old attribute pair reported `window.origin` equal to the embedder's origin and then successfully read the embedder's `document.title`, read an embedder-scope JS global, **wrote** the embedder's `document.title` (verified on the embedder side, not self-reported), read the embedder's `localStorage`, and completed a same-origin `fetch`. In that configuration the frame's "own" storage and the embedder's storage are literally the same object — verified in both directions.

## Fix

`allow-same-origin` means "let this document keep its own origin". Whether that is safe depends entirely on what its own origin is, so the two frame kinds are treated differently. The policy now lives in one place, `src/common/constants/iframeSandbox.ts`.

**HTML previews (`ThrottledHtmlRenderer`, `FullscreenModal`) — always strict, `allow-scripts` only.** Their content arrives via `srcDoc` and therefore inherits this page's origin; there is no legitimate need for a one-shot preview to keep origin-keyed state. Scripts still execute, now in an opaque origin.

**Embed frames (`EmbedFrameRenderer`) — decided per URL by `resolveEmbedFrameSandbox(src)`.** A cross-origin `http(s)` target keeps `allow-same-origin`; a same-origin, relative, unparsable or non-`http(s)` URL (`javascript:`, `data:`, `blob:`, `about:`) gets the strict policy, and any parse failure falls through to strict. `allow-forms allow-popups allow-modals` is retained in both cases because embedded tools drive their own forms, popups and dialogs.

Keeping the flag for cross-origin targets is not a concession: it does **not** grant embedder access. The framed page keeps its own remote origin, which is still cross-origin to the UI, and parent access stays refused with `SecurityError: ... Blocked a frame with origin "<remote origin>" from accessing a cross-origin frame.` What it does preserve is the embedded tool's ability to use its own `localStorage`, `sessionStorage`, cookies and same-origin requests. Dropping it there would buy no protection and would break embedded tools outright — measured: `SecurityError: ... The document is sandboxed and lacks the 'allow-same-origin' flag.` for storage, `TypeError: Failed to fetch` plus a CORS rejection from `origin 'null'` for the tool's own-origin requests. Embed URLs also come from deployment-side web UI configuration rather than model output, so they are not on the zero-click path that motivates this change.

### Streaming preview mechanism

The old streaming path had the parent write into the frame: `iframeDoc.open()/write()`, `tempDiv.innerHTML` for appended chunks, and a `srcDoc` fallback. An opaque origin makes `contentDocument` unreachable, so that mechanism had to go.

`ThrottledHtmlRenderer` now keeps two stacked frames and alternates them: incoming content goes into the hidden frame's `srcDoc`, and the frames swap visibility on that frame's `load` event, so a partially parsed or empty document is never shown. Streaming commits stay throttled to one per 200 ms as before, and a non-streaming change commits immediately. A guard covers the case where the hidden frame already holds byte-identical content, which would otherwise produce no `load` event and no swap.

## Verification

Mechanism-level, before/after, same payload, only the `sandbox` attribute differing:

| Probe | `allow-scripts allow-same-origin` | `allow-scripts` |
| --- | --- | --- |
| frame `window.origin` | embedder's origin | `null` |
| read `parent.document.title` | succeeded | blocked |
| **write** `parent.document.title` | succeeded, verified on embedder | blocked, embedder title unchanged |
| read embedder JS global | succeeded | blocked |
| read embedder `localStorage` | succeeded | blocked |
| same-origin `fetch` | `200` + body | `TypeError: Failed to fetch` |
| scripts execute | yes | yes |
| Chromium sandbox-escape warning | emitted | absent |

Verbatim after-fix errors: `SecurityError: Failed to read a named property 'document' from 'Window': Blocked a frame with origin "null" from accessing a cross-origin frame.` and, for storage, `SecurityError: Failed to read the 'localStorage' property from 'Window': The document is sandboxed and lacks the 'allow-same-origin' flag.` The `origin "null"` in those messages is the opaque origin taking effect. The parent side also confirms isolation: `iframe.contentDocument` now reads `null`, where before it returned a live document.

Component-level, driving the real components in a browser with fabricated props:

- **Streaming preview** — 14 growing chunks: rendered sections grew strictly monotonically (0→12) with no regression in visible content. A 60 Hz sampler over the 13 s stream (781 samples, all 13 swaps covered) never observed zero visible frames or two visible frames, and the visible frame's content length never shrank. A 126-frame burst capture across every swap contains no blank frame (payload background present in all 126, non-zero painted text in all 126). Inline `<script>` in the previewed document still executes. Final `srcdoc` is byte-identical to the final input, and the resulting DOM is character-identical to what a plain `srcDoc` iframe produces from the same string. Throttling verified: 14 chunks at 40 ms produced 5 document loads, final content still complete.
- **Non-streaming preview** — full content on screen 33 ms after commit, all sections, scripts ran, clean console.
- **Fullscreen preview** — renders with `sandbox="allow-scripts"`, all sections, scripts ran.
- **Embed frame** — cross-origin target: attribute includes `allow-same-origin`, and the tool's `localStorage`, `sessionStorage`, cookies, `fetch`/XHR and WebSocket (correct `Origin` header) all work, while `parent.document`, `parent.location` and `top.location` remain blocked. Same-origin and relative targets: attribute excludes `allow-same-origin` and parent access is blocked. `allow-forms`, `allow-popups` and `allow-modals` verified working under both policies. The full URL matrix (`http(s)` cross-origin, protocol-relative, same-origin absolute, root-relative, path-relative, `javascript:`, `data:`, `blob:`, `about:blank`, `file:`, `ws:`, unparsable, empty) resolves as intended.

Build artifact, `multimodal/tarko/agent-ui-builder/static/`:

```
$ grep -rc "allow-same-origin" .   # -> no matches
$ grep -o "allow-scripts[a-z -]*" index.html | sort | uniq -c
      1 allow-scripts
      1 allow-scripts allow-forms allow-popups allow-modals
$ grep -o -E 'sandbox:"[^"]*"' index.html   # -> no inline literal sandbox strings
```

Minification hoists the two policies to module-level variables referenced by all four frames; `allow-same-origin` is appended at runtime only on the cross-origin embed branch. In the source tree the token now appears only in explanatory comments.

`tsc --noEmit` for the package: zero new errors against the base commit, and one pre-existing error removed (`TS2551 Property 'srcDoc' does not exist on type 'HTMLIFrameElement'`, from the deleted imperative fallback). The 43 remaining errors are pre-existing and in untouched files. `vitest` on the repo is unchanged versus the base commit (same 10 pre-existing collection failures from unbuilt sibling packages; 700/700 individual tests pass). Prettier clean. This package has no tests or lint script of its own, so the security property rests on the browser measurements and the artifact check above.

## Behaviour differences, stated plainly

Replacing a document is not identical to mutating one, and two differences are user-perceptible:

- **In-frame scroll position resets on each streaming commit.** Measured: scrolled to y=1400 inside the frame, the next streaming chunk returns it to y=0, where the old append path held position. With the 200 ms throttle this can happen several times a second while a long HTML report streams in. The old code only preserved position for pure appends and reset on any other change; now every commit resets.
- **Sub-resources are re-requested once per commit** (14 commits of a payload with one image produced 14 requests versus 1). Rendering is unaffected, but a heavy external asset can flash mid-stream.
- The old code forced `body { background-color: white }` inside the frame after every write, overriding the previewed document's own stylesheet — that inline override is gone, so a document that sets a dark background now renders dark. Previously such a document could render white-on-white and be unreadable. The wrapper keeps its white background for documents that set none.
- Wrapper height differs by 2 px, from the border now sitting inside the `100vh` box.

## Not in this change

- No CSP is shipped with the UI, and embed URL schemes are not allow-listed at the source. Both would be worthwhile defence-in-depth follow-ups on top of this sandbox correction.
- `EmbedFrameRenderer` has a pre-existing quirk unrelated to this fix: when it first renders with an empty `src` it returns early, so its `ResizeObserver` is never attached and a later non-empty `src` renders unscaled. Its `isFullscreen` branch is also currently unreachable; both of its frames read the same resolved policy, so the conditional applies consistently if that branch is ever wired up.
- No sanitizer dependency was added. This corrects a permission boundary; it is not content sanitisation.
