### PR TITLE
fix(mcp-agent): surface initialization failures

### DIFF
--- a/multimodal/pnpm-lock.yaml
+++ b/multimodal/pnpm-lock.yaml
@@ -1363,6 +1363,9 @@ importers:
       typescript:
         specifier: ^5.5.3
         version: 5.8.3
+      vitest:
+        specifier: 3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.15.30)(jiti@2.6.1)(sass-embedded@1.89.0)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0)
 
   tarko/mcp-agent-interface:
     dependencies:

--- a/multimodal/tarko/mcp-agent/package.json
+++ b/multimodal/tarko/mcp-agent/package.json
@@ -23,6 +23,8 @@
     "dev": "rslib build --watch",
     "build": "rslib build",
     "prepublishOnly": "pnpm run build",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "agent:snapshot:genreate": "npx tsx snapshot/runner.ts generate all",
     "agent:snapshot:test": "npx vitest snapshot/index.test.ts"
   },
@@ -38,6 +40,7 @@
   "devDependencies": {
     "@rslib/core": "0.10.0",
     "@types/node": "22.15.30",
-    "typescript": "^5.5.3"
+    "typescript": "^5.5.3",
+    "vitest": "3.2.4"
   }
 }

--- a/multimodal/tarko/mcp-agent/src/mcp-agent.ts
+++ b/multimodal/tarko/mcp-agent/src/mcp-agent.ts
@@ -55,47 +55,69 @@ export class MCPAgent<T extends MCPAgentOptions = MCPAgentOptions> extends Agent
 
     // Initialize MCP clients and register tools
     for (const [serverName, config] of Object.entries(filteredMcpServerConfig)) {
+      this.logger.info(`🔌 Connecting to MCP server: ${serverName}`);
+
+      const defaultTimeout = this.options.defaultConnectionTimeout ?? 60;
+      let mcpClient: MCPClientV2 | undefined;
+
       try {
-        this.logger.info(`🔌 Connecting to MCP server: ${serverName}`);
-
-        // Create MCP client using v2
-        const defaultTimeout = this.options.defaultConnectionTimeout ?? 60;
-        const mcpClient = new MCPClientV2(serverName, config, this.logger, defaultTimeout);
-
-        // Initialize the client and get tools
+        mcpClient = new MCPClientV2(serverName, config, this.logger, defaultTimeout);
         await mcpClient.initialize();
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        const message = `Failed to initialize MCP server "${serverName}": ${errorMessage}`;
 
-        // Store the client for later use
-        this.mcpClients.set(serverName, mcpClient);
+        this.logger.error(`❌ ${message}`);
 
-        // Create and register tools directly
-        const mcpTools = mcpClient.getTools();
-        for (const mcpTool of mcpTools) {
-          const tool = new Tool({
-            id: mcpTool.name,
-            description: `[${serverName}] ${mcpTool.description}`,
-            parameters: (mcpTool.inputSchema || {
-              type: 'object',
-              properties: {},
-            }) as JSONSchema7,
-            function: async (args: Record<string, unknown>) => {
-              return await mcpClient.callTool(mcpTool.name, args);
+        const eventStream = this.getEventStream();
+        eventStream.sendEvent(
+          eventStream.createEvent('system', {
+            level: 'error',
+            message,
+            details: {
+              source: 'mcp',
+              phase: 'initialization',
+              serverName,
             },
-          });
-          this.registerTool(tool as unknown as Tool);
+          }),
+        );
+
+        if (mcpClient) {
+          try {
+            await mcpClient.close();
+          } catch (cleanupError) {
+            this.logger.error(
+              `Failed to clean up MCP client ${serverName}: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`,
+            );
+          }
         }
 
-        const toolCount = mcpTools.length;
-
-        this.logger.success(`✅ Connected to MCP server ${serverName} with ${toolCount} tools`);
-      } catch (error) {
-        this.logger.error(
-          `❌ Failed to connect to MCP server ${serverName}: ${error instanceof Error ? error.message : JSON.stringify(error)}`,
-        );
-        throw new Error(
-          `❌ Failed to connect to MCP server ${serverName}: ${error instanceof Error ? error.message : JSON.stringify(error)}`,
-        );
+        continue;
       }
+
+      // Store the client for later use
+      this.mcpClients.set(serverName, mcpClient);
+
+      // Create and register tools directly
+      const mcpTools = mcpClient.getTools();
+      for (const mcpTool of mcpTools) {
+        const tool = new Tool({
+          id: mcpTool.name,
+          description: `[${serverName}] ${mcpTool.description}`,
+          parameters: (mcpTool.inputSchema || {
+            type: 'object',
+            properties: {},
+          }) as JSONSchema7,
+          function: async (args: Record<string, unknown>) => {
+            return await mcpClient.callTool(mcpTool.name, args);
+          },
+        });
+        this.registerTool(tool as unknown as Tool);
+      }
+
+      const toolCount = mcpTools.length;
+
+      this.logger.success(`✅ Connected to MCP server ${serverName} with ${toolCount} tools`);
     }
 
     super.initialize();

--- a/multimodal/tarko/mcp-agent/src/mcp-client-v2.ts
+++ b/multimodal/tarko/mcp-agent/src/mcp-client-v2.ts
@@ -15,6 +15,7 @@ export class MCPClientV2 implements IMCPClient {
   private v2Client: V2Client;
   private serverName: string;
   private tools: Tool[] = [];
+  private hasStarted = false;
   private isInitialized = false;
 
   constructor(
@@ -45,6 +46,7 @@ export class MCPClientV2 implements IMCPClient {
 
     try {
       this.logger.info(`Initializing MCP client v2 for ${this.serverName}`);
+      this.hasStarted = true;
       await this.v2Client.init();
       this.tools = await this.v2Client.listTools(this.serverName as string);
       this.isInitialized = true;
@@ -75,18 +77,28 @@ export class MCPClientV2 implements IMCPClient {
       return result.content;
     } catch (error) {
       this.logger.error(`Error calling MCP tool ${toolName}:`, error);
-      throw new Error(`Failed to execute tool ${toolName}: ${error instanceof Error ? error.message : String(error)}`);
+      throw new Error(
+        `Failed to execute tool ${toolName}: ${error instanceof Error ? error.message : String(error)}`,
+      );
     }
   }
 
   async close(): Promise<void> {
-    if (this.isInitialized) {
-      this.logger.info(`Closing MCP client v2 for ${this.serverName}`);
+    if (!this.hasStarted) {
+      return;
+    }
+
+    this.logger.info(`Closing MCP client v2 for ${this.serverName}`);
+
+    try {
       await this.v2Client.cleanup();
+    } finally {
+      this.hasStarted = false;
       this.isInitialized = false;
       this.tools = [];
-      this.logger.success(`MCP client v2 closed successfully for ${this.serverName}`);
     }
+
+    this.logger.success(`MCP client v2 closed successfully for ${this.serverName}`);
   }
 
   getTools(): Tool[] {

--- a/multimodal/tarko/mcp-agent/tests/mcp-agent.test.ts
+++ b/multimodal/tarko/mcp-agent/tests/mcp-agent.test.ts
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Tool as MCPTool } from '@modelcontextprotocol/sdk/types.js';
+
+const { constructClient, initializeClient, closeClient, getClientTools } = vi.hoisted(() => ({
+  constructClient: vi.fn<(serverName: string) => void>(),
+  initializeClient: vi.fn<(serverName: string) => Promise<MCPTool[]>>(),
+  closeClient: vi.fn<(serverName: string) => Promise<void>>(),
+  getClientTools: vi.fn<(serverName: string) => MCPTool[]>(),
+}));
+
+vi.mock('../src/mcp-client-v2', () => ({
+  MCPClientV2: class {
+    constructor(private serverName: string) {
+      constructClient(serverName);
+    }
+
+    initialize() {
+      return initializeClient(this.serverName);
+    }
+
+    close() {
+      return closeClient(this.serverName);
+    }
+
+    getTools() {
+      return getClientTools(this.serverName);
+    }
+
+    callTool() {
+      return Promise.resolve(undefined);
+    }
+  },
+}));
+
+import { MCPAgent } from '../src/mcp-agent';
+
+const healthyTool: MCPTool = {
+  name: 'healthy_tool',
+  description: 'A tool from the healthy server',
+  inputSchema: {
+    type: 'object',
+    properties: {},
+  },
+};
+
+describe('MCPAgent initialization', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    constructClient.mockImplementation(() => undefined);
+    initializeClient.mockImplementation(async (serverName) => {
+      if (serverName === 'broken') {
+        throw new Error('connection refused');
+      }
+
+      return [healthyTool];
+    });
+    closeClient.mockResolvedValue(undefined);
+    getClientTools.mockImplementation((serverName) =>
+      serverName === 'healthy' ? [healthyTool] : [],
+    );
+  });
+
+  it('surfaces a failed server and continues initializing the remaining servers', async () => {
+    const agent = new MCPAgent({
+      mcpServers: {
+        broken: { command: 'broken-server' },
+        healthy: { command: 'healthy-server' },
+      },
+    });
+
+    await expect(agent.initialize()).resolves.toBeUndefined();
+
+    expect(initializeClient).toHaveBeenNthCalledWith(1, 'broken');
+    expect(initializeClient).toHaveBeenNthCalledWith(2, 'healthy');
+    expect(closeClient).toHaveBeenCalledWith('broken');
+    expect(agent.getTools().map((tool) => tool.name)).toEqual(['healthy_tool']);
+
+    const errorEvents = agent
+      .getEventStream()
+      .getEvents()
+      .filter((event) => event.type === 'system' && event.level === 'error');
+
+    expect(errorEvents).toEqual([
+      expect.objectContaining({
+        type: 'system',
+        level: 'error',
+        message: 'Failed to initialize MCP server "broken": connection refused',
+        details: {
+          source: 'mcp',
+          phase: 'initialization',
+          serverName: 'broken',
+        },
+      }),
+    ]);
+  });
+
+  it('surfaces client construction failures without blocking later servers', async () => {
+    constructClient.mockImplementation((serverName) => {
+      if (serverName === 'broken') {
+        throw new Error('invalid transport configuration');
+      }
+    });
+
+    const agent = new MCPAgent({
+      mcpServers: {
+        broken: { command: 'broken-server' },
+        healthy: { command: 'healthy-server' },
+      },
+    });
+
+    await expect(agent.initialize()).resolves.toBeUndefined();
+
+    expect(initializeClient).toHaveBeenCalledOnce();
+    expect(initializeClient).toHaveBeenCalledWith('healthy');
+    expect(closeClient).not.toHaveBeenCalledWith('broken');
+    expect(agent.getTools().map((tool) => tool.name)).toEqual(['healthy_tool']);
+    expect(agent.getEventStream().getEvents()).toEqual([
+      expect.objectContaining({
+        type: 'system',
+        level: 'error',
+        message: 'Failed to initialize MCP server "broken": invalid transport configuration',
+        details: {
+          source: 'mcp',
+          phase: 'initialization',
+          serverName: 'broken',
+        },
+      }),
+    ]);
+  });
+});

--- a/multimodal/tarko/mcp-agent/tests/mcp-client-v2.test.ts
+++ b/multimodal/tarko/mcp-agent/tests/mcp-client-v2.test.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Logger } from '@agent-infra/logger';
+
+const { initClient, listTools, cleanupClient } = vi.hoisted(() => ({
+  initClient: vi.fn<() => Promise<void>>(),
+  listTools: vi.fn<() => Promise<never>>(),
+  cleanupClient: vi.fn<() => Promise<void>>(),
+}));
+
+vi.mock('@agent-infra/mcp-client', () => ({
+  MCPClient: class {
+    init() {
+      return initClient();
+    }
+
+    listTools() {
+      return listTools();
+    }
+
+    cleanup() {
+      return cleanupClient();
+    }
+  },
+}));
+
+import { MCPClientV2 } from '../src/mcp-client-v2';
+
+const logger = {
+  info: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+} as unknown as Logger;
+
+describe('MCPClientV2 cleanup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    initClient.mockResolvedValue(undefined);
+    listTools.mockRejectedValue(new Error('connection closed'));
+    cleanupClient.mockResolvedValue(undefined);
+  });
+
+  it('cleans up a partially initialized client after initialization fails', async () => {
+    const client = new MCPClientV2('broken', { command: 'broken-server' }, logger);
+
+    await expect(client.initialize()).rejects.toThrow('connection closed');
+    await client.close();
+    await client.close();
+
+    expect(cleanupClient).toHaveBeenCalledOnce();
+  });
+});

--- a/multimodal/tarko/mcp-agent/vitest.config.mts
+++ b/multimodal/tarko/mcp-agent/vitest.config.mts
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## Summary

- emit a structured `system` error event when an MCP server cannot be constructed or initialized
- continue initializing the remaining MCP servers so one unavailable integration does not abort the session
- clean up partially initialized MCP clients and keep `close()` idempotent
- add package-level Vitest coverage and test scripts for the failure path

## Why

`MCPAgent.initialize()` previously logged an MCP connection failure and immediately rethrew it. That stopped the server loop, prevented later MCP servers from becoming available, and left the Web UI without an initialization event it could render.

The agent server already subscribes to the agent event stream before calling `initialize()`, persists non-streaming events, returns initialization events from session creation, and the Web UI already renders `system` events. Emitting the failure through that existing path therefore surfaces a clear error without adding a parallel UI-only error channel.

The regression test was red on `main`: initialization rejected on the first failed server instead of reaching the healthy server. It now verifies that:

- the failed server produces a `system` event with `level: "error"`
- later servers still initialize and register their tools
- constructor failures follow the same visible degradation path
- a partially initialized client is cleaned up exactly once, even if `close()` is called again

## Related work

#1834 addresses a lower-level case where MCP tool-list errors can be swallowed. This PR handles the next layer: any propagated construction or initialization failure is surfaced to the event stream and isolated to that server. The changes are independent and merge cleanly.

## Validation

- `vitest run --config vitest.config.mts` — 3 passed, 4 existing snapshot tests skipped
- `rslib build` — ESM, CJS, and declaration output
- strict standalone TypeScript check for both new test files
- Prettier check
- ESLint check
- merge-tree check with #1834

Closes #1338

## Checklist

- [x] Added or updated necessary tests.
- [ ] Updated documentation (not needed; no public API surface changed).
- [x] Verified no breaking API changes; the behavior change is intentionally limited to per-server initialization failure handling.
