### PR TITLE
fix(browser-search): respect result count limit

### DIFF
--- a/packages/agent-infra/search/browser-search/src/browser-search.test.ts
+++ b/packages/agent-infra/search/browser-search/src/browser-search.test.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import type { BrowserInterface } from '@agent-infra/browser';
+import type { Logger } from '@agent-infra/logger';
+import { describe, expect, it, vi } from 'vitest';
+import { BrowserSearch } from './browser-search';
+import type { SearchResult } from './types';
+
+const createSearchResults = (query: string): SearchResult[] =>
+  Array.from({ length: 3 }, (_, index) => ({
+    title: `${query}-${index}`,
+    url: `https://example.com/${query}/${index}`,
+    snippet: 'snippet',
+    content: '',
+  }));
+
+const createBrowser = (): BrowserInterface =>
+  ({
+    launch: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
+    evaluateOnNewPage: vi.fn().mockImplementation(async ({ url }) => {
+      const query = new URL(url).searchParams.get('q') || 'query';
+      return createSearchResults(query);
+    }),
+  }) as unknown as BrowserInterface;
+
+const logger = {
+  info: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+} as unknown as Logger;
+
+describe('BrowserSearch', () => {
+  it('limits results to count for a single query', async () => {
+    const search = new BrowserSearch({ browser: createBrowser(), logger });
+
+    const results = await search.perform({
+      query: 'first',
+      count: 1,
+      needVisitedUrls: false,
+    });
+
+    expect(results).toHaveLength(1);
+  });
+
+  it('limits combined results to count for multiple queries', async () => {
+    const search = new BrowserSearch({ browser: createBrowser(), logger });
+
+    const results = await search.perform({
+      query: ['first', 'second'],
+      count: 4,
+      needVisitedUrls: false,
+    });
+
+    expect(results).toHaveLength(4);
+  });
+});

--- a/packages/agent-infra/search/browser-search/src/browser-search.ts
+++ b/packages/agent-infra/search/browser-search/src/browser-search.ts
@@ -90,9 +90,13 @@ export class BrowserSearch {
       );
 
       this.logger.success('Search completed successfully');
-      const flattenedResults = results.flat().filter((v) => v !== null);
+      const flattenedResults = results
+        .flat()
+        .filter((v) => v !== null) as SearchResult[];
       this.logger.info('Search results', flattenedResults);
-      return flattenedResults as SearchResult[];
+      return options.count === undefined
+        ? flattenedResults
+        : flattenedResults.slice(0, options.count);
     } catch (error) {
       this.logger.error('Search failed:', error);
       throw error;


### PR DESCRIPTION
## Summary

`BrowserSearchOptions.count` is documented as the maximum result length, but `perform()` previously returned every extracted result. This change caps the final flattened array while preserving the existing per-query engine request behavior.

The regression coverage verifies both a single query with `count: 1` and a multi-query search where the combined results exceed the global count.

Closes #1947

### Verification

- Package-local Vitest 3.0.7 run for `src/browser-search.test.ts` with an equivalent focused config: 2 tests passed.
- `tsc --noEmit -p packages/agent-infra/search/browser-search/tsconfig.json`
- Target package `rslib build` (ESM, CJS, and declarations)
- Prettier check for both changed files
- `git diff --check` and secretlint for both changed files

On Windows, the initial workspace `pnpm install --frozen-lockfile` verified the unchanged lockfile and installed dependencies, then stopped in a pre-existing `mcp-http-server` prepare step because `shx` was unavailable. I completed linking with `--ignore-scripts`, built the existing dependency chain directly, and ran the focused checks above.

## Checklist

- [x] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [x] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [ ] My change does not involve the above items.