### PR TITLE
fix(agent-server): release exclusive slot on stream startup failure

### DIFF
--- a/multimodal/tarko/agent-server-next/src/services/session/AgentSession.ts
+++ b/multimodal/tarko/agent-server-next/src/services/session/AgentSession.ts
@@ -444,6 +444,9 @@ export class AgentSession {
       // Wrap the stream to clear running session when done
       return this.wrapStreamForExclusiveMode(stream);
     } catch (error) {
+      // No stream was created, so release the exclusive slot before returning an error stream
+      this.server.clearRunningSession(this.id);
+
       // Emit error event
       this.eventBridge.emit('error', {
         message: error instanceof Error ? error.message : String(error),

--- a/multimodal/tarko/agent-server/src/core/AgentSession.ts
+++ b/multimodal/tarko/agent-server/src/core/AgentSession.ts
@@ -424,6 +424,9 @@ export class AgentSession {
       // Wrap the stream to clear running session when done
       return this.wrapStreamForExclusiveMode(stream);
     } catch (error) {
+      // No stream was created, so release the exclusive slot before returning an error stream
+      this.server.clearRunningSession(this.id);
+
       // Emit error event
       this.eventBridge.emit('error', {
         message: error instanceof Error ? error.message : String(error),

--- a/multimodal/tarko/agent-server/tests/core/agent-session-exclusive-mode.test.ts
+++ b/multimodal/tarko/agent-server/tests/core/agent-session-exclusive-mode.test.ts
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { AgentEventStream } from '@tarko/interface';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AgentSession as LegacyAgentSession } from '../../src/core/AgentSession';
+import { AgentSession as NextAgentSession } from '../../../agent-server-next/src/services/session/AgentSession';
+
+vi.mock('../../../agent-server-next/src/utils/logger', () => ({
+  getLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+type SystemEventData = Omit<AgentEventStream.SystemEvent, 'id' | 'type' | 'timestamp'>;
+
+type TestSession = {
+  agent: {
+    run: (...args: unknown[]) => Promise<unknown>;
+    getEventStream: () => {
+      createEvent: (type: 'system', data: SystemEventData) => AgentEventStream.SystemEvent;
+    };
+  };
+  runQueryStreaming(options: { input: string }): Promise<AsyncIterable<AgentEventStream.Event>>;
+};
+
+type SessionConstructor = new (
+  server: ReturnType<typeof createExclusiveServerStub>,
+  sessionId: string,
+) => TestSession;
+
+const implementations: Array<[string, SessionConstructor]> = [
+  ['agent-server', LegacyAgentSession as unknown as SessionConstructor],
+  ['agent-server-next', NextAgentSession as unknown as SessionConstructor],
+];
+
+function createExclusiveServerStub() {
+  let runningSessionId: string | null = null;
+
+  return {
+    isDebug: false,
+    setRunningSession: vi.fn((sessionId: string) => {
+      runningSessionId = sessionId;
+    }),
+    clearRunningSession: vi.fn((sessionId: string) => {
+      if (runningSessionId === sessionId) {
+        runningSessionId = null;
+      }
+    }),
+    canAcceptNewRequest: vi.fn(() => runningSessionId === null),
+    getRunningSessionId: vi.fn(() => runningSessionId),
+  };
+}
+
+function createEventStream() {
+  return {
+    createEvent: vi.fn(
+      (type: 'system', data: SystemEventData): AgentEventStream.SystemEvent => ({
+        id: 'event-id',
+        type,
+        timestamp: Date.now(),
+        ...data,
+      }),
+    ),
+  };
+}
+
+async function collectEvents(stream: AsyncIterable<AgentEventStream.Event>) {
+  const events: AgentEventStream.Event[] = [];
+  for await (const event of stream) {
+    events.push(event);
+  }
+  return events;
+}
+
+describe.each(implementations)('%s exclusive streaming lifecycle', (_, Session) => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('releases the slot immediately when the stream fails to start', async () => {
+    const server = createExclusiveServerStub();
+    const sessionId = 'failed-session';
+    const session = new Session(server, sessionId);
+    const eventStream = createEventStream();
+    session.agent = {
+      run: vi.fn().mockRejectedValue(new Error('startup failed')),
+      getEventStream: () => eventStream,
+    };
+
+    const errorStream = await session.runQueryStreaming({ input: 'test' });
+
+    expect(server.getRunningSessionId()).toBeNull();
+    expect(server.canAcceptNewRequest()).toBe(true);
+    expect(server.clearRunningSession).toHaveBeenCalledOnce();
+    expect(server.clearRunningSession).toHaveBeenCalledWith(sessionId);
+
+    server.setRunningSession(sessionId);
+    const events = await collectEvents(errorStream);
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: 'system',
+      level: 'error',
+      message: 'startup failed',
+      details: { errorCode: 'AGENT_EXECUTION_ERROR' },
+    });
+    expect(server.getRunningSessionId()).toBe(sessionId);
+    expect(server.clearRunningSession).toHaveBeenCalledOnce();
+  });
+
+  it('keeps the slot until a successfully started stream finishes', async () => {
+    const server = createExclusiveServerStub();
+    const sessionId = 'active-session';
+    const session = new Session(server, sessionId);
+    const eventStream = createEventStream();
+    const sourceEvent = eventStream.createEvent('system', {
+      level: 'info',
+      message: 'running',
+    });
+    session.agent = {
+      run: vi.fn().mockResolvedValue(
+        (async function* () {
+          yield sourceEvent;
+        })(),
+      ),
+      getEventStream: () => eventStream,
+    };
+
+    const stream = await session.runQueryStreaming({ input: 'test' });
+
+    expect(server.getRunningSessionId()).toBe(sessionId);
+    expect(server.canAcceptNewRequest()).toBe(false);
+    expect(server.clearRunningSession).not.toHaveBeenCalled();
+
+    await expect(collectEvents(stream)).resolves.toEqual([sourceEvent]);
+    expect(server.getRunningSessionId()).toBeNull();
+    expect(server.canAcceptNewRequest()).toBe(true);
+    expect(server.clearRunningSession).toHaveBeenCalledOnce();
+    expect(server.clearRunningSession).toHaveBeenCalledWith(sessionId);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1951

In exclusive mode, both Agent Server implementations mark a session as running before awaiting `agent.run()`. If that promise rejects before returning an `AsyncIterable`, the catch path returns a synthetic error stream while leaving the exclusive slot occupied indefinitely.

This change releases the slot immediately in that startup-failure path for both `@tarko/agent-server` and `@tarko/agent-server-next`. A successfully created stream still owns the slot until iteration finishes, preserving the existing lifecycle for active streams.

The regression tests exercise both server generations and verify that:

- a startup rejection releases the slot even when the synthetic error stream is never consumed;
- consuming that old error stream later cannot clear a newer run for the same session;
- a successfully started stream continues to hold the slot until it finishes.

### Verification

- `pnpm exec vitest run tests/core/agent-session-exclusive-mode.test.ts`: 4 tests pass.
- `pnpm exec vitest run --exclude tests/SQLiteStorageProvider.test.ts`: 6 suites, 45 tests pass.
- `pnpm --filter @tarko/agent-server build`: passes.
- `pnpm --filter @tarko/agent-server-next build`: passes.
- `pnpm exec prettier --check tarko/agent-server/tests/core/agent-session-exclusive-mode.test.ts`: passes.
- Full `@tarko/agent-server` suite: 45 tests pass; the same 19 pre-existing SQLite tests fail before and after this change on Windows because the test setup constructs paths such as `D:\tmp\C:\Users\...`.

## Checklist

- [x] Added or updated necessary tests (Optional).
- [ ] Updated documentation to align with changes (Optional).
- [x] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [ ] My change does not involve the above items.
