### PR TITLE
fix(omni-tars): await MCP plugin initialization

### DIFF
--- a/multimodal/omni-tars/mcp-agent/src/McpAgentPlugin.ts
+++ b/multimodal/omni-tars/mcp-agent/src/McpAgentPlugin.ts
@@ -30,8 +30,7 @@ export class McpAgentPlugin extends AgentPlugin {
   }
 
   async initialize(): Promise<void> {
-    //FIXME:Temporarily remove await to speed up the agent initialization process; the logic of mcpManager.getClient() needs to be added later
-    this.mcpManager.init();
+    await this.mcpManager.init();
 
     // Initialize tools
     this.tools = [


### PR DESCRIPTION
## Summary

Await MCP manager initialization before exposing the plugin tools. This keeps plugin initialization from completing while the MCP clients are still starting.

## Validation

- `git diff --check`
- Package build could not run because this checkout has no installed `rslib` dependency.
