### PR TITLE
fix(agent-server): prioritize source workspace results

### DIFF
--- a/multimodal/tarko/agent-server/src/api/controllers/sessions.ts
+++ b/multimodal/tarko/agent-server/src/api/controllers/sessions.ts
@@ -112,7 +112,6 @@ export async function createSession(req: Request, res: Response) {
       server.storageUnsubscribes[sessionId] = storageUnsubscribe;
     }
 
-
     // Wait a short time to ensure all initialization events are persisted
     // This handles the async nature of event storage during agent initialization
     await session.waitForEventSavesToComplete();
@@ -633,8 +632,26 @@ async function searchWorkspaceItemsRecursive(
 
   await searchInDirectory(basePath);
 
+  // Keep dist searchable, but avoid generated artifacts outranking source matches.
+  const sourceItems = new Set(
+    items.filter((item) => hasPathSegment(item.relativePath, SOURCE_DIRECTORY)),
+  );
+  const shouldPrioritizeSourceItems =
+    !hasPathSegment(query, GENERATED_OUTPUT_DIRECTORY) &&
+    sourceItems.size > 0 &&
+    items.some((item) => hasPathSegment(item.relativePath, GENERATED_OUTPUT_DIRECTORY));
+
   // Smart relevance-based sorting
   return items.sort((a, b) => {
+    if (shouldPrioritizeSourceItems) {
+      const sourceA = sourceItems.has(a);
+      const sourceB = sourceItems.has(b);
+
+      if (sourceA !== sourceB) {
+        return sourceA ? -1 : 1;
+      }
+    }
+
     const scoreA = calculateRelevanceScore(a, query);
     const scoreB = calculateRelevanceScore(b, query);
 
@@ -651,6 +668,13 @@ async function searchWorkspaceItemsRecursive(
     // Finally, sort by name
     return a.name.localeCompare(b.name);
   });
+}
+
+const SOURCE_DIRECTORY = 'src';
+const GENERATED_OUTPUT_DIRECTORY = 'dist';
+
+function hasPathSegment(value: string, segment: string): boolean {
+  return value.toLowerCase().replace(/\\/g, '/').split('/').filter(Boolean).includes(segment);
 }
 
 /**

--- a/multimodal/tarko/agent-server/tests/api/workspace-search.test.ts
+++ b/multimodal/tarko/agent-server/tests/api/workspace-search.test.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import type { Request, Response } from 'express';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.unmock('fs');
+vi.unmock('path');
+
+import { searchWorkspaceItems } from '../../src/api/controllers/sessions';
+
+describe('workspace search ordering', () => {
+  let workspacePath: string;
+
+  beforeEach(async () => {
+    workspacePath = await fs.mkdtemp(path.join(os.tmpdir(), 'tarko-workspace-search-'));
+
+    await Promise.all([
+      fs.mkdir(path.join(workspacePath, 'dist'), { recursive: true }),
+      fs.mkdir(path.join(workspacePath, 'src', 'runtime'), { recursive: true }),
+    ]);
+
+    await Promise.all([
+      fs.writeFile(path.join(workspacePath, 'dist', 'repository-context.d.ts'), ''),
+      fs.writeFile(path.join(workspacePath, 'dist', 'repository-context.d.ts.map'), ''),
+      fs.writeFile(path.join(workspacePath, 'dist', 'repository-context.js'), ''),
+      fs.writeFile(path.join(workspacePath, 'dist', 'repository-context.js.map'), ''),
+      fs.writeFile(path.join(workspacePath, 'dist', 'repository-context.mjs'), ''),
+      ...Array.from({ length: 25 }, (_, index) =>
+        fs.writeFile(path.join(workspacePath, 'dist', `repository-context-${index}.js`), ''),
+      ),
+      fs.writeFile(path.join(workspacePath, 'src', 'runtime', 'repository-context.ts'), ''),
+    ]);
+  });
+
+  afterEach(async () => {
+    await fs.rm(workspacePath, { recursive: true, force: true });
+  });
+
+  async function search(query: string) {
+    const json = vi.fn();
+    const req = {
+      query: {
+        sessionId: 'test-session',
+        q: query,
+        type: 'file',
+      },
+      app: {
+        locals: {
+          server: {
+            getCurrentWorkspace: () => workspacePath,
+          },
+        },
+      },
+    } as unknown as Request;
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json,
+    } as unknown as Response;
+
+    await searchWorkspaceItems(req, res);
+
+    expect(json).toHaveBeenCalledOnce();
+    return json.mock.calls[0][0].items as Array<{ relativePath: string }>;
+  }
+
+  it('ranks source files ahead of matching dist artifacts', async () => {
+    const results = await search('context');
+    const paths = results.map((item) => item.relativePath);
+
+    expect(paths).toHaveLength(20);
+    expect(paths[0]).toBe('src/runtime/repository-context.ts');
+    expect(paths.slice(1).every((resultPath) => resultPath.startsWith('dist/'))).toBe(true);
+  });
+
+  it('keeps dist artifacts searchable when the query names dist explicitly', async () => {
+    const results = await search('dist');
+
+    expect(results).not.toHaveLength(0);
+    expect(results.every((item) => item.relativePath.startsWith('dist/'))).toBe(true);
+  });
+
+  it('preserves relevance ordering when there is no source match', async () => {
+    await fs.mkdir(path.join(workspacePath, 'notes'));
+    await fs.writeFile(path.join(workspacePath, 'notes', 'repository-context-0.js.notes.md'), '');
+
+    const results = await search('repository-context-0.js');
+
+    expect(results[0].relativePath).toBe('dist/repository-context-0.js');
+  });
+});


### PR DESCRIPTION
<!--------------------------------------------------------------------------------
    Thank you for submitting a pull request!

    We appreciate the time and effort you have invested in making these changes. Please 
    ensure that you provide enough information to allow others to review your pull request 
    effectively, so please DO NOT delete this template.

    If you're new to contributing, learn more about contributing here:
    https://github.com/bytedance/UI-TARS-desktop/blob/main/CONTRIBUTING.md.  
---------------------------------------------------------------------------------->

## Summary

<!--------------------------------------------------------------------------------
    Can you explain the reasoning behind implementing this change?  
    What problem or issue does this pull request resolve?  

    It would be helpful to include relevant context, such as GitHub issues 
    (e.g., Close: #xxx) or related discussions.

    If updating the UI, please include a **before/after screenshot** for visibility.
    Thank you for reading. Next, start describing your Summary on the next line
    after the comment ends. 👇🏻
---------------------------------------------------------------------------------->

Addresses the workspace search ordering bug reported in #1100.

When both source files and generated output match a contextual-selector query, source results under a `src` path segment are now ranked first before applying the existing relevance ordering and result limit. This prevents a large `dist` directory from pushing the source file out of the default 20 results.

Generated artifacts remain searchable:

- Queries that explicitly target `dist` keep the existing relevance ordering.
- Searches without a matching source result also keep the existing relevance ordering.

This PR intentionally covers only the ordering bug from #1100. It does not implement the separate `AgentOptions` switch for gitignored files mentioned under "Other", so it does not automatically close the issue.

## Test plan

- [x] Added 3 workspace-search regression tests: source priority under the 20-result limit, explicit `dist` queries, and no-source relevance preservation.
- [x] Regression test fails on `origin/main` as expected (`1 failed, 2 passed`) and passes on this branch (`3 passed`).
- [x] Agent server tests excluding the unrelated baseline SQLite fixture: `44 passed`.
- [x] `tsc --noEmit -p tsconfig.json`.
- [x] `pnpm --dir multimodal --filter @tarko/agent-server build` on Node 24 / pnpm 9.10.0. The build retains the existing optional MongoDB `gcp-metadata` warning.

The full suite's 19 SQLite tests already fail identically on `origin/main` under Windows because the shared test setup combines a mocked `/tmp` prefix with an absolute Windows temp path; this change does not touch SQLite storage.

## Checklist  

<!--  Before submitting the pull request, ensure the following items are checked: -->

- [x] Added or updated necessary tests (Optional).  
- [ ] Updated documentation to align with changes (Optional).  
- [x] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).  
- [ ] My change does not involve the above items. 
