### PR TITLE
fix(ci): trigger Agent TARS workflow changes

### DIFF
--- a/.github/workflows/agent_tars_test.yml
+++ b/.github/workflows/agent_tars_test.yml
@@ -5,7 +5,7 @@ on:
       - '**'
     paths:
       - 'multimodal/**'
-      - '.github/workflows/agent_tars_build.yml'
+      - '.github/workflows/agent_tars_test.yml'
 
 permissions:
   id-token: write


### PR DESCRIPTION
## Summary

The Agent TARS workflow path filter referenced `.github/workflows/agent_tars_build.yml`, which does not exist. Point the filter at the workflow file that owns the build and test jobs so edits to that workflow trigger CI.

## Validation

- `git diff --check`
