### PR TITLE
fix(mcp-filesystem): add default search exclusions

### DIFF
--- a/packages/agent-infra/mcp-servers/filesystem/src/schema.ts
+++ b/packages/agent-infra/mcp-servers/filesystem/src/schema.ts
@@ -56,7 +56,11 @@ export const MoveFileArgsSchema = z.object({
 export const SearchFilesArgsSchema = z.object({
   path: z.string(),
   pattern: z.string(),
-  excludePatterns: z.array(z.string()).optional().default([]),
+  excludePatterns: z
+    .array(z.string())
+    .optional()
+    .default([])
+    .describe('Additional glob patterns to exclude from the search'),
 });
 
 export const GetFileInfoArgsSchema = z.object({

--- a/packages/agent-infra/mcp-servers/filesystem/src/server.ts
+++ b/packages/agent-infra/mcp-servers/filesystem/src/server.ts
@@ -10,7 +10,7 @@ import fs from 'node:fs/promises';
 import fsSync from 'node:fs';
 import path from 'node:path';
 
-import { minimatch } from 'minimatch';
+import { Minimatch } from 'minimatch';
 import {
   CreateDirectoryArgsSchema,
   DirectoryTreeArgsSchema,
@@ -32,6 +32,25 @@ import {
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 let allowedDirectories: string[] = [];
+
+// Keep aligned with the safe directory_tree defaults in Agent TARS.
+const DEFAULT_EXCLUDE_PATTERNS = [
+  'node_modules',
+  '.git',
+  'dist',
+  'build',
+  '.next',
+  '.nuxt',
+  'coverage',
+  '.nyc_output',
+  'logs',
+  '.cache',
+  'tmp',
+  'temp',
+  '*.log',
+  '.DS_Store',
+  'Thumbs.db',
+];
 
 /**
  * dynamic set allowed directories
@@ -118,12 +137,47 @@ async function validatePath(requestedPath: string): Promise<string> {
   }
 }
 
+function createExcludeMatcher(
+  pattern: string,
+): (relativePath: string, isDirectory: boolean) => boolean {
+  const normalizedPattern = pattern
+    .split(path.sep)
+    .join('/')
+    .replace(/^\.\/+/, '')
+    .replace(/\/+$/, '');
+
+  if (!normalizedPattern) {
+    return () => false;
+  }
+
+  const matcher = new Minimatch(normalizedPattern, {
+    dot: true,
+    magicalBraces: true,
+    matchBase: true,
+    nocomment: true,
+    nonegate: true,
+  });
+  const hasMagic = matcher.hasMagic();
+
+  return (relativePath: string, isDirectory: boolean) =>
+    matcher.match(relativePath) ||
+    (isDirectory && matcher.match(`${relativePath}/`)) ||
+    (!hasMagic &&
+      (relativePath === normalizedPattern ||
+        relativePath.startsWith(`${normalizedPattern}/`) ||
+        relativePath.endsWith(`/${normalizedPattern}`) ||
+        relativePath.includes(`/${normalizedPattern}/`)));
+}
+
 async function searchFiles(
   rootPath: string,
   pattern: string,
   excludePatterns: string[] = [],
 ): Promise<string[]> {
   const results: string[] = [];
+  const excludeMatchers = [...DEFAULT_EXCLUDE_PATTERNS, ...excludePatterns].map(
+    createExcludeMatcher,
+  );
 
   async function search(currentPath: string) {
     const entries = await fs.readdir(currentPath, { withFileTypes: true });
@@ -132,21 +186,20 @@ async function searchFiles(
       const fullPath = path.join(currentPath, entry.name);
 
       try {
-        // Validate each path before processing
-        await validatePath(fullPath);
-
-        // Check if path matches any exclude pattern
-        const relativePath = path.relative(rootPath, fullPath);
-        const shouldExclude = excludePatterns.some((pattern) => {
-          const globPattern = pattern.includes('*')
-            ? pattern
-            : `**/${pattern}/**`;
-          return minimatch(relativePath, globPattern, { dot: true });
-        });
+        const relativePath = path
+          .relative(rootPath, fullPath)
+          .split(path.sep)
+          .join('/');
+        const shouldExclude = excludeMatchers.some((matches) =>
+          matches(relativePath, entry.isDirectory()),
+        );
 
         if (shouldExclude) {
           continue;
         }
+
+        // Validate each path before processing
+        await validatePath(fullPath);
 
         if (entry.name.toLowerCase().includes(pattern.toLowerCase())) {
           results.push(fullPath);
@@ -412,8 +465,10 @@ function createServer(args: { allowedDirectories: string[] }): McpServer {
     'search_files',
     'Recursively search for files and directories matching a pattern. ' +
       'Searches through all subdirectories from the starting path. The search ' +
-      'is case-insensitive and matches partial names. Returns full paths to all ' +
-      "matching items. Great for finding files when you don't know their exact location. " +
+      'is case-insensitive and matches partial names. Common dependency, build, ' +
+      'cache, log, and version-control paths are excluded by default; use ' +
+      'excludePatterns to add more exclusions. Returns full paths to all matching ' +
+      "items. Great for finding files when you don't know their exact location. " +
       'Only searches within allowed directories.',
     SearchFilesArgsSchema.shape,
     async (args) => {

--- a/packages/agent-infra/mcp-servers/filesystem/tests/server-in-memory.test.ts
+++ b/packages/agent-infra/mcp-servers/filesystem/tests/server-in-memory.test.ts
@@ -1,9 +1,11 @@
 import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
-import { createServer } from '../src/server.js';
-import path from 'path';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 import url from 'node:url';
+import { createServer } from '../src/server.js';
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 
@@ -98,6 +100,156 @@ describe('MCP Server in memory', () => {
           ],
         });
       });
+    });
+  });
+
+  describe('search_files exclusions', () => {
+    const defaultExcludedDirectories = [
+      'node_modules',
+      '.git',
+      'dist',
+      'build',
+      '.next',
+      '.nuxt',
+      'coverage',
+      '.nyc_output',
+      'logs',
+      '.cache',
+      'tmp',
+      'temp',
+    ];
+
+    let client: Client;
+    let temporaryDirectory: string;
+
+    beforeAll(async () => {
+      temporaryDirectory = await fs.mkdtemp(
+        path.join(os.tmpdir(), 'mcp-filesystem-search-'),
+      );
+      await Promise.all(
+        [
+          ...defaultExcludedDirectories,
+          'brace-a',
+          'custom-a.tmp',
+          'custom-cache',
+          'node_modules_backup',
+          'visible',
+        ].map((directory) =>
+          fs.mkdir(path.join(temporaryDirectory, directory), {
+            recursive: true,
+          }),
+        ),
+      );
+      await Promise.all([
+        ...defaultExcludedDirectories.map((directory) =>
+          fs.writeFile(
+            path.join(temporaryDirectory, directory, 'hidden-match.txt'),
+            'excluded',
+          ),
+        ),
+        fs.writeFile(
+          path.join(temporaryDirectory, 'visible', 'match.txt'),
+          'visible',
+        ),
+        fs.writeFile(
+          path.join(temporaryDirectory, 'visible', 'match.log'),
+          'excluded',
+        ),
+        fs.writeFile(
+          path.join(temporaryDirectory, 'visible', 'custom.tmp'),
+          'custom',
+        ),
+        fs.writeFile(
+          path.join(temporaryDirectory, 'custom-a.tmp', 'glob-hidden.txt'),
+          'custom',
+        ),
+        fs.writeFile(
+          path.join(temporaryDirectory, 'brace-a', 'brace-hidden.txt'),
+          'custom',
+        ),
+        fs.writeFile(path.join(temporaryDirectory, 'visible', '.DS_Store'), ''),
+        fs.writeFile(path.join(temporaryDirectory, 'visible', 'Thumbs.db'), ''),
+      ]);
+
+      client = new Client({
+        name: 'search test client',
+        version: '1.0',
+      });
+      const server = createServer({
+        allowedDirectories: [temporaryDirectory],
+      });
+      const [clientTransport, serverTransport] =
+        InMemoryTransport.createLinkedPair();
+
+      await Promise.all([
+        client.connect(clientTransport),
+        server.connect(serverTransport),
+      ]);
+    });
+
+    afterAll(async () => {
+      try {
+        await client.close();
+      } finally {
+        await fs.rm(temporaryDirectory, { recursive: true, force: true });
+      }
+    });
+
+    async function search(pattern: string, excludePatterns?: string[]) {
+      const result = await client.callTool({
+        name: 'search_files',
+        arguments: {
+          path: temporaryDirectory,
+          pattern,
+          ...(excludePatterns && { excludePatterns }),
+        },
+      });
+      return (result.content as Array<{ type: 'text'; text: string }>)[0].text;
+    }
+
+    test('applies the default exclusions before traversing', async () => {
+      const result = await search('');
+
+      expect(result.split('\n').sort()).toEqual(
+        [
+          path.join(temporaryDirectory, 'brace-a'),
+          path.join(temporaryDirectory, 'brace-a', 'brace-hidden.txt'),
+          path.join(temporaryDirectory, 'custom-a.tmp'),
+          path.join(temporaryDirectory, 'custom-a.tmp', 'glob-hidden.txt'),
+          path.join(temporaryDirectory, 'custom-cache'),
+          path.join(temporaryDirectory, 'node_modules_backup'),
+          path.join(temporaryDirectory, 'visible'),
+          path.join(temporaryDirectory, 'visible', 'custom.tmp'),
+          path.join(temporaryDirectory, 'visible', 'match.txt'),
+        ].sort(),
+      );
+    });
+
+    test('merges custom exclusions with the defaults', async () => {
+      await expect(search('cache', ['custom-cache'])).resolves.toBe(
+        'No matches found',
+      );
+    });
+
+    test('applies custom glob exclusions at any depth', async () => {
+      await expect(search('custom.tmp', ['*.tmp'])).resolves.toBe(
+        'No matches found',
+      );
+    });
+
+    test.each([
+      ['question-mark', 'glob-hidden.txt', 'custom-?.tmp'],
+      ['brace', 'brace-hidden.txt', 'brace-{a,b}'],
+    ])('preserves %s glob patterns', async (_, fileName, excludePattern) => {
+      await expect(search(fileName, [excludePattern])).resolves.toBe(
+        'No matches found',
+      );
+    });
+
+    test('excludes exact path segments without hiding partial matches', async () => {
+      await expect(search('node_modules')).resolves.toBe(
+        path.join(temporaryDirectory, 'node_modules_backup'),
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary

Closes #1258

`search_files` previously traversed every allowed subdirectory unless each caller supplied exclusions. That made it easy to scan dependency and build trees accidentally, producing slow searches and noisy agent context even though Agent TARS's safe `directory_tree` already filters those paths.

This change:

- applies the same 15 default exclusions used by the safe `directory_tree` (`node_modules`, `.git`, build/cache/log paths, and common metadata files);
- merges caller-provided `excludePatterns` with those defaults instead of replacing them;
- normalizes relative paths across platforms and preserves minimatch glob forms such as `*.tmp`, `?`, and brace expansion;
- precompiles exclusion matchers once per search and prunes matching entries before validation or recursion;
- updates the tool and schema descriptions to make the additive exclusion behavior explicit.

The in-memory MCP tests exercise the public `search_files` tool against a temporary directory tree. They verify default directory/file pruning, no traversal into excluded directories, additive custom exclusions, nested globs, existing non-asterisk glob forms, and exact path-segment matching without hiding partial-name search results.

### Verification

- Final regression suite against `origin/main`: 4 failures / 5 passes (expected red baseline).
- `pnpm --filter @agent-infra/mcp-server-filesystem test`: 1 suite, 9 tests pass.
- `pnpm --filter @agent-infra/mcp-server-filesystem build`: ESM, CJS, and declarations build successfully.
- Standalone strict TypeScript check for `tests/server-in-memory.test.ts`: passes.
- Prettier check for the three changed files: passes.
- ESLint for the three changed files: passes.
- Git `merge-tree` with the current head of #1906 completes without conflicts.

## Checklist

- [x] Added or updated necessary tests (Optional).
- [x] Updated documentation to align with changes (Optional).
- [x] Verified no breaking API changes (Optional).
- [ ] My change does not involve the above items.
