### PR TITLE
fix(tarko): report package version in standalone CLI

### DIFF
--- a/multimodal/tarko/agent-cli/bin/cli.js
+++ b/multimodal/tarko/agent-cli/bin/cli.js
@@ -6,4 +6,4 @@
 
 const { version } = require('../package.json');
 const { AgentCLI } = require('../dist');
-new AgentCLI({ version, binName: 'tarko' }).bootstrap();
+new AgentCLI({ versionInfo: { version }, binName: 'tarko' }).bootstrap();

--- a/multimodal/tarko/agent-cli/tests/cli-version.test.ts
+++ b/multimodal/tarko/agent-cli/tests/cli-version.test.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { execFileSync } from 'child_process';
+import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+describe('standalone CLI version', () => {
+  let fixtureDir: string | undefined;
+
+  afterEach(() => {
+    if (fixtureDir) {
+      rmSync(fixtureDir, { recursive: true, force: true });
+      fixtureDir = undefined;
+    }
+  });
+
+  it('passes the package version to AgentCLI', () => {
+    fixtureDir = mkdtempSync(path.join(tmpdir(), 'tarko-cli-version-'));
+    const binDir = path.join(fixtureDir, 'bin');
+    const distDir = path.join(fixtureDir, 'dist');
+    mkdirSync(binDir);
+    mkdirSync(distDir);
+
+    const packageJson = JSON.parse(
+      readFileSync(path.resolve(__dirname, '../package.json'), 'utf8'),
+    );
+    writeFileSync(
+      path.join(fixtureDir, 'package.json'),
+      JSON.stringify({ version: packageJson.version }),
+    );
+    copyFileSync(path.resolve(__dirname, '../bin/cli.js'), path.join(binDir, 'cli.js'));
+    writeFileSync(
+      path.join(distDir, 'index.js'),
+      `exports.AgentCLI = class AgentCLI {
+  constructor(options) {
+    this.options = options;
+  }
+
+  bootstrap() {
+    process.stdout.write(\`tarko/\${this.options.versionInfo?.version}\`);
+  }
+};
+`,
+    );
+
+    const output = execFileSync(process.execPath, [path.join(binDir, 'cli.js'), '--version'], {
+      encoding: 'utf8',
+    });
+
+    expect(output).toBe(`tarko/${packageJson.version}`);
+  });
+});


### PR DESCRIPTION
## Summary

Close: #1946

- pass the standalone package version through the existing `versionInfo.version` option consumed by `AgentCLI`
- add a subprocess regression test for the published bin-to-CLI boundary
- keep the version sourced from `package.json`, so future releases do not require another hard-coded update

## Validation

- `pnpm --filter @tarko/agent-cli exec vitest run tests/cli-version.test.ts` (1 passed)
- `pnpm --filter @tarko/agent-cli exec tsc --noEmit -p tsconfig.json`
- `pnpm --filter @tarko/agent-cli... --filter '!@tarko/agio' build`
- `node multimodal/tarko/agent-cli/bin/cli.js --version` -> `tarko/0.3.0 win32-x64 node-v24.14.1`

The full dependency build reaches an unrelated existing Windows quoting failure in `@tarko/agio`'s `build:json-schema` script; its rslib declarations build successfully, and excluding that schema-only step allows the target package build to complete.

## Checklist

- [x] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [x] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [ ] My change does not involve the above items.