### PR TITLE
fix(operators): preserve zero-valued screen coordinates

### DIFF
--- a/apps/ui-tars/src/main/remote/operators.ts
+++ b/apps/ui-tars/src/main/remote/operators.ts
@@ -285,7 +285,16 @@ export class RemoteComputerOperator extends Operator {
           const endX = rawEndX !== null ? Math.round(rawEndX) : null;
           const endY = rawEndY !== null ? Math.round(rawEndY) : null;
 
-          if (startX && startY && endX && endY) {
+          if (
+            startX !== null &&
+            startY !== null &&
+            endX !== null &&
+            endY !== null &&
+            Number.isFinite(startX) &&
+            Number.isFinite(startY) &&
+            Number.isFinite(endX) &&
+            Number.isFinite(endY)
+          ) {
             await this.remoteComputer.dragMouse(startX, startY, endX, endY);
           }
         }

--- a/apps/ui-tars/src/main/shared/setOfMarks.test.ts
+++ b/apps/ui-tars/src/main/shared/setOfMarks.test.ts
@@ -130,3 +130,23 @@ const testMakeScreenMarker = () => {
 test('not throw error', () => {
   expect(() => testMakeScreenMarker()).not.toThrow();
 });
+
+test('renders a click overlay at the screen origin', () => {
+  const { overlays } = setOfMarksOverlays({
+    predictions: [
+      {
+        reflection: '',
+        thought: '',
+        action_type: 'click',
+        action_inputs: { start_box: '[0,0,0,0]' },
+      },
+    ],
+    screenshotContext: {
+      size: { width: 1920, height: 1080 },
+      scaleFactor: 1,
+    },
+  });
+
+  expect(overlays).toHaveLength(1);
+  expect(overlays[0]).toMatchObject({ xPos: 0, yPos: 0 });
+});

--- a/apps/ui-tars/src/main/shared/setOfMarks.ts
+++ b/apps/ui-tars/src/main/shared/setOfMarks.ts
@@ -56,7 +56,14 @@ export const setOfMarksOverlays = ({
           });
           const clickX = coords.x;
           const clickY = coords.y;
-          if (!clickX || !clickY) break;
+          if (
+            clickX === null ||
+            clickY === null ||
+            !Number.isFinite(clickX) ||
+            !Number.isFinite(clickY)
+          ) {
+            break;
+          }
 
           boxWidth = 250;
           boxHeight = 100;

--- a/apps/ui-tars/src/main/utils/image.ts
+++ b/apps/ui-tars/src/main/utils/image.ts
@@ -26,7 +26,12 @@ export async function markClickPosition(data: {
     });
     const imageOverlays: sharp.OverlayOptions[] = overlays
       .map((o) => {
-        if (o.yPos && o.xPos) {
+        if (
+          o.yPos !== undefined &&
+          o.xPos !== undefined &&
+          Number.isFinite(o.yPos) &&
+          Number.isFinite(o.xPos)
+        ) {
           return {
             input: Buffer.from(o.svg),
             top: o.yPos + o.offsetY,

--- a/apps/ui-tars/src/main/window/ScreenMarker.ts
+++ b/apps/ui-tars/src/main/window/ScreenMarker.ts
@@ -227,8 +227,10 @@ class ScreenMarker {
           paintWhenInitiallyHidden: true,
           type: 'panel',
           webPreferences: { nodeIntegration: true, contextIsolation: false },
-          ...(overlay.xPos &&
-            overlay.yPos && {
+          ...(overlay.xPos !== undefined &&
+            overlay.yPos !== undefined &&
+            Number.isFinite(overlay.xPos) &&
+            Number.isFinite(overlay.yPos) && {
               // logical pixels
               x: (overlay.xPos + overlay.offsetX) * scaleFactor,
               y: (overlay.yPos + overlay.offsetY) * scaleFactor,
@@ -253,7 +255,12 @@ class ScreenMarker {
         //   });
         // }
 
-        if (overlay.xPos && overlay.yPos) {
+        if (
+          overlay.xPos !== undefined &&
+          overlay.yPos !== undefined &&
+          Number.isFinite(overlay.xPos) &&
+          Number.isFinite(overlay.yPos)
+        ) {
           this.lastShowPredictionMarkerPos = {
             xPos: overlay.xPos,
             yPos: overlay.yPos,

--- a/apps/ui-tars/src/renderer/src/hooks/useScreenRecord.ts
+++ b/apps/ui-tars/src/renderer/src/hooks/useScreenRecord.ts
@@ -48,7 +48,12 @@ export const useScreenRecord = (
         const url = DOMURL.createObjectURL(svgBlob);
 
         img.onload = function () {
-          if (xPos && yPos) {
+          if (
+            xPos !== undefined &&
+            yPos !== undefined &&
+            Number.isFinite(xPos) &&
+            Number.isFinite(yPos)
+          ) {
             ctx.drawImage(img, xPos + offsetX, yPos + offsetY);
             lastPosRef.current = { xPos, yPos };
           }

--- a/multimodal/gui-agent/operator-browser/src/browser-operator.ts
+++ b/multimodal/gui-agent/operator-browser/src/browser-operator.ts
@@ -484,7 +484,7 @@ export class BrowserOperator extends Operator {
     }
     const { realX: startX, realY: startY } = await this.calculateRealCoords(inputs.point);
 
-    if (startX !== null && startY !== null) {
+    if (Number.isFinite(startX) && Number.isFinite(startY)) {
       this.logger.info(`Moving mouse to scroll position: (${startX}, ${startY})`);
       await page.mouse.move(startX, startY);
       await sleep(100); // Small delay to ensure mouse position is set
@@ -545,7 +545,12 @@ export class BrowserOperator extends Operator {
     const { realX: startX, realY: startY } = await this.calculateRealCoords(inputs.start);
     const { realX: endX, realY: endY } = await this.calculateRealCoords(inputs.end);
 
-    if (startX === null || startY === null || endX === null || endY === null) {
+    if (
+      !Number.isFinite(startX) ||
+      !Number.isFinite(startY) ||
+      !Number.isFinite(endX) ||
+      !Number.isFinite(endY)
+    ) {
       throw new Error('Invalid coordinates for drag operation');
     }
 

--- a/multimodal/gui-agent/operator-browser/src/browser-operator.ts
+++ b/multimodal/gui-agent/operator-browser/src/browser-operator.ts
@@ -484,7 +484,7 @@ export class BrowserOperator extends Operator {
     }
     const { realX: startX, realY: startY } = await this.calculateRealCoords(inputs.point);
 
-    if (startX && startY) {
+    if (startX !== null && startY !== null) {
       this.logger.info(`Moving mouse to scroll position: (${startX}, ${startY})`);
       await page.mouse.move(startX, startY);
       await sleep(100); // Small delay to ensure mouse position is set
@@ -545,7 +545,7 @@ export class BrowserOperator extends Operator {
     const { realX: startX, realY: startY } = await this.calculateRealCoords(inputs.start);
     const { realX: endX, realY: endY } = await this.calculateRealCoords(inputs.end);
 
-    if (!startX || !startY || !endX || !endY) {
+    if (startX === null || startY === null || endX === null || endY === null) {
       throw new Error('Invalid coordinates for drag operation');
     }
 

--- a/multimodal/gui-agent/operator-browser/test/browser-operator.test.ts
+++ b/multimodal/gui-agent/operator-browser/test/browser-operator.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2025 Bytedance, Inc. and its affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+import { BrowserOperator } from '../src/browser-operator';
+
+/**
+ * Builds a BrowserOperator whose page and screen context are stubbed so the
+ * coordinate guards can be exercised without a real browser.
+ */
+function createOperator() {
+  const operator = new BrowserOperator({ browser: {} as any });
+
+  const page = {
+    mouse: { move: vi.fn(), down: vi.fn(), up: vi.fn(), wheel: vi.fn() },
+    evaluate: vi.fn().mockResolvedValue(undefined),
+  };
+
+  (operator as any).getActivePage = vi.fn().mockResolvedValue(page);
+  (operator as any).getScreenContext = vi.fn().mockResolvedValue({
+    screenWidth: 1920,
+    screenHeight: 1080,
+    scaleX: 1,
+    scaleY: 1,
+  });
+
+  return { operator, page };
+}
+
+describe('BrowserOperator coordinate guards', () => {
+  describe('drag', () => {
+    it('rejects non-finite coordinates instead of forwarding them', async () => {
+      const { operator, page } = createOperator();
+
+      await expect(
+        (operator as any).handleDrag({
+          start: { raw: { x: Number.NaN, y: 10 } },
+          end: { raw: { x: 10, y: 10 } },
+        }),
+      ).rejects.toThrow('Invalid coordinates for drag operation');
+
+      expect(page.mouse.move).not.toHaveBeenCalled();
+    });
+
+    it('preserves zero-valued coordinates', async () => {
+      const { operator, page } = createOperator();
+
+      await (operator as any).handleDrag({
+        start: { raw: { x: 0, y: 0 } },
+        end: { raw: { x: 0, y: 0 } },
+      });
+
+      expect(page.mouse.move).toHaveBeenCalledWith(0, 0);
+    });
+  });
+
+  describe('scroll', () => {
+    it('skips non-finite coordinates instead of forwarding them', async () => {
+      const { operator, page } = createOperator();
+
+      await (operator as any).handleScroll({
+        point: { raw: { x: Number.NaN, y: 0 } },
+        direction: 'down',
+      });
+
+      expect(page.mouse.move).not.toHaveBeenCalled();
+    });
+
+    it('preserves zero-valued coordinates', async () => {
+      const { operator, page } = createOperator();
+
+      await (operator as any).handleScroll({
+        point: { raw: { x: 0, y: 0 } },
+        direction: 'down',
+      });
+
+      expect(page.mouse.move).toHaveBeenCalledWith(0, 0);
+    });
+  });
+});

--- a/packages/ui-tars/operators/browser-operator/src/browser-operator.ts
+++ b/packages/ui-tars/operators/browser-operator/src/browser-operator.ts
@@ -208,8 +208,14 @@ export class BrowserOperator extends Operator {
       screenWidth,
       screenHeight,
     });
-    const startX = coords.x ? coords.x / deviceScaleFactor : null;
-    const startY = coords.y ? coords.y / deviceScaleFactor : null;
+    const startX =
+      coords.x !== null && Number.isFinite(coords.x)
+        ? coords.x / deviceScaleFactor
+        : null;
+    const startY =
+      coords.y !== null && Number.isFinite(coords.y)
+        ? coords.y / deviceScaleFactor
+        : null;
 
     this.logger.info(`Parsed coordinates: (${startX}, ${startY})`);
     this.logger.info(`Executing action: ${action_type}`);
@@ -240,18 +246,21 @@ export class BrowserOperator extends Operator {
         case 'click':
         case 'left_click':
         case 'left_single':
-          if (startX && startY) await this.handleClick(startX, startY);
+          if (startX !== null && startY !== null)
+            await this.handleClick(startX, startY);
           else throw new Error(`Missing startX(${startX}) or startY${startX}.`);
           break;
 
         case 'double_click':
         case 'left_double':
-          if (startX && startY) await this.handleDoubleClick(startX, startY);
+          if (startX !== null && startY !== null)
+            await this.handleDoubleClick(startX, startY);
           else throw new Error(`Missing startX(${startX}) or startY${startX}.`);
           break;
 
         case 'right_click':
-          if (startX && startY) await this.handleRightClick(startX, startY);
+          if (startX !== null && startY !== null)
+            await this.handleRightClick(startX, startY);
           else throw new Error(`Missing startX(${startX}) or startY${startX}.`);
           break;
 
@@ -597,12 +606,24 @@ export class BrowserOperator extends Operator {
     });
 
     // Adjust for device scale factor
-    const startX = startCoords.x ? startCoords.x / deviceScaleFactor : null;
-    const startY = startCoords.y ? startCoords.y / deviceScaleFactor : null;
-    const endX = endCoords.x ? endCoords.x / deviceScaleFactor : null;
-    const endY = endCoords.y ? endCoords.y / deviceScaleFactor : null;
+    const startX =
+      startCoords.x !== null && Number.isFinite(startCoords.x)
+        ? startCoords.x / deviceScaleFactor
+        : null;
+    const startY =
+      startCoords.y !== null && Number.isFinite(startCoords.y)
+        ? startCoords.y / deviceScaleFactor
+        : null;
+    const endX =
+      endCoords.x !== null && Number.isFinite(endCoords.x)
+        ? endCoords.x / deviceScaleFactor
+        : null;
+    const endY =
+      endCoords.y !== null && Number.isFinite(endCoords.y)
+        ? endCoords.y / deviceScaleFactor
+        : null;
 
-    if (!startX || !startY || !endX || !endY) {
+    if (startX === null || startY === null || endX === null || endY === null) {
       throw new Error('Invalid coordinates for drag operation');
     }
 

--- a/packages/ui-tars/operators/nut-js/src/index.ts
+++ b/packages/ui-tars/operators/nut-js/src/index.ts
@@ -221,7 +221,16 @@ export class NutJSOperator extends Operator {
             screenHeight,
           });
 
-          if (startX && startY && endX && endY) {
+          if (
+            startX !== null &&
+            startY !== null &&
+            endX !== null &&
+            endY !== null &&
+            Number.isFinite(startX) &&
+            Number.isFinite(startY) &&
+            Number.isFinite(endX) &&
+            Number.isFinite(endY)
+          ) {
             logger.info(
               `[NutjsOperator] drag coordinates: startX=${startX}, startY=${startY}, endX=${endX}, endY=${endY}`,
             );

--- a/packages/ui-tars/operators/nut-js/test/execute.test.ts
+++ b/packages/ui-tars/operators/nut-js/test/execute.test.ts
@@ -238,4 +238,28 @@ describe('execute', () => {
       straightTo(new Point(138.24, 589.68)),
     );
   });
+
+  it('drag can start and end at the screen origin', async () => {
+    const nutJSOperator = new NutJSOperator();
+    const executeParams: ExecuteParams = {
+      prediction: "Action: drag(start_box='(0,0)', end_box='(0,0)')",
+      parsedPrediction: {
+        reflection: '',
+        thought: 'Drag from the screen origin.',
+        action_type: 'drag',
+        action_inputs: {
+          start_box: '[0,0,0,0]',
+          end_box: '[0,0,0,0]',
+        },
+      },
+      screenWidth: 1920,
+      screenHeight: 1080,
+      scaleFactor: 1,
+    };
+
+    await nutJSOperator.execute(executeParams);
+
+    expect(mouse.move).toHaveBeenCalledWith(straightTo(new Point(0, 0)));
+    expect(mouse.drag).toHaveBeenCalledWith(straightTo(new Point(0, 0)));
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #1964.

Coordinate guards treated `0` as missing, so valid actions at the top or left screen edges could be skipped. This updates the desktop marker, screenshot overlay, recording, remote operator, browser operators, and NutJS operator to accept finite zero coordinates while continuing to reject null, undefined, and non-finite values.

The regression coverage includes a click overlay at `(0, 0)` and a NutJS drag whose start and end points are both `(0, 0)`.

## Checklist

- [x] Added or updated necessary tests (Optional).
- [x] Updated documentation to align with changes (Optional).
- [x] Verified no breaking changes, or prepared solutions for any occurring breaking changes (Optional).
- [ ] My change does not involve the above items.

## Validation

- `corepack pnpm@9.10.0 --filter ui-tars-desktop exec vitest run src/main/shared/setOfMarks.test.ts`
- `corepack pnpm@9.10.0 --filter @ui-tars/operator-nut-js exec vitest run test/execute.test.ts --config vitest.config.mts -t "drag can start and end at the screen origin"`
- `corepack pnpm@9.10.0 --filter @ui-tars/operator-nut-js run build`
- `corepack pnpm@9.10.0 --filter @ui-tars/operator-browser run build`
- `corepack pnpm@9.10.0 --filter ui-tars-desktop run typecheck`
- `corepack pnpm@9.10.0 exec prettier --check` on changed files
