### PR TITLE
docs: add OpenAI-compatible hosted endpoint examples

### DIFF
--- a/multimodal/websites/docs/docs/en/guide/basic/cli.mdx
+++ b/multimodal/websites/docs/docs/en/guide/basic/cli.mdx
@@ -181,6 +181,22 @@ npx agent-tars workspace --open
 
 This command will open the global workspace located at `~/.agent-tars-workspace`.
 
+## OpenAI-compatible hosted endpoints
+
+For a hosted endpoint that follows the OpenAI Chat Completions protocol, use the explicit `openai-compatible` provider. The base URL must include the provider's `/v1` API prefix, and the model ID must match the ID returned by that provider's model catalog.
+
+```bash
+npx agent-tars run \
+  --input "Explain the architecture of a retrieval-augmented agent" \
+  --model.provider openai-compatible \
+  --model.id your-model-id \
+  --model.apiKey OPENAI_COMPAT_API_KEY \
+  --model.baseURL https://your-endpoint.example.com/v1
+```
+
+- Do not append `/chat/completions` to `--model.baseURL`.
+- Do not prefix the model ID with `openai/`; that prefix is only used by providers such as OpenRouter or LiteLLM.
+- API key and base URL values can reference environment variables, as shown above.
 ## Configuration files
 
 Agent TARS automatically looks for these configuration files in the current directory:

--- a/multimodal/websites/tarko/docs/en/guide/basic/model-provider.mdx
+++ b/multimodal/websites/tarko/docs/en/guide/basic/model-provider.mdx
@@ -61,9 +61,15 @@ You can also use any OpenAI-compatible endpoint:
 
 ```typescript
 {
-  provider: 'custom',
-  baseURL: 'https://your-endpoint.com/v1',
-  apiKey: 'your-api-key',
-  model: 'your-model'
+  provider: 'openai-compatible',
+  baseURL: 'https://your-endpoint.example.com/v1',
+  apiKey: process.env.OPENAI_COMPAT_API_KEY,
+  model: 'your-model-id'
 }
+```
+
+The endpoint must expose the OpenAI Chat Completions API under the `/v1` prefix. Use the model ID returned by the endpoint's model catalog; do not add an `openai/` prefix. The same values can be supplied through CLI flags, for example:
+
+```bash
+npx agent-tars run --input "Explain the architecture of a retrieval-augmented agent" --model.provider openai-compatible --model.id your-model-id --model.apiKey OPENAI_COMPAT_API_KEY --model.baseURL https://your-endpoint.example.com/v1
 ```


### PR DESCRIPTION
  ## Summary

  The existing model-provider documentation mentions OpenAI-compatible endpoints but does not explain the `/v1` base URL
  requirement or the model ID format. This makes hosted providers easy to configure incorrectly when using Agent TARS
  with a custom model gateway.

  This addresses #1956.

  The change:

  - adds a CLI example using `--model.provider openai-compatible`;
  - documents that `--model.baseURL` must include `/v1` but must not include `/chat/completions`;
  - clarifies that the model ID comes from the provider catalog and should not use an `openai/` prefix;
  - updates the Tarko provider example to use the same explicit provider and environment-variable pattern.

  ## Checklist

  - [ ] Added or updated necessary tests (Optional).
  - [x] Updated documentation to align with changes (Optional).
  - [x] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
  - [ ] My change does not involve the above items.