### PR TITLE
fix(agent-server): block request-body injection into agent constructor options

### DIFF
--- a/multimodal/tarko/agent-cli/src/config/builder.ts
+++ b/multimodal/tarko/agent-cli/src/config/builder.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { deepMerge, isTest } from '@tarko/shared-utils';
+import { deepMerge, isTest, resolveServerHost } from '@tarko/shared-utils';
 import { getStaticPath } from '@tarko/agent-ui-builder';
 import {
   CommonFilterOptions,
@@ -64,6 +64,7 @@ export function buildAppConfig<
     debug,
     quiet,
     port,
+    host,
     stream,
     headless,
     input,
@@ -119,7 +120,7 @@ export function buildAppConfig<
 
   // Apply CLI shortcuts
   applyLoggingShortcuts(config, { debug, quiet });
-  applyServerConfiguration(config, { port });
+  applyServerConfiguration(config, { port, host });
 
   // Apply WebUI defaults
   applyWebUIDefaults(config as AgentAppConfig);
@@ -243,7 +244,10 @@ function parseLogLevel(level: string): LogLevel | undefined {
 /**
  * Apply server configuration with defaults
  */
-function applyServerConfiguration(config: AgentAppConfig, serverOptions: { port?: number }): void {
+function applyServerConfiguration(
+  config: AgentAppConfig,
+  serverOptions: { port?: number; host?: string },
+): void {
   if (!config.server) {
     config.server = {
       port: 8888,
@@ -259,6 +263,12 @@ function applyServerConfiguration(config: AgentAppConfig, serverOptions: { port?
   if (serverOptions.port) {
     config.server.port = serverOptions.port;
   }
+
+  if (serverOptions.host) {
+    config.server.host = serverOptions.host;
+  }
+
+  config.server.host = resolveServerHost(config.server.host);
 }
 
 /**

--- a/multimodal/tarko/agent-cli/src/core/commands/run.ts
+++ b/multimodal/tarko/agent-cli/src/core/commands/run.ts
@@ -5,6 +5,7 @@
 
 import { LogLevel } from '@tarko/interface';
 import { AgentServer, resolveAgentImplementation } from '@tarko/agent-server';
+import { DEFAULT_SERVER_HOST } from '@tarko/shared-utils';
 import { ConsoleInterceptor } from '../../utils';
 import { AgentCLIRunCommandOptions } from '../../types';
 
@@ -73,9 +74,12 @@ export async function processServerRun(options: AgentCLIRunCommandOptions): Prom
 
   const { appConfig } = agentServerInitOptions;
 
+  // This server only exists to serve the one-shot request issued below, so keep it
+  // on loopback regardless of any configured host.
   appConfig.server = {
     ...(appConfig.server || {}),
     port: 8899,
+    host: DEFAULT_SERVER_HOST,
   };
 
   const { result, logs } = await ConsoleInterceptor.run(

--- a/multimodal/tarko/agent-cli/src/core/commands/serve.ts
+++ b/multimodal/tarko/agent-cli/src/core/commands/serve.ts
@@ -8,6 +8,7 @@ import { LogLevel } from '@tarko/interface';
 import { AgentCLIServeCommandOptions } from '../../types';
 import { AgentServer } from '@tarko/agent-server';
 import { ensureServerConfig } from '../../utils';
+import { formatServerUrl, isExternallyReachableHost } from '@tarko/shared-utils';
 import boxen from 'boxen';
 import chalk from 'chalk';
 
@@ -27,13 +28,19 @@ export async function startHeadlessServer(
   const httpServer = await server.start();
 
   const port = appConfig.server!.port!;
-  const serverUrl = `http://localhost:${port}`;
+  const serverUrl = formatServerUrl(server.host, port);
 
   if (appConfig.logLevel !== LogLevel.SILENT) {
     const boxContent = [
       `${chalk.bold(`${server.getCurrentAgentName()} Headless Server`)}`,
       '',
       `${chalk.cyan('API URL:')} ${chalk.underline(serverUrl)}`,
+      '',
+      `${chalk.cyan('Bound to:')} ${chalk.yellow(`${server.host}:${port}`)}${
+        isExternallyReachableHost(server.host)
+          ? ` ${chalk.red('- reachable from the network, and unauthenticated')}`
+          : ''
+      }`,
       '',
       `${chalk.cyan('Mode:')} ${chalk.yellow('Headless (API only)')}`,
     ].join('\n');

--- a/multimodal/tarko/agent-cli/src/core/commands/start.ts
+++ b/multimodal/tarko/agent-cli/src/core/commands/start.ts
@@ -17,7 +17,7 @@ import boxen from 'boxen';
 import chalk from 'chalk';
 import gradient from 'gradient-string';
 import { logger, toUserFriendlyPath, ensureServerConfig } from '../../utils';
-import { createPathMatcher } from '@tarko/shared-utils';
+import { createPathMatcher, formatServerUrl, isExternallyReachableHost } from '@tarko/shared-utils';
 import { AgentCLIRunInteractiveUICommandOptions } from '../../types';
 
 /**
@@ -56,7 +56,7 @@ export async function startInteractiveWebUI(
   }
 
   const port = appConfig.server!.port!;
-  const serverUrl = `http://localhost:${port}`;
+  const serverUrl = formatServerUrl(server.host, port);
 
   if (appConfig.logLevel !== LogLevel.SILENT) {
     // Define brand colors
@@ -75,6 +75,12 @@ export async function startInteractiveWebUI(
         chalk.underline(brandGradient(serverUrl)),
       '',
       `📁 ${chalk.gray('Workspace:')} ${brandGradient(workspaceDir)}`,
+      '',
+      `🔌 ${chalk.gray('Bound to:')} ${brandGradient(`${server.host}:${port}`)}${
+        isExternallyReachableHost(server.host)
+          ? ` ${chalk.red('- reachable from the network, and unauthenticated')}`
+          : ''
+      }`,
       '',
       `🤖 ${chalk.gray('Model:')} ${appConfig.model?.provider ? brandGradient(`${provider} | ${modelId}`) : chalk.gray('Not specified')}`,
     ].join('\n');

--- a/multimodal/tarko/agent-cli/src/core/options.ts
+++ b/multimodal/tarko/agent-cli/src/core/options.ts
@@ -5,6 +5,7 @@
 
 import { Command } from 'cac';
 import { AgentCLIArguments, AgentImplementation } from '@tarko/interface';
+import { DEFAULT_SERVER_HOST } from '@tarko/shared-utils';
 import { AgioProvider } from '../agio/AgioProvider';
 
 export type { AgentCLIArguments };
@@ -17,6 +18,15 @@ export const DEFAULT_PORT = 8888;
 export function addCommonOptions(command: Command): Command {
   const baseCommand = command
     .option('--port <port>', 'Port to run the server on', { default: DEFAULT_PORT })
+    .option(
+      '--host <host>',
+      `Network interface to bind (default: ${DEFAULT_SERVER_HOST})
+
+                            The server exposes agent execution without authentication, so it binds
+                            loopback only by default. Pass --host 0.0.0.0 to listen on every
+                            interface, and only do so behind a proxy that authenticates requests.
+      `,
+    )
     .option('--open', 'Open the web UI in the default browser on server start')
     .option(
       '--config, -c <path>',

--- a/multimodal/tarko/agent-cli/src/utils/server-setup.ts
+++ b/multimodal/tarko/agent-cli/src/utils/server-setup.ts
@@ -1,21 +1,17 @@
-/*
- * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { AgentAppConfig } from '@tarko/interface';
+import { resolveServerHost } from '@tarko/shared-utils';
 import chalk from 'chalk';
 import { findAvailablePort } from './port';
 
 export async function ensureServerConfig(appConfig: AgentAppConfig): Promise<void> {
-  // Ensure server config exists with defaults
   if (!appConfig.server) {
     appConfig.server = {
       port: 8888,
     };
   }
 
-  // Find available port
+  appConfig.server.host = resolveServerHost(appConfig.server.host);
+
   const availablePort = await findAvailablePort(appConfig.server.port!);
   if (availablePort !== appConfig.server.port) {
     console.log(

--- a/multimodal/tarko/agent-cli/tests/config-builder.test.ts
+++ b/multimodal/tarko/agent-cli/tests/config-builder.test.ts
@@ -58,6 +58,7 @@ describe('buildAppConfig', () => {
             "provider": "openai",
           },
           "server": {
+            "host": "127.0.0.1",
             "port": 3000,
             "storage": {
               "type": "sqlite",
@@ -234,6 +235,7 @@ describe('buildAppConfig', () => {
       const result = buildAppConfig(cliArgs, userConfig);
 
       expect(result.server).toEqual({
+        host: '127.0.0.1',
         port: 8888, // Default port
         storage: {
           type: 'sqlite',
@@ -255,6 +257,7 @@ describe('buildAppConfig', () => {
       const result = buildAppConfig(cliArgs, userConfig);
 
       expect(result.server).toEqual({
+        host: '127.0.0.1',
         port: 3000, // CLI overrides user config
         storage: {
           type: 'sqlite',
@@ -300,6 +303,7 @@ describe('buildAppConfig', () => {
       const result = buildAppConfig(cliArgs, {});
 
       expect(result.server).toEqual({
+        host: '127.0.0.1',
         port: 8888, // Default port always added
         storage: {
           type: 'sqlite',
@@ -340,6 +344,7 @@ describe('buildAppConfig', () => {
             "provider": "openai",
           },
           "server": {
+            "host": "127.0.0.1",
             "port": 8888,
             "storage": {
               "type": "sqlite",
@@ -455,6 +460,7 @@ describe('buildAppConfig', () => {
             "provider": "openai",
           },
           "server": {
+            "host": "127.0.0.1",
             "port": 8888,
             "storage": {
               "type": "sqlite",
@@ -612,6 +618,7 @@ describe('buildAppConfig', () => {
       const result = buildAppConfig(cliArgs, userConfig);
 
       expect(result.server).toEqual({
+        host: '127.0.0.1',
         port: 9999,
         storage: {
           type: 'file',
@@ -681,6 +688,7 @@ describe('buildAppConfig', () => {
       const result = buildAppConfig(cliArgs, userConfig);
 
       expect(result.server).toEqual({
+        host: '127.0.0.1',
         port: 9999,
         storage: {
           type: 'file',

--- a/multimodal/tarko/agent-server-next/src/controllers/sessions.ts
+++ b/multimodal/tarko/agent-server-next/src/controllers/sessions.ts
@@ -7,6 +7,12 @@ import type { HonoContext } from '../types';
 import { getCurrentUserId } from '../middlewares/auth';
 import { SessionInfo } from '@tarko/interface';
 import { ShareService } from '../services';
+import { InvalidSessionInputError } from '../services/session/AgentSessionFactory';
+import {
+  ALLOWED_SESSION_AGENT_OPTION_KEYS,
+  filterDeclaredRuntimeSettings,
+  sanitizeSessionAgentOptions,
+} from '@tarko/shared-utils';
 import { filterSessionModel } from '../utils';
 
 /**
@@ -67,6 +73,9 @@ export async function createSession(c: HonoContext) {
       201,
     );
   } catch (error) {
+    if (error instanceof InvalidSessionInputError) {
+      return c.json({ error: error.message, ...error.details }, 400);
+    }
     console.error('Failed to create session:', error);
     return c.json({ error: 'Failed to create session' }, 500);
   }
@@ -200,10 +209,39 @@ export async function updateSession(c: HonoContext) {
       return c.json({ error: 'Session not found' }, 404);
     }
 
+    // Session metadata is replayed into the Agent constructor on every session
+    // initialization, so hold its agent-facing fields to the same boundary as
+    // session creation instead of persisting the payload verbatim.
+    const sanitizedUpdates = { ...metadataUpdates };
+
+    if ('agentOptions' in sanitizedUpdates) {
+      const { value, rejectedKeys } = sanitizeSessionAgentOptions(sanitizedUpdates.agentOptions);
+      if (rejectedKeys.length > 0) {
+        return c.json(
+          {
+            error: 'Unsupported agentOptions',
+            message: `agentOptions may only contain ${ALLOWED_SESSION_AGENT_OPTION_KEYS.join(', ')}; rejected: ${rejectedKeys.join(', ')}. Configure anything else on the server.`,
+            allowed: ALLOWED_SESSION_AGENT_OPTION_KEYS,
+            rejected: rejectedKeys,
+          },
+          400,
+        );
+      }
+      sanitizedUpdates.agentOptions = value;
+    }
+
+    if ('runtimeSettings' in sanitizedUpdates) {
+      const { value } = filterDeclaredRuntimeSettings(
+        sanitizedUpdates.runtimeSettings,
+        server.appConfig?.server?.runtimeSettings?.schema,
+      );
+      sanitizedUpdates.runtimeSettings = value;
+    }
+
     const updatedMetadata = await server.daoFactory.updateSessionInfo(sessionId, {
       metadata: {
         ...sessionInfo.metadata,
-        ...metadataUpdates,
+        ...sanitizedUpdates,
       },
     });
 

--- a/multimodal/tarko/agent-server-next/src/server.ts
+++ b/multimodal/tarko/agent-server-next/src/server.ts
@@ -22,6 +22,7 @@ import { SandboxScheduler } from './services/sandbox';
 import { UserConfigService } from './services/user';
 import { MongoDAOFactory } from './dao/mongodb/MongoDAOFactory';
 import { TARKO_CONSTANTS, GlobalDirectoryOptions } from '@tarko/interface';
+import { formatServerUrl, resolveServerHost } from '@tarko/shared-utils';
 import {
   createQueryRoutes,
   createSessionRoutes,
@@ -62,6 +63,7 @@ export class AgentServer<T extends AgentAppConfig = AgentAppConfig> {
 
   // Configuration
   public readonly port: number;
+  public readonly host: string;
   public readonly isDebug: boolean;
   public readonly isExclusive: boolean;
   public readonly daoFactory: IDAOFactory;
@@ -95,6 +97,7 @@ export class AgentServer<T extends AgentAppConfig = AgentAppConfig> {
 
     // Extract server configuration from agent options
     this.port = appConfig.server?.port ?? 3000;
+    this.host = resolveServerHost(appConfig.server?.host);
     this.isDebug = appConfig.logLevel === LogLevel.DEBUG;
     this.isExclusive = appConfig.server?.exclusive ?? false;
     this.tenantConfig = appConfig.server?.tenant || { mode: 'single', auth: false };
@@ -349,10 +352,11 @@ export class AgentServer<T extends AgentAppConfig = AgentAppConfig> {
     this.server = serve({
       fetch: this.app.fetch,
       port: this.port,
+      hostname: this.host,
     });
 
     this.isRunning = true;
-    console.log(`Server started on port ${this.port}`);
+    console.log(`Server started on ${formatServerUrl(this.host, this.port)} (bound to ${this.host})`);
   }
 
   /**

--- a/multimodal/tarko/agent-server-next/src/services/session/AgentSession.ts
+++ b/multimodal/tarko/agent-server-next/src/services/session/AgentSession.ts
@@ -17,6 +17,7 @@ import {
   AgentAppConfig,
 } from '@tarko/interface';
 import { AgentSnapshot } from '@tarko/agent-snapshot';
+import { filterDeclaredRuntimeSettings, sanitizeSessionAgentOptions } from '@tarko/shared-utils';
 import { EventStreamBridge } from '../../utils/event-stream';
 import type { AgentServer, ILogger } from '../../types';
 import { AgioEvent } from '@tarko/agio';
@@ -178,22 +179,45 @@ export class AgentSession {
 
     // Apply runtime settings transformation if available
     const runtimeSettingsConfig = this.server.appConfig?.server?.runtimeSettings;
-    let transformedOptions = sessionInfo?.metadata?.runtimeSettings ?? {};
 
-    if (runtimeSettingsConfig?.transform && sessionInfo?.metadata?.runtimeSettings) {
+    // Runtime settings arrive from the client and land in session metadata, so
+    // reduce them to the keys the server declared before they reach the Agent.
+    const { value: declaredRuntimeSettings } = filterDeclaredRuntimeSettings(
+      sessionInfo?.metadata?.runtimeSettings,
+      runtimeSettingsConfig?.schema,
+    );
+    const hasDeclaredRuntimeSettings = Object.keys(declaredRuntimeSettings).length > 0;
+
+    // A server-provided transform maps settings onto agent options; its output is
+    // server code and stays free to override configuration. Without a transform the
+    // declared settings are passed through as plain values instead.
+    let trustedOverrides: Record<string, any> = {};
+    let clientRuntimeOverrides: Record<string, any> = declaredRuntimeSettings;
+
+    if (runtimeSettingsConfig?.transform && hasDeclaredRuntimeSettings) {
+      clientRuntimeOverrides = {};
       try {
-        transformedOptions = runtimeSettingsConfig.transform(sessionInfo.metadata.runtimeSettings);
+        trustedOverrides = runtimeSettingsConfig.transform(declaredRuntimeSettings) ?? {};
       } catch (error) {
         console.warn('Failed to apply runtime settings transform:', error);
       }
     }
 
-    // Merge base options with transformed runtime settings and one-time agent options
+    // One-time options are allowlisted at the API boundary; re-apply the allowlist
+    // here so neither another caller nor persisted session metadata can widen it.
+    const { value: requestAgentOptions } = sanitizeSessionAgentOptions(this.agentOptions);
+    const { value: storedAgentOptions } = sanitizeSessionAgentOptions(
+      this.sessionInfo?.metadata?.agentOptions,
+    );
+
+    // Client-derived values are applied first so server configuration always wins.
+    // Only the server's own transform output may override it.
     const agentOptions = {
+      ...clientRuntimeOverrides,
+      ...(requestAgentOptions ?? {}),
+      ...(storedAgentOptions ?? {}),
       ...baseAgentOptions,
-      ...transformedOptions,
-      ...(this.agentOptions || {}), // Apply one-time agent initialization options
-      ...(this.sessionInfo?.metadata?.agentOptions || {}),
+      ...trustedOverrides,
     };
 
     // Create base agent
@@ -254,7 +278,7 @@ export class AgentSession {
             id: agentOptions.model?.id,
             provider: agentOptions.model?.provider,
           },
-          runtimeSettings: transformedOptions,
+          runtimeSettings: declaredRuntimeSettings,
         },
         null,
         2,

--- a/multimodal/tarko/agent-server-next/src/services/session/AgentSessionFactory.ts
+++ b/multimodal/tarko/agent-server-next/src/services/session/AgentSessionFactory.ts
@@ -12,6 +12,25 @@ import type { AgioProviderConstructor, SessionInfo } from '@tarko/interface';
 import { ISessionDAO } from '../../dao';
 import { getDefaultModel } from '../../utils/model-utils';
 import { getLogger } from '../../utils/logger';
+import {
+  ALLOWED_SESSION_AGENT_OPTION_KEYS,
+  filterDeclaredRuntimeSettings,
+  sanitizeSessionAgentOptions,
+} from '@tarko/shared-utils';
+
+/**
+ * Raised when a session creation payload carries options the server will not accept.
+ * Controllers map this to a 400 instead of a generic failure.
+ */
+export class InvalidSessionInputError extends Error {
+  constructor(
+    message: string,
+    readonly details: Record<string, unknown> = {},
+  ) {
+    super(message);
+    this.name = 'InvalidSessionInputError';
+  }
+}
 
 export interface CreateSessionOptions {
   sessionId?: string;
@@ -55,10 +74,31 @@ export class AgentSessionFactory {
     // Get runtimeSettings and agentOptions from request body
     const body = await c.req.json().catch(() => ({}));
 
-    const { runtimeSettings, agentOptions } = body as {
+    const {
+      runtimeSettings: requestedRuntimeSettings,
+      agentOptions: requestedAgentOptions,
+    } = body as {
       runtimeSettings?: Record<string, any>;
       agentOptions?: Record<string, any>;
     };
+
+    // Both fields are merged into the Agent constructor, so accept only the
+    // allowlisted agent options and only runtime settings the server declared.
+    const { value: agentOptions, rejectedKeys } =
+      sanitizeSessionAgentOptions(requestedAgentOptions);
+    if (rejectedKeys.length > 0) {
+      throw new InvalidSessionInputError('Unsupported agentOptions', {
+        message: `agentOptions may only contain ${ALLOWED_SESSION_AGENT_OPTION_KEYS.join(', ')}; rejected: ${rejectedKeys.join(', ')}. Configure anything else on the server.`,
+        allowed: ALLOWED_SESSION_AGENT_OPTION_KEYS,
+        rejected: rejectedKeys,
+      });
+    }
+
+    const { value: runtimeSettings } = filterDeclaredRuntimeSettings(
+      requestedRuntimeSettings,
+      server.appConfig?.server?.runtimeSettings?.schema,
+    );
+    const hasRuntimeSettings = Object.keys(runtimeSettings).length > 0;
 
     // Allocate sandbox if scheduler is available
     let sandboxUrl: string | undefined;
@@ -98,7 +138,7 @@ export class AgentSessionFactory {
           }),
         sandboxUrl,
         // Include runtime settings if provided (persistent session settings)
-        ...(runtimeSettings && {
+        ...(hasRuntimeSettings && {
           runtimeSettings,
         }),
         // Include agent options if provided (one-time initialization options)

--- a/multimodal/tarko/agent-server/src/api/controllers/sessions.ts
+++ b/multimodal/tarko/agent-server/src/api/controllers/sessions.ts
@@ -9,6 +9,11 @@ import { SessionInfo } from '../../storage';
 import { AgentSession } from '../../core';
 import { ShareService } from '../../services';
 import { getDefaultModel } from '../../utils/model-utils';
+import {
+  ALLOWED_SESSION_AGENT_OPTION_KEYS,
+  filterDeclaredRuntimeSettings,
+  sanitizeSessionAgentOptions,
+} from '@tarko/shared-utils';
 import * as path from 'path';
 import * as fs from 'fs';
 
@@ -45,10 +50,33 @@ export async function getAllSessions(req: Request, res: Response) {
 export async function createSession(req: Request, res: Response) {
   try {
     const server = req.app.locals.server;
-    const { runtimeSettings, agentOptions } = req.body as {
-      runtimeSettings?: Record<string, any>;
-      agentOptions?: Record<string, any>;
-    };
+    const { runtimeSettings: requestedRuntimeSettings, agentOptions: requestedAgentOptions } =
+      req.body as {
+        runtimeSettings?: Record<string, any>;
+        agentOptions?: Record<string, any>;
+      };
+
+    // Session creation options are merged into the Agent constructor, so accept
+    // only the allowlisted keys instead of whatever the caller sent.
+    const { value: agentOptions, rejectedKeys } =
+      sanitizeSessionAgentOptions(requestedAgentOptions);
+    if (rejectedKeys.length > 0) {
+      return res.status(400).json({
+        error: 'Unsupported agentOptions',
+        message: `agentOptions may only contain ${ALLOWED_SESSION_AGENT_OPTION_KEYS.join(', ')}; rejected: ${rejectedKeys.join(', ')}. Configure anything else on the server.`,
+        allowed: ALLOWED_SESSION_AGENT_OPTION_KEYS,
+        rejected: rejectedKeys,
+      });
+    }
+
+    // Runtime settings reach the same constructor, so keep only the keys the
+    // server declared in its runtime settings schema.
+    const { value: runtimeSettings } = filterDeclaredRuntimeSettings(
+      requestedRuntimeSettings,
+      server.appConfig?.server?.runtimeSettings?.schema,
+    );
+    const hasRuntimeSettings = Object.keys(runtimeSettings).length > 0;
+
     const sessionId = nanoid();
 
     // Get session metadata if it exists (for restored sessions)
@@ -81,7 +109,7 @@ export async function createSession(req: Request, res: Response) {
             modelConfig: defaultModel,
           }),
           // Include runtime settings if provided (persistent session settings)
-          ...(runtimeSettings && {
+          ...(hasRuntimeSettings && {
             runtimeSettings,
           }),
           // Include agent options if provided (one-time initialization options)

--- a/multimodal/tarko/agent-server/src/api/controllers/system.ts
+++ b/multimodal/tarko/agent-server/src/api/controllers/system.ts
@@ -5,6 +5,7 @@
 
 import { Request, Response } from 'express';
 import { sanitizeAgentOptions } from '../../utils/config-sanitizer';
+import { filterDeclaredRuntimeSettings } from '@tarko/shared-utils';
 import { getPublicAvailableModels, isModelConfigValid } from '../../utils/model-utils';
 
 export function healthCheck(req: Request, res: Response) {
@@ -86,7 +87,7 @@ export async function getRuntimeSettings(req: Request, res: Response) {
  * Requires sessionId parameter
  */
 export async function updateRuntimeSettings(req: Request, res: Response) {
-  const { sessionId, runtimeSettings } = req.body as {
+  const { sessionId, runtimeSettings: requestedRuntimeSettings } = req.body as {
     sessionId: string;
     runtimeSettings: Record<string, any>;
   };
@@ -95,12 +96,19 @@ export async function updateRuntimeSettings(req: Request, res: Response) {
     return res.status(400).json({ error: 'Session ID is required' });
   }
 
-  if (!runtimeSettings || typeof runtimeSettings !== 'object') {
+  if (!requestedRuntimeSettings || typeof requestedRuntimeSettings !== 'object') {
     return res.status(400).json({ error: 'Runtime settings object is required' });
   }
 
   try {
     const server = req.app.locals.server;
+
+    // Session metadata is replayed into the Agent constructor on every
+    // initialization, so persist only the keys the server declared.
+    const { value: runtimeSettings } = filterDeclaredRuntimeSettings(
+      requestedRuntimeSettings,
+      server.appConfig?.server?.runtimeSettings?.schema,
+    );
 
     if (!server.storageProvider) {
       return res.status(404).json({ error: 'Storage not configured, cannot update runtime settings' });

--- a/multimodal/tarko/agent-server/src/core/AgentSession.ts
+++ b/multimodal/tarko/agent-server/src/core/AgentSession.ts
@@ -15,6 +15,7 @@ import {
   IAgent,
 } from '@tarko/interface';
 import { AgentSnapshot } from '@tarko/agent-snapshot';
+import { filterDeclaredRuntimeSettings, sanitizeSessionAgentOptions } from '@tarko/shared-utils';
 import { EventStreamBridge } from '../utils/event-stream';
 import type { AgentServer } from '../server';
 import { AgioEvent } from '@tarko/agio';
@@ -171,21 +172,41 @@ export class AgentSession {
 
     // Apply runtime settings transformation if available
     const runtimeSettingsConfig = this.server.appConfig?.server?.runtimeSettings;
-    let transformedOptions = sessionInfo?.metadata?.runtimeSettings ?? {};
 
-    if (runtimeSettingsConfig?.transform && sessionInfo?.metadata?.runtimeSettings) {
+    // Runtime settings arrive from the client and land in session metadata, so
+    // reduce them to the keys the server declared before they reach the Agent.
+    const { value: declaredRuntimeSettings } = filterDeclaredRuntimeSettings(
+      sessionInfo?.metadata?.runtimeSettings,
+      runtimeSettingsConfig?.schema,
+    );
+    const hasDeclaredRuntimeSettings = Object.keys(declaredRuntimeSettings).length > 0;
+
+    // A server-provided transform maps settings onto agent options; its output is
+    // server code and stays free to override configuration. Without a transform the
+    // declared settings are passed through as plain values instead.
+    let trustedOverrides: Record<string, any> = {};
+    let clientRuntimeOverrides: Record<string, any> = declaredRuntimeSettings;
+
+    if (runtimeSettingsConfig?.transform && hasDeclaredRuntimeSettings) {
+      clientRuntimeOverrides = {};
       try {
-        transformedOptions = runtimeSettingsConfig.transform(sessionInfo.metadata.runtimeSettings);
+        trustedOverrides = runtimeSettingsConfig.transform(declaredRuntimeSettings) ?? {};
       } catch (error) {
         console.warn('Failed to apply runtime settings transform:', error);
       }
     }
 
-    // Merge base options with transformed runtime settings and one-time agent options
+    // One-time options are allowlisted at the API boundary; re-apply the allowlist
+    // here so no other caller can widen it.
+    const { value: sessionAgentOptions } = sanitizeSessionAgentOptions(this.agentOptions);
+
+    // Client-derived values are applied first so server configuration always wins.
+    // Only the server's own transform output may override it.
     const agentOptions = {
+      ...clientRuntimeOverrides,
+      ...(sessionAgentOptions ?? {}),
       ...baseAgentOptions,
-      ...transformedOptions,
-      ...(this.agentOptions || {}), // Apply one-time agent initialization options
+      ...trustedOverrides,
     };
 
     // Create base agent

--- a/multimodal/tarko/agent-server/src/server.ts
+++ b/multimodal/tarko/agent-server/src/server.ts
@@ -18,6 +18,7 @@ import type {
   AgioProviderConstructor,
 } from './types';
 import { TARKO_CONSTANTS, GlobalDirectoryOptions } from '@tarko/interface';
+import { resolveServerHost } from '@tarko/shared-utils';
 
 export { express };
 
@@ -48,6 +49,7 @@ export class AgentServer<T extends AgentAppConfig = AgentAppConfig> {
 
   // Configuration
   public readonly port: number;
+  public readonly host: string;
   public readonly isDebug: boolean;
   public readonly isExclusive: boolean;
   public readonly storageProvider: StorageProvider | null = null;
@@ -79,6 +81,7 @@ export class AgentServer<T extends AgentAppConfig = AgentAppConfig> {
 
     // Extract server configuration from agent options
     this.port = appConfig.server?.port ?? 3000;
+    this.host = resolveServerHost(appConfig.server?.host);
     this.isDebug = appConfig.logLevel === LogLevel.DEBUG;
     this.isExclusive = appConfig.server?.exclusive ?? false;
 
@@ -256,7 +259,7 @@ export class AgentServer<T extends AgentAppConfig = AgentAppConfig> {
     }
 
     return new Promise((resolve) => {
-      this.server.listen(this.port, () => {
+      this.server.listen(this.port, this.host, () => {
         this.isRunning = true;
         resolve(this.server);
       });

--- a/multimodal/tarko/agent-server/tests/api/session-request-boundary.test.ts
+++ b/multimodal/tarko/agent-server/tests/api/session-request-boundary.test.ts
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Request, Response } from 'express';
+
+import { createSession } from '../../src/api/controllers/sessions';
+import { MockAgent } from '../mocks/MockAgent';
+
+const createServer = (runtimeSettingsSchema?: Record<string, unknown>) => ({
+  appConfig: {
+    server: runtimeSettingsSchema
+      ? { runtimeSettings: { schema: runtimeSettingsSchema } }
+      : undefined,
+  },
+  storageProvider: null,
+  sessions: {},
+  storageUnsubscribes: {},
+  getCurrentWorkspace: vi.fn().mockReturnValue('/test/workspace'),
+  getCurrentAgentName: vi.fn().mockReturnValue('mock-agent'),
+  getCustomAgioProvider: vi.fn().mockReturnValue(undefined),
+  getCurrentAgentResolution: vi.fn().mockReturnValue({
+    agentName: 'mock-agent',
+    agentConstructor: MockAgent,
+  }),
+  setRunningSession: vi.fn(),
+  clearRunningSession: vi.fn(),
+  isDebug: false,
+});
+
+const createRequest = (body: Record<string, unknown>, server: unknown) =>
+  ({ body, app: { locals: { server } } }) as unknown as Request;
+
+const createResponse = () => {
+  const res = {
+    statusCode: undefined as number | undefined,
+    body: undefined as any,
+    status: vi.fn((code: number) => {
+      res.statusCode = code;
+      return res;
+    }),
+    json: vi.fn((payload: any) => {
+      res.body = payload;
+      return res;
+    }),
+  };
+  return res as unknown as Response & { statusCode?: number; body?: any };
+};
+
+describe('createSession request boundary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects mcpServers in agentOptions, which would spawn a local process', async () => {
+    const res = createResponse();
+
+    await createSession(
+      createRequest(
+        { agentOptions: { mcpServers: { evil: { command: 'sh', args: ['-c', 'id'] } } } },
+        createServer(),
+      ),
+      res,
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toBe('Unsupported agentOptions');
+    expect(res.body.rejected).toEqual(['mcpServers']);
+  });
+
+  it('rejects aioSandbox in agentOptions, which would redirect sandboxed execution', async () => {
+    const res = createResponse();
+
+    await createSession(
+      createRequest({ agentOptions: { aioSandbox: 'http://attacker.example' } }, createServer()),
+      res,
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.rejected).toEqual(['aioSandbox']);
+  });
+
+  it('rejects model credential and agio endpoint overrides in agentOptions', async () => {
+    const res = createResponse();
+
+    await createSession(
+      createRequest(
+        {
+          agentOptions: {
+            model: { baseURL: 'http://attacker.example', apiKey: 'stolen' },
+            agio: { provider: 'http://attacker.example' },
+          },
+        },
+        createServer(),
+      ),
+      res,
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.rejected).toEqual(['model', 'agio']);
+  });
+
+  it('accepts the allowlisted agentMode', async () => {
+    const res = createResponse();
+
+    await createSession(
+      createRequest({ agentOptions: { agentMode: { id: 'gui' } } }, createServer()),
+      res,
+    );
+
+    expect(res.status).not.toHaveBeenCalledWith(400);
+  });
+});

--- a/multimodal/tarko/agent-server/tests/core/agent-session-option-boundary.test.ts
+++ b/multimodal/tarko/agent-server/tests/core/agent-session-option-boundary.test.ts
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { AgentSession } from '../../src/core/AgentSession';
+import { MemoryStorageProvider } from '../../src/storage/MemoryStorageProvider';
+import { MockAgent } from '../mocks/MockAgent';
+import { AgentServer } from '../../src/server';
+import { SessionInfo } from '@tarko/interface';
+
+/**
+ * The options a session hands to the Agent constructor are the boundary that keeps
+ * a request from reconfiguring the Agent. These tests pin that boundary down by
+ * capturing the constructor argument.
+ */
+describe('AgentSession - agent option boundary', () => {
+  let capturedOptions: Record<string, any>;
+  let storageProvider: MemoryStorageProvider;
+  let session: AgentSession;
+  const sessionId = 'test-session-boundary';
+
+  class CapturingAgent extends MockAgent {
+    constructor(options: any) {
+      super(options);
+      capturedOptions = options;
+    }
+  }
+
+  const buildServer = (appConfig: Record<string, any>): AgentServer =>
+    ({
+      storageProvider,
+      appConfig,
+      getCurrentAgentResolution: vi.fn().mockReturnValue({
+        agentName: 'test-agent',
+        agentConstructor: CapturingAgent,
+      }),
+      getCurrentAgentName: vi.fn().mockReturnValue('test-agent'),
+      getCurrentWorkspace: vi.fn().mockReturnValue('/tmp/test'),
+      setRunningSession: vi.fn(),
+      clearRunningSession: vi.fn(),
+      isDebug: false,
+    }) as unknown as AgentServer;
+
+  const createSessionInfo = async (metadata: SessionInfo['metadata'] = {}) =>
+    storageProvider.createSession({
+      id: sessionId,
+      workspace: '/tmp/test',
+      metadata,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+
+  beforeEach(async () => {
+    capturedOptions = {};
+    storageProvider = new MemoryStorageProvider();
+    await storageProvider.initialize();
+  });
+
+  afterEach(async () => {
+    if (session) {
+      await session.cleanup();
+    }
+    if (storageProvider) {
+      await storageProvider.close();
+    }
+  });
+
+  it('drops mcpServers supplied as one-time agentOptions', async () => {
+    const sessionInfo = await createSessionInfo();
+    const server = buildServer({ workspace: '/tmp/test' });
+
+    session = new AgentSession(server, sessionId, undefined, sessionInfo, {
+      mcpServers: { evil: { command: 'sh', args: ['-c', 'id'] } },
+    });
+    await session.initialize();
+
+    expect(capturedOptions.mcpServers).toBeUndefined();
+  });
+
+  it('drops mcpServers and aioSandbox supplied as undeclared runtimeSettings', async () => {
+    const sessionInfo = await createSessionInfo({
+      runtimeSettings: {
+        mcpServers: { evil: { command: 'sh', args: ['-c', 'id'] } },
+        aioSandbox: 'http://attacker.example',
+      },
+    } as SessionInfo['metadata']);
+    const server = buildServer({ workspace: '/tmp/test' });
+
+    session = new AgentSession(server, sessionId, undefined, sessionInfo);
+    await session.initialize();
+
+    expect(capturedOptions.mcpServers).toBeUndefined();
+    expect(capturedOptions.aioSandbox).toBeUndefined();
+  });
+
+  it('keeps server configuration when a request supplies the same key', async () => {
+    const sessionInfo = await createSessionInfo();
+    const server = buildServer({
+      workspace: '/tmp/test',
+      aioSandbox: 'http://sandbox.internal',
+    });
+
+    session = new AgentSession(server, sessionId, undefined, sessionInfo, {
+      aioSandbox: 'http://attacker.example',
+      workspace: '/etc',
+    });
+    await session.initialize();
+
+    expect(capturedOptions.aioSandbox).toBe('http://sandbox.internal');
+    expect(capturedOptions.workspace).toBe('/tmp/test');
+  });
+
+  it('passes through the allowlisted agentMode', async () => {
+    const sessionInfo = await createSessionInfo();
+    const server = buildServer({ workspace: '/tmp/test' });
+    const agentMode = { id: 'game', link: 'https://example.com/g', browserMode: 'hybrid' };
+
+    session = new AgentSession(server, sessionId, undefined, sessionInfo, { agentMode });
+    await session.initialize();
+
+    expect(capturedOptions.agentMode).toEqual(agentMode);
+  });
+
+  it('passes through runtime settings the server declared', async () => {
+    const sessionInfo = await createSessionInfo({
+      runtimeSettings: { browserMode: 'hybrid', mcpServers: { evil: { command: 'sh' } } },
+    } as SessionInfo['metadata']);
+    const server = buildServer({
+      workspace: '/tmp/test',
+      server: { runtimeSettings: { schema: { properties: { browserMode: { type: 'string' } } } } },
+    });
+
+    session = new AgentSession(server, sessionId, undefined, sessionInfo);
+    await session.initialize();
+
+    expect(capturedOptions.browserMode).toBe('hybrid');
+    expect(capturedOptions.mcpServers).toBeUndefined();
+  });
+
+  it('still lets a server-provided runtime settings transform shape agent options', async () => {
+    const sessionInfo = await createSessionInfo({
+      runtimeSettings: { mode: 'game' },
+    } as SessionInfo['metadata']);
+    const server = buildServer({
+      workspace: '/tmp/test',
+      server: {
+        runtimeSettings: {
+          schema: { properties: { mode: { type: 'string' } } },
+          transform: (runtimeSettings: Record<string, unknown>) => ({
+            agentMode: { id: runtimeSettings.mode },
+          }),
+        },
+      },
+    });
+
+    session = new AgentSession(server, sessionId, undefined, sessionInfo);
+    await session.initialize();
+
+    expect(capturedOptions.agentMode).toEqual({ id: 'game' });
+  });
+});

--- a/multimodal/tarko/agent-server/tests/setup.ts
+++ b/multimodal/tarko/agent-server/tests/setup.ts
@@ -44,14 +44,18 @@ vi.mock('@tarko/shared-media-utils', () => ({
   default: {},
 }));
 
-vi.mock('@tarko/shared-utils', () => ({
-  getLogger: vi.fn(() => ({
-    debug: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  })),
-}));
+vi.mock('@tarko/shared-utils', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('@tarko/shared-utils');
+  return {
+    ...actual,
+    getLogger: vi.fn(() => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    })),
+  };
+});
 
 vi.mock('@tarko/agent-snapshot', () => ({
   AgentSnapshot: vi.fn().mockImplementation((agent) => agent),

--- a/multimodal/tarko/interface/src/cli.ts
+++ b/multimodal/tarko/interface/src/cli.ts
@@ -21,6 +21,9 @@ export type AgentCLIArguments = Pick<
   /** Server port number - maps to server.port */
   port?: number;
 
+  /** Network interface to bind - maps to server.host, defaults to 127.0.0.1 */
+  host?: string;
+
   // Deprecated options, for backward compatible
   provider?: string;
   apiKey?: string;

--- a/multimodal/tarko/interface/src/server.ts
+++ b/multimodal/tarko/interface/src/server.ts
@@ -183,6 +183,17 @@ export interface AgentServerOptions {
      */
     port?: number;
     /**
+     * Network interface the server binds to.
+     *
+     * Defaults to `127.0.0.1`. The server has no authentication, so binding a
+     * non-loopback address exposes session creation and agent execution to
+     * anyone who can reach the port; use `0.0.0.0` only behind a proxy that
+     * authenticates requests.
+     *
+     * @default '127.0.0.1'
+     */
+    host?: string;
+    /**
      * Server Storage options.
      */
     storage?: AgentStorageImplementation;

--- a/multimodal/tarko/shared-utils/src/index.ts
+++ b/multimodal/tarko/shared-utils/src/index.ts
@@ -9,3 +9,5 @@ export * from './env';
 export * from './filter';
 export * from './gui-agent';
 export * from './webui-routing';
+export * from './session-agent-options';
+export * from './server-host';

--- a/multimodal/tarko/shared-utils/src/server-host.test.ts
+++ b/multimodal/tarko/shared-utils/src/server-host.test.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_SERVER_HOST,
+  formatServerUrl,
+  isExternallyReachableHost,
+  resolveServerHost,
+} from './server-host';
+
+describe('resolveServerHost', () => {
+  it('defaults to loopback', () => {
+    expect(DEFAULT_SERVER_HOST).toBe('127.0.0.1');
+    expect(resolveServerHost(undefined)).toBe('127.0.0.1');
+    expect(resolveServerHost('')).toBe('127.0.0.1');
+    expect(resolveServerHost('   ')).toBe('127.0.0.1');
+  });
+
+  it('honours an explicit host', () => {
+    expect(resolveServerHost('0.0.0.0')).toBe('0.0.0.0');
+    expect(resolveServerHost(' 192.168.1.10 ')).toBe('192.168.1.10');
+  });
+});
+
+describe('isExternallyReachableHost', () => {
+  it('treats loopback as not reachable', () => {
+    for (const host of ['127.0.0.1', '127.0.0.2', 'localhost', '::1', '[::1]']) {
+      expect(isExternallyReachableHost(host)).toBe(false);
+    }
+  });
+
+  it('treats wildcard and routable addresses as reachable', () => {
+    for (const host of ['0.0.0.0', '::', '192.168.1.10', '10.0.0.5']) {
+      expect(isExternallyReachableHost(host)).toBe(true);
+    }
+  });
+});
+
+describe('formatServerUrl', () => {
+  it('renders wildcard binds as localhost', () => {
+    expect(formatServerUrl('0.0.0.0', 8888)).toBe('http://localhost:8888');
+    expect(formatServerUrl('::', 8888)).toBe('http://localhost:8888');
+  });
+
+  it('renders a concrete host as-is', () => {
+    expect(formatServerUrl('127.0.0.1', 8888)).toBe('http://127.0.0.1:8888');
+    expect(formatServerUrl('192.168.1.10', 3000)).toBe('http://192.168.1.10:3000');
+  });
+
+  it('brackets IPv6 hosts', () => {
+    expect(formatServerUrl('::1', 8888)).toBe('http://[::1]:8888');
+    expect(formatServerUrl('[::1]', 8888)).toBe('http://[::1]:8888');
+  });
+});

--- a/multimodal/tarko/shared-utils/src/server-host.ts
+++ b/multimodal/tarko/shared-utils/src/server-host.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Default network interface an Agent server binds to.
+ *
+ * Loopback by default: the server exposes session creation, workspace files and
+ * agent execution without authentication, so it must not be reachable from the
+ * network unless the operator asks for it via `server.host`.
+ */
+export const DEFAULT_SERVER_HOST = '127.0.0.1';
+
+/** Hosts that bind every interface rather than a single address. */
+const WILDCARD_HOSTS = new Set(['0.0.0.0', '::', '::0']);
+
+export function resolveServerHost(host?: string): string {
+  const trimmed = host?.trim();
+  return trimmed ? trimmed : DEFAULT_SERVER_HOST;
+}
+
+/**
+ * Whether a bind address makes the server reachable from outside the machine.
+ */
+export function isExternallyReachableHost(host: string): boolean {
+  const normalized = host.trim().toLowerCase();
+  if (WILDCARD_HOSTS.has(normalized)) {
+    return true;
+  }
+  return !(
+    normalized === 'localhost' ||
+    normalized === '::1' ||
+    normalized === '[::1]' ||
+    normalized.startsWith('127.')
+  );
+}
+
+/**
+ * Build a URL that a user can actually open for a given bind address.
+ *
+ * Wildcard binds have no meaningful URL, so they render as `localhost`; every
+ * other address is shown as-is so the log reflects the real binding.
+ */
+export function formatServerUrl(host: string, port: number, protocol = 'http'): string {
+  const normalized = host.trim();
+  const hostname = WILDCARD_HOSTS.has(normalized.toLowerCase())
+    ? 'localhost'
+    : normalized.includes(':') && !normalized.startsWith('[')
+      ? `[${normalized}]`
+      : normalized;
+
+  return `${protocol}://${hostname}:${port}`;
+}

--- a/multimodal/tarko/shared-utils/src/session-agent-options.test.ts
+++ b/multimodal/tarko/shared-utils/src/session-agent-options.test.ts
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  ALLOWED_SESSION_AGENT_OPTION_KEYS,
+  filterDeclaredRuntimeSettings,
+  sanitizeSessionAgentOptions,
+} from './session-agent-options';
+
+describe('sanitizeSessionAgentOptions', () => {
+  it('keeps allowlisted keys', () => {
+    const agentMode = { id: 'game', link: 'https://example.com/g', browserMode: 'hybrid' };
+
+    expect(sanitizeSessionAgentOptions({ agentMode })).toEqual({
+      value: { agentMode },
+      rejectedKeys: [],
+    });
+  });
+
+  it('rejects mcpServers, which would let a request start a local process', () => {
+    const result = sanitizeSessionAgentOptions({
+      mcpServers: { evil: { command: 'sh', args: ['-c', 'id'] } },
+    });
+
+    expect(result.value).toBeUndefined();
+    expect(result.rejectedKeys).toEqual(['mcpServers']);
+  });
+
+  it('rejects aioSandbox, which would downgrade or redirect sandboxed execution', () => {
+    const result = sanitizeSessionAgentOptions({ aioSandbox: 'http://attacker.example' });
+
+    expect(result.value).toBeUndefined();
+    expect(result.rejectedKeys).toEqual(['aioSandbox']);
+  });
+
+  it('rejects credential and endpoint overrides', () => {
+    const result = sanitizeSessionAgentOptions({
+      model: { baseURL: 'http://attacker.example', apiKey: 'stolen' },
+      agio: { provider: 'http://attacker.example' },
+      workspace: '/etc',
+    });
+
+    expect(result.value).toBeUndefined();
+    expect(result.rejectedKeys).toEqual(['model', 'agio', 'workspace']);
+  });
+
+  it('reports rejected keys alongside accepted ones', () => {
+    const result = sanitizeSessionAgentOptions({
+      agentMode: { id: 'gui' },
+      mcpServers: {},
+    });
+
+    expect(result.value).toEqual({ agentMode: { id: 'gui' } });
+    expect(result.rejectedKeys).toEqual(['mcpServers']);
+  });
+
+  it('rejects prototype-reaching keys', () => {
+    const payload = JSON.parse('{"__proto__": {"polluted": true}, "constructor": {}}');
+    const result = sanitizeSessionAgentOptions(payload);
+
+    expect(result.value).toBeUndefined();
+    expect(result.rejectedKeys).toContain('__proto__');
+    expect(result.rejectedKeys).toContain('constructor');
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
+  it('rejects an allowlisted key carrying a non-JSON value', () => {
+    const result = sanitizeSessionAgentOptions({ agentMode: () => 'nope' });
+
+    expect(result.value).toBeUndefined();
+    expect(result.rejectedKeys).toEqual(['agentMode']);
+  });
+
+  it('rejects an allowlisted key nesting a prototype-reaching key', () => {
+    const payload = JSON.parse('{"agentMode": {"__proto__": {"polluted": true}}}');
+
+    expect(sanitizeSessionAgentOptions(payload).rejectedKeys).toEqual(['agentMode']);
+  });
+
+  it('passes through absent input untouched', () => {
+    expect(sanitizeSessionAgentOptions(undefined)).toEqual({ value: undefined, rejectedKeys: [] });
+    expect(sanitizeSessionAgentOptions(null)).toEqual({ value: undefined, rejectedKeys: [] });
+  });
+
+  it('rejects non-object input', () => {
+    expect(sanitizeSessionAgentOptions('agentMode').value).toBeUndefined();
+    expect(sanitizeSessionAgentOptions([{ agentMode: {} }]).value).toBeUndefined();
+  });
+
+  it('does not allowlist anything that can start a process or carry a credential', () => {
+    expect(ALLOWED_SESSION_AGENT_OPTION_KEYS).toEqual(['agentMode']);
+  });
+});
+
+describe('filterDeclaredRuntimeSettings', () => {
+  const schema = {
+    properties: {
+      agentMode: { type: 'string' as const },
+      browserMode: { type: 'string' as const },
+      maxSteps: { type: 'number' as const },
+      thinking: { type: 'boolean' as const },
+    },
+  };
+
+  it('keeps declared keys with matching types', () => {
+    const input = { agentMode: 'gui', maxSteps: 5, thinking: true };
+
+    expect(filterDeclaredRuntimeSettings(input, schema)).toEqual({
+      value: input,
+      rejectedKeys: [],
+    });
+  });
+
+  it('drops undeclared keys, so runtime settings cannot inject agent options', () => {
+    const result = filterDeclaredRuntimeSettings(
+      {
+        agentMode: 'gui',
+        mcpServers: { evil: { command: 'sh' } },
+        aioSandbox: 'http://attacker.example',
+      },
+      schema,
+    );
+
+    expect(result.value).toEqual({ agentMode: 'gui' });
+    expect(result.rejectedKeys).toEqual(['mcpServers', 'aioSandbox']);
+  });
+
+  it('drops declared keys whose value does not match the declared type', () => {
+    const result = filterDeclaredRuntimeSettings(
+      { maxSteps: { toString: 'nope' }, thinking: 'yes' },
+      schema,
+    );
+
+    expect(result.value).toEqual({});
+    expect(result.rejectedKeys).toEqual(['maxSteps', 'thinking']);
+  });
+
+  it('drops everything when no schema is configured', () => {
+    const result = filterDeclaredRuntimeSettings({ mcpServers: {}, agentMode: 'gui' });
+
+    expect(result.value).toEqual({});
+    expect(result.rejectedKeys).toEqual(['mcpServers', 'agentMode']);
+  });
+
+  it('returns an empty object for non-object input', () => {
+    expect(filterDeclaredRuntimeSettings(undefined, schema).value).toEqual({});
+    expect(filterDeclaredRuntimeSettings('nope', schema).value).toEqual({});
+  });
+
+  it('never returns a prototype-reaching key even if the schema declares one', () => {
+    const payload = JSON.parse('{"__proto__": "polluted"}');
+    const pollutedSchema = { properties: { __proto__: { type: 'string' as const } } };
+
+    expect(filterDeclaredRuntimeSettings(payload, pollutedSchema).value).toEqual({});
+  });
+});

--- a/multimodal/tarko/shared-utils/src/session-agent-options.ts
+++ b/multimodal/tarko/shared-utils/src/session-agent-options.ts
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Agent option keys a client may supply when creating a session.
+ *
+ * Session creation payloads are merged into the Agent constructor options, so an
+ * unrestricted object turns the create-session endpoint into arbitrary Agent
+ * reconfiguration: `mcpServers` entries carrying a `command` spawn local child
+ * processes, `aioSandbox` decides whether work runs in a sandbox or on the host,
+ * and `model` / `agio` redirect credentials and telemetry to a chosen endpoint.
+ *
+ * Only keys that a session legitimately needs to vary belong here, and only
+ * those that cannot start a process, change an outbound endpoint, or carry a
+ * credential. `agentMode` is the single such key in use today: it selects a
+ * preset interaction mode and is consumed by the GUI agent plugin.
+ */
+export const ALLOWED_SESSION_AGENT_OPTION_KEYS = ['agentMode'] as const;
+
+export type AllowedSessionAgentOptionKey = (typeof ALLOWED_SESSION_AGENT_OPTION_KEYS)[number];
+
+/** Keys that would let a payload reach an object prototype. */
+const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+/** Guards against pathological nesting in an attacker-supplied payload. */
+const MAX_VALUE_DEPTH = 6;
+
+export interface SanitizeResult<T> {
+  /** The values that survived sanitization. */
+  value: T;
+  /** Keys that were dropped, for error responses and audit logs. */
+  rejectedKeys: string[];
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+/**
+ * Whether a value is safe to hand to an Agent constructor: plain JSON data only,
+ * no prototype-reaching keys, no functions, bounded depth.
+ */
+function isJsonSafeValue(value: unknown, depth = 0): boolean {
+  if (depth > MAX_VALUE_DEPTH) {
+    return false;
+  }
+
+  if (value === null) {
+    return true;
+  }
+
+  switch (typeof value) {
+    case 'string':
+    case 'boolean':
+      return true;
+    case 'number':
+      return Number.isFinite(value);
+    case 'object':
+      break;
+    default:
+      return false;
+  }
+
+  if (Array.isArray(value)) {
+    return value.every((item) => isJsonSafeValue(item, depth + 1));
+  }
+
+  if (!isPlainObject(value)) {
+    return false;
+  }
+
+  return Object.keys(value).every(
+    (key) => !FORBIDDEN_KEYS.has(key) && isJsonSafeValue(value[key], depth + 1),
+  );
+}
+
+/**
+ * Reduce a client-supplied `agentOptions` payload to the allowlist.
+ *
+ * Anything outside {@link ALLOWED_SESSION_AGENT_OPTION_KEYS}, and any allowlisted
+ * key whose value is not plain JSON data, is reported in `rejectedKeys` and left
+ * out of `value`.
+ */
+export function sanitizeSessionAgentOptions(
+  input: unknown,
+): SanitizeResult<Record<string, unknown> | undefined> {
+  if (input === undefined || input === null) {
+    return { value: undefined, rejectedKeys: [] };
+  }
+
+  if (!isPlainObject(input)) {
+    return { value: undefined, rejectedKeys: ['<agentOptions must be an object>'] };
+  }
+
+  const allowed = new Set<string>(ALLOWED_SESSION_AGENT_OPTION_KEYS);
+  const sanitized: Record<string, unknown> = {};
+  const rejectedKeys: string[] = [];
+
+  for (const key of Object.keys(input)) {
+    if (!allowed.has(key) || FORBIDDEN_KEYS.has(key) || !isJsonSafeValue(input[key])) {
+      rejectedKeys.push(key);
+      continue;
+    }
+    sanitized[key] = input[key];
+  }
+
+  return {
+    value: Object.keys(sanitized).length > 0 ? sanitized : undefined,
+    rejectedKeys,
+  };
+}
+
+/**
+ * Minimal shape of the server-declared runtime settings schema this module needs.
+ */
+export interface RuntimeSettingsSchemaLike {
+  properties?: Record<string, { type?: 'boolean' | 'string' | 'number' } | undefined>;
+}
+
+/**
+ * Reduce a client-supplied `runtimeSettings` payload to the keys the server declared.
+ *
+ * Runtime settings are merged into the Agent constructor options too, so an
+ * undeclared key is the same injection channel as `agentOptions`. The server's
+ * schema is the contract the UI renders from, so a key that is not declared in it
+ * is not a setting. Declared keys must also match their declared primitive type.
+ *
+ * With no schema configured nothing is passed through.
+ */
+export function filterDeclaredRuntimeSettings(
+  input: unknown,
+  schema?: RuntimeSettingsSchemaLike,
+): SanitizeResult<Record<string, unknown>> {
+  if (!isPlainObject(input)) {
+    return { value: {}, rejectedKeys: [] };
+  }
+
+  const properties = schema?.properties;
+  const filtered: Record<string, unknown> = {};
+  const rejectedKeys: string[] = [];
+
+  for (const key of Object.keys(input)) {
+    const declared = FORBIDDEN_KEYS.has(key) ? undefined : properties?.[key];
+    if (!declared) {
+      rejectedKeys.push(key);
+      continue;
+    }
+
+    const value = input[key];
+    const matchesDeclaredType =
+      declared.type === undefined
+        ? typeof value === 'boolean' || typeof value === 'string' || typeof value === 'number'
+        : declared.type === 'number'
+          ? typeof value === 'number' && Number.isFinite(value)
+          : typeof value === declared.type;
+
+    if (!matchesDeclaredType) {
+      rejectedKeys.push(key);
+      continue;
+    }
+
+    filtered[key] = value;
+  }
+
+  return { value: filtered, rejectedKeys };
+}

--- a/multimodal/tarko/shared-utils/src/session-agent-options.ts
+++ b/multimodal/tarko/shared-utils/src/session-agent-options.ts
@@ -142,7 +142,7 @@ export function filterDeclaredRuntimeSettings(
   }
 
   const properties = schema?.properties;
-  const filtered: Record<string, unknown> = {};
+  const filtered: Record<string, unknown> = Object.create(null);
   const rejectedKeys: string[] = [];
 
   for (const key of Object.keys(input)) {


### PR DESCRIPTION
## Problem

`POST /api/v1/sessions/create` accepts an unfiltered `agentOptions` object that
is spread **last** into the Agent constructor parameters, overriding every
server-side default. An attacker supplying `mcpServers` entries with a `command`
field triggers `StdioClientTransport`, which spawns an arbitrary local process.
The same primitive allows sandbox downgrade (`aioSandbox`) and credential/model
endpoint redirection.

Three injection channels existed:
1. `agentOptions` in the session-creation request body (both packages)
2. `runtimeSettings` when no server-side `transform` is configured (spread into
   constructor options verbatim)
3. `sessionInfo.metadata.agentOptions` in agent-server-next (persisted via
   `POST /sessions/update`, reapplied on every session init)

Amplifiers: the server binds all interfaces by default, has no authentication,
the CSRF token endpoint is unauthenticated and origin-unchecked, and CORS
explicitly allows requests with no `Origin` header.

## Fix

**Input boundary (primary):**
- `sanitizeSessionAgentOptions`: strict allowlist — only `agentMode` passes
  through. Prototype-pollution keys (`__proto__`, `constructor`, `prototype`)
  rejected. Values must be plain JSON data with bounded depth.
- `filterDeclaredRuntimeSettings`: passes only keys declared in the server's
  runtime-settings JSON schema, and only when the value matches the declared
  primitive type (`boolean`/`string`/`number`). No schema configured = nothing
  passes. Object-typed values (like `mcpServers`) are structurally impossible.
- Both filters applied at session creation (both packages) and at the
  runtime-settings update endpoint.

**Default bind address (defense in depth):**
- Server now listens on `127.0.0.1` by default, matching the convention
  established by `mcp-http-server` in #1918.
- Explicit opt-in: `server.host` config key or `--host` CLI flag.
- Startup log reflects the actual bind address.

## Breaking change

The server previously listened on all interfaces (`0.0.0.0`). Deployments
relying on network access must now set `server.host` to `0.0.0.0` (or the
desired address) in their config, or pass `--host 0.0.0.0` to the CLI.

## Verification

- New unit tests cover allowlist enforcement, prototype-pollution rejection,
  schema-based filtering, and host resolution defaults.
- Additional route-level integration tests confirm the create-session endpoint
  rejects dangerous keys and returns them in the error response.

## Not in this change

- Authentication, path-traversal in workspace static server, missing CSP,
  agent-server-next security hooks never being registered — tracked separately.
- iframe sandbox escape in agent-ui — addressed in #1938.