### PR TITLE
fix(operator-adb): await async ADB actions so execute() reflects device state

### DIFF
--- a/multimodal/gui-agent/operator-adb/src/AdbOperator.ts
+++ b/multimodal/gui-agent/operator-adb/src/AdbOperator.ts
@@ -110,7 +110,7 @@ export class AdbOperator extends Operator {
           throw new Error('point is required when click');
         }
         const { realX, realY } = await this.calculateRealCoords(point);
-        this.handleSwipe({ x: realX, y: realY }, { x: realX, y: realY }, 1500);
+        await this.handleSwipe({ x: realX, y: realY }, { x: realX, y: realY }, 1500);
         break;
       }
       case 'swipe':
@@ -124,7 +124,7 @@ export class AdbOperator extends Operator {
         }
         const { realX: startX, realY: startY } = await this.calculateRealCoords(startPoint);
         const { realX: endX, realY: endY } = await this.calculateRealCoords(endPoint);
-        this.handleSwipe({ x: startX, y: startY }, { x: endX, y: endY }, 300);
+        await this.handleSwipe({ x: startX, y: startY }, { x: endX, y: endY }, 300);
         break;
       }
       case 'scroll': {
@@ -132,12 +132,12 @@ export class AdbOperator extends Operator {
         if (!direction) {
           throw new Error(`Direction required when scroll`);
         }
-        this.handleScroll(direction, point);
+        await this.handleScroll(direction, point);
         break;
       }
       case 'type': {
         const { content } = actionInputs;
-        this.handleType(content);
+        await this.handleType(content);
         break;
       }
       case 'hotkey': {
@@ -332,7 +332,7 @@ export class AdbOperator extends Operator {
     if (!keyCode) {
       throw new Error(`Unsupported key: ${keyStr}`);
     }
-    this._adb!.keyevent(keyCode);
+    await this._adb!.keyevent(keyCode);
   }
 
   private async handleSwipe(
@@ -370,7 +370,7 @@ export class AdbOperator extends Operator {
       default:
         throw new Error(`Unsupported scroll direction: ${direction}`);
     }
-    this.handleSwipe({ x: startX, y: startY }, { x: endX, y: endY }, 300);
+    await this.handleSwipe({ x: startX, y: startY }, { x: endX, y: endY }, 300);
   }
 
   /**

--- a/multimodal/gui-agent/operator-adb/test/AdbOperator.async.test.ts
+++ b/multimodal/gui-agent/operator-adb/test/AdbOperator.async.test.ts
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const shell = vi.fn<(cmd: string) => Promise<void>>();
+const inputText = vi.fn<(text: string) => Promise<void>>();
+const keyevent = vi.fn<(code: number) => Promise<void>>();
+
+vi.mock('node:child_process', () => ({
+  exec: (_cmd: string, cb: (e: unknown, r: { stdout: string }) => void) =>
+    cb(null, { stdout: 'List of devices attached\nemulator-5554\tdevice\n' }),
+}));
+
+vi.mock('appium-adb', () => ({
+  ADB: {
+    createADB: async () => ({
+      shell,
+      inputText,
+      keyevent,
+      getScreenSize: async () => '1080x1920',
+      getScreenDensity: async () => 320,
+    }),
+  },
+}));
+
+const { AdbOperator } = await import('../src/AdbOperator');
+
+/** A promise the test resolves/rejects by hand, to observe whether execute() waits for it. */
+function deferred<T = void>() {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+/** Resolves on the next macrotask, so a non-awaited branch has every chance to settle first. */
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+/** 'settled' only if doExecute() finished before the pending ADB command did. */
+async function raceExecution(execution: Promise<unknown>) {
+  return Promise.race([
+    execution.then(() => 'settled' as const),
+    tick().then(() => 'pending' as const),
+  ]);
+}
+
+const point = { raw: { x: 100, y: 200 } };
+
+describe('AdbOperator awaits its ADB commands', () => {
+  beforeEach(() => {
+    shell.mockReset();
+    inputText.mockReset();
+    keyevent.mockReset();
+  });
+
+  it.each([
+    ['long_press', { type: 'long_press', inputs: { point } }],
+    ['swipe', { type: 'swipe', inputs: { start: point, end: { raw: { x: 300, y: 400 } } } }],
+    ['drag', { type: 'drag', inputs: { start: point, end: { raw: { x: 300, y: 400 } } } }],
+    ['scroll', { type: 'scroll', inputs: { direction: 'down', point } }],
+  ])('%s stays pending until the ADB shell command settles', async (_name, action) => {
+    const pending = deferred();
+    shell.mockReturnValue(pending.promise);
+
+    const execution = new AdbOperator().doExecute({ actions: [action] } as never);
+
+    await expect(raceExecution(execution)).resolves.toBe('pending');
+
+    pending.resolve();
+    await expect(execution).resolves.toMatchObject({ status: 'success' });
+  });
+
+  it('type stays pending until inputText settles', async () => {
+    const pending = deferred();
+    inputText.mockReturnValue(pending.promise);
+
+    const execution = new AdbOperator().doExecute({
+      actions: [{ type: 'type', inputs: { content: 'hello' } }],
+    } as never);
+
+    await expect(raceExecution(execution)).resolves.toBe('pending');
+
+    pending.resolve();
+    await expect(execution).resolves.toMatchObject({ status: 'success' });
+  });
+
+  it('hotkey stays pending until keyevent settles', async () => {
+    const pending = deferred();
+    keyevent.mockReturnValue(pending.promise);
+
+    const execution = new AdbOperator().doExecute({
+      actions: [{ type: 'hotkey', inputs: { key: 'home' } }],
+    } as never);
+
+    await expect(raceExecution(execution)).resolves.toBe('pending');
+
+    pending.resolve();
+    await expect(execution).resolves.toMatchObject({ status: 'success' });
+  });
+});
+
+describe('AdbOperator surfaces ADB failures instead of detaching them', () => {
+  beforeEach(() => {
+    shell.mockReset();
+    inputText.mockReset();
+    keyevent.mockReset();
+  });
+
+  it('reports a rejected swipe as failed rather than success', async () => {
+    shell.mockRejectedValue(new Error('adb failed'));
+
+    await expect(
+      new AdbOperator().doExecute({
+        actions: [{ type: 'swipe', inputs: { start: point, end: { raw: { x: 300, y: 400 } } } }],
+      } as never),
+    ).resolves.toMatchObject({ status: 'failed', errorMessage: 'adb failed' });
+  });
+
+  it('reports a rejected keyevent as failed rather than success', async () => {
+    keyevent.mockRejectedValue(new Error('keyevent failed'));
+
+    await expect(
+      new AdbOperator().doExecute({
+        actions: [{ type: 'hotkey', inputs: { key: 'home' } }],
+      } as never),
+    ).resolves.toMatchObject({ status: 'failed', errorMessage: 'keyevent failed' });
+  });
+
+  it('does not start the next action before the previous one finishes', async () => {
+    const order: string[] = [];
+    shell.mockImplementation(async (cmd: string) => {
+      const label = cmd.startsWith('input swipe') ? 'swipe' : cmd;
+      order.push(`start:${label}`);
+      await tick();
+      order.push(`end:${label}`);
+    });
+    inputText.mockImplementation(async () => {
+      order.push('start:type');
+      await tick();
+      order.push('end:type');
+    });
+
+    await new AdbOperator().doExecute({
+      actions: [
+        { type: 'swipe', inputs: { start: point, end: { raw: { x: 300, y: 400 } } } },
+        { type: 'type', inputs: { content: 'hello' } },
+      ],
+    } as never);
+
+    expect(order).toEqual(['start:swipe', 'end:swipe', 'start:type', 'end:type']);
+  });
+});


### PR DESCRIPTION
### What

Await the six ADB calls in `AdbOperator` that were started without `await`: `long_press`, `swipe`/`drag`, `scroll`, `type`, the `keyevent` inside `handleHotkey()`, and the `handleSwipe()` at the end of `handleScroll()`.

### Why

Closes #1952. `execute()` awaits `singleActionExecutor(action)`, but those branches return before their device promise settles, so:

- multi-action plans overlap and can run out of order — a screenshot may be taken before the preceding gesture finishes;
- a failing ADB command surfaces as a detached rejection while `execute()` still reports `{ status: 'success' }`.

`click` and `hotkey` in the same switch already await, so this was an oversight rather than intent.

### How verified

Adds `test/AdbOperator.async.test.ts` — the first test file in this package. Nine cases using a delayed/rejecting ADB mock cover per-branch awaiting, failure propagation through `doExecute()`, and action ordering.

All nine fail on current `main`:

```
× long_press stays pending until the ADB shell command settles
  → expected 'settled' to be 'pending'
× reports a rejected swipe as failed rather than success
  → expected { status: 'success' } to match object { status: 'failed' }
× does not start the next action before the previous one finishes
  → expected [ 'start:swipe', 'start:type' ] to deeply equal
             [ 'start:swipe', 'end:swipe', 'start:type', 'end:type' ]
```

and pass with this change (`9 passed`). `prettier --check` is clean on both files.

No Android device was used: the tests mock `appium-adb` and `node:child_process`, so they exercise the real `initialize()` → `doExecute()` path without hardware. A device-level smoke test for swipe/type/key events would still be worth running before release.

### Note for reviewers

#1883 touches the same file (shell-injection hardening). It changes command construction rather than awaiting, so the two should not conflict at line level — happy to rebase whichever lands second.