### PR TITLE
fix(browser-search): enforce excluded domains in results

### DIFF
--- a/packages/agent-infra/search/browser-search/src/browser-search.test.ts
+++ b/packages/agent-infra/search/browser-search/src/browser-search.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import type { BrowserInterface } from '@agent-infra/browser';
+import { describe, expect, it, vi } from 'vitest';
+
+import { BrowserSearch } from './browser-search';
+import type { SearchResult } from './types';
+
+describe('BrowserSearch', () => {
+  it('filters excluded domains before visiting result pages', async () => {
+    const searchResults: SearchResult[] = [
+      {
+        title: 'Excluded domain',
+        url: 'https://example.com/ignored',
+        snippet: 'excluded',
+        content: '',
+      },
+      {
+        title: 'Excluded subdomain',
+        url: 'https://docs.example.com/ignored',
+        snippet: 'excluded',
+        content: '',
+      },
+      {
+        title: 'Hostname lookalike',
+        url: 'https://example.com.evil.test/allowed',
+        snippet: 'allowed',
+        content: '',
+      },
+      {
+        title: 'Allowed domain',
+        url: 'https://allowed.test/page',
+        snippet: 'allowed',
+        content: '',
+      },
+    ];
+    const evaluateOnNewPage = vi.fn(async ({ url }: { url: string }) => {
+      if (url.startsWith('https://www.google.com/search?')) {
+        return searchResults;
+      }
+
+      return {
+        title: `Visited ${url}`,
+        content: `<p>Content from ${url}</p>`,
+      };
+    });
+    const browser = {
+      launch: vi.fn(),
+      close: vi.fn(),
+      evaluateOnNewPage,
+    } as unknown as BrowserInterface;
+    const search = new BrowserSearch({ browser });
+
+    const results = await search.perform({
+      query: 'test query',
+      excludeDomains: [
+        ' HTTPS://*.Example.COM/path ',
+        'example.com',
+        '',
+        '://invalid',
+      ],
+      needVisitedUrls: true,
+    });
+
+    expect(results.map(({ url }) => url)).toEqual([
+      'https://example.com.evil.test/allowed',
+      'https://allowed.test/page',
+    ]);
+    const searchUrl = new URL(evaluateOnNewPage.mock.calls[0][0].url);
+    expect(searchUrl.searchParams.get('q')).toBe(
+      '-site:example.com test query',
+    );
+    expect(evaluateOnNewPage.mock.calls.map(([{ url }]) => url)).toEqual([
+      expect.stringContaining('https://www.google.com/search?'),
+      'https://example.com.evil.test/allowed',
+      'https://allowed.test/page',
+    ]);
+    expect(browser.launch).toHaveBeenCalledOnce();
+    expect(browser.close).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/agent-infra/search/browser-search/src/browser-search.ts
+++ b/packages/agent-infra/search/browser-search/src/browser-search.ts
@@ -14,7 +14,7 @@ import {
   extractPageInformation,
   toMarkdown,
 } from '@agent-infra/shared';
-import { shouldSkipDomain } from './utils/url';
+import { shouldExcludeDomain, shouldSkipDomain } from './utils/url';
 import { interceptRequest } from './utils/misc';
 import { getSearchEngine } from './engines';
 import type {
@@ -158,9 +158,15 @@ export class BrowserSearch {
     // Filter links
     links =
       links?.filter((link) => {
+        if (
+          shouldSkipDomain(link.url) ||
+          shouldExcludeDomain(link.url, options.excludeDomains)
+        ) {
+          return false;
+        }
         if (options.visitedUrls.has(link.url)) return false;
         options.visitedUrls.add(link.url);
-        return !shouldSkipDomain(link.url);
+        return true;
       }) || [];
 
     if (!links.length) {

--- a/packages/agent-infra/search/browser-search/src/browser-search.ts
+++ b/packages/agent-infra/search/browser-search/src/browser-search.ts
@@ -14,7 +14,11 @@ import {
   extractPageInformation,
   toMarkdown,
 } from '@agent-infra/shared';
-import { shouldExcludeDomain, shouldSkipDomain } from './utils/url';
+import {
+  normalizeExcludedDomains,
+  shouldExcludeDomain,
+  shouldSkipDomain,
+} from './utils/url';
 import { interceptRequest } from './utils/misc';
 import { getSearchEngine } from './engines';
 import type {
@@ -56,7 +60,9 @@ export class BrowserSearch {
     const queries = Array.isArray(options.query)
       ? options.query
       : [options.query];
-    const excludeDomains = options.excludeDomains || [];
+    const excludeDomains = normalizeExcludedDomains(
+      options.excludeDomains || [],
+    );
     const count =
       options.count && Math.max(3, Math.floor(options.count / queries.length));
     const engine = options.engine || this.defaultEngine;

--- a/packages/agent-infra/search/browser-search/src/utils/url.test.ts
+++ b/packages/agent-infra/search/browser-search/src/utils/url.test.ts
@@ -30,13 +30,23 @@ describe('shouldExcludeDomain', () => {
   });
 
   it('normalizes schemes, paths, wildcards, case, and trailing dots', () => {
-    const excludedDomains = [' HTTPS://Example.COM/path ', '*.blocked.test'];
+    const excludedDomains = [
+      ' HTTPS://Example.COM/path ',
+      '*.blocked.test',
+      'https://*.wildcard.example/path',
+    ];
 
     expect(shouldExcludeDomain('https://EXAMPLE.com./', excludedDomains)).toBe(
       true,
     );
     expect(
       shouldExcludeDomain('https://api.blocked.test/', excludedDomains),
+    ).toBe(true);
+    expect(
+      shouldExcludeDomain('https://wildcard.example/', excludedDomains),
+    ).toBe(true);
+    expect(
+      shouldExcludeDomain('https://docs.wildcard.example/', excludedDomains),
     ).toBe(true);
   });
 

--- a/packages/agent-infra/search/browser-search/src/utils/url.test.ts
+++ b/packages/agent-infra/search/browser-search/src/utils/url.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { describe, expect, it } from 'vitest';
+
+import { shouldExcludeDomain } from './url';
+
+describe('shouldExcludeDomain', () => {
+  it('matches exact domains and their subdomains', () => {
+    const excludedDomains = ['example.com'];
+
+    expect(
+      shouldExcludeDomain('https://example.com/page', excludedDomains),
+    ).toBe(true);
+    expect(
+      shouldExcludeDomain('https://docs.example.com/page', excludedDomains),
+    ).toBe(true);
+  });
+
+  it('does not match hostname lookalikes', () => {
+    const excludedDomains = ['example.com'];
+
+    expect(
+      shouldExcludeDomain('https://example.com.evil.test', excludedDomains),
+    ).toBe(false);
+    expect(
+      shouldExcludeDomain('https://notexample.com/page', excludedDomains),
+    ).toBe(false);
+  });
+
+  it('normalizes schemes, paths, wildcards, case, and trailing dots', () => {
+    const excludedDomains = [' HTTPS://Example.COM/path ', '*.blocked.test'];
+
+    expect(shouldExcludeDomain('https://EXAMPLE.com./', excludedDomains)).toBe(
+      true,
+    );
+    expect(
+      shouldExcludeDomain('https://api.blocked.test/', excludedDomains),
+    ).toBe(true);
+  });
+
+  it('ignores empty or invalid excluded-domain entries', () => {
+    expect(shouldExcludeDomain('https://example.com', ['', '://invalid'])).toBe(
+      false,
+    );
+  });
+});

--- a/packages/agent-infra/search/browser-search/src/utils/url.ts
+++ b/packages/agent-infra/search/browser-search/src/utils/url.ts
@@ -17,6 +17,37 @@ const parseUrl = (url: string) => {
 };
 
 /**
+ * Converts a user-provided domain (with or without a scheme/path) to a
+ * hostname that can be compared safely.
+ */
+const normalizeDomain = (domain: string) => {
+  const value = domain.trim().toLowerCase().replace(/^\*\./, '');
+  if (!value) return null;
+
+  const parsed = parseUrl(value.includes('://') ? value : `https://${value}`);
+  return parsed?.hostname.replace(/\.$/, '') || null;
+};
+
+/**
+ * Determines whether a URL belongs to one of the caller-provided excluded
+ * domains. Subdomains are excluded as well, while lookalike hostnames such as
+ * `example.com.evil.test` are not.
+ */
+export const shouldExcludeDomain = (url: string, excludedDomains: string[]) => {
+  const hostname = parseUrl(url)?.hostname.toLowerCase().replace(/\.$/, '');
+  if (!hostname) return false;
+
+  return excludedDomains.some((domain) => {
+    const excludedHostname = normalizeDomain(domain);
+    return (
+      excludedHostname !== null &&
+      (hostname === excludedHostname ||
+        hostname.endsWith(`.${excludedHostname}`))
+    );
+  });
+};
+
+/**
  * Determines if a domain should be skipped based on a blocklist
  * @param url - The URL to check
  * @returns True if the domain should be skipped, false otherwise

--- a/packages/agent-infra/search/browser-search/src/utils/url.ts
+++ b/packages/agent-infra/search/browser-search/src/utils/url.ts
@@ -25,8 +25,21 @@ const normalizeDomain = (domain: string) => {
   if (!value) return null;
 
   const parsed = parseUrl(value.includes('://') ? value : `https://${value}`);
-  return parsed?.hostname.replace(/\.$/, '') || null;
+  return parsed?.hostname.replace(/^\*\./, '').replace(/\.$/, '') || null;
 };
+
+/**
+ * Normalizes and deduplicates excluded domains before they are used in search
+ * engine queries or compared with result URLs.
+ */
+export const normalizeExcludedDomains = (domains: string[]) =>
+  Array.from(
+    new Set(
+      domains
+        .map(normalizeDomain)
+        .filter((domain): domain is string => domain !== null),
+    ),
+  );
 
 /**
  * Determines whether a URL belongs to one of the caller-provided excluded

--- a/packages/agent-infra/search/browser-search/vitest.config.ts
+++ b/packages/agent-infra/search/browser-search/vitest.config.ts
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+  },
+});


### PR DESCRIPTION
## Summary

Ensure `BrowserSearchOptions.excludeDomains` is enforced on extracted search results, not only expressed as a `-site:` hint in the search-engine query.

Search engines may ignore, reinterpret, or partially apply query operators. Before this change, an excluded result returned by the engine was still visited and returned to the caller. The new post-extraction filter:

- matches exact hostnames and all subdomains;
- avoids lookalikes such as `example.com.evil.test` and `notexample.com`;
- normalizes case, trailing dots, optional schemes/paths, and wildcard prefixes;
- removes invalid and duplicate entries before building the search-engine query;
- filters before visiting a result or adding its URL to the shared visited set.

A package-level Vitest config is included so this package's `test` script does not inherit the root workspace glob and misinterpret source files as Vitest projects. Unit coverage verifies both hostname edge cases and the `BrowserSearch` integration, including that excluded pages are never visited.

Testing:

- `pnpm --filter @agent-infra/browser-search test` — 5 tests passed
- `pnpm --filter @agent-infra/browser-search coverage -- --reporter=text` — passed; URL utility reached 100% statements, lines, and functions coverage
- `pnpm --filter @agent-infra/browser-search build` — ESM, CJS, and declarations built successfully
- targeted TypeScript, ESLint, and Prettier checks passed
- repository pre-commit `secretlint` and `prettier` hooks passed

## Checklist

- [x] Added or updated necessary tests.
- [ ] Updated documentation to align with changes (public option contract is unchanged).
- [x] Verified no breaking changes.
- [ ] My change does not involve the above items.
