### PR TITLE
fix(legacy-site): handle unknown documentation routes

### DIFF
--- a/multimodal/websites/main/src/render/pages/Docs.tsx
+++ b/multimodal/websites/main/src/render/pages/Docs.tsx
@@ -26,7 +26,8 @@ const Docs: React.FC = () => {
     }
   }, [docId, navigate, firstAvailableDoc]);
 
-  const currentDoc = availableDocs.find(doc => doc.id === currentDocId)!;
+  const currentDoc = availableDocs.find(doc => doc.id === currentDocId);
+  const currentDocTitle = currentDoc?.title ?? 'Document Not Found';
 
   // Get GitHub edit URL
   const githubEditUrl = currentDocId ? getGithubEditPath(currentDocId) : undefined;
@@ -58,7 +59,7 @@ const Docs: React.FC = () => {
   return (
     <>
       <TwitterCardMeta
-        title={`${currentDoc.title} | Agent TARS Docs`}
+        title={`${currentDocTitle} | Agent TARS Docs`}
         description="Agent TARS documentation and guides"
         url={`${window.location.origin}${ETopRoute.DOC}/${currentDocId}`}
       />
@@ -92,7 +93,7 @@ const Docs: React.FC = () => {
                 markdown={markdown}
                 isLoading={isLoading}
                 contentKey={currentDocId}
-                publishDate={currentDoc.publishDate}
+                publishDate={currentDoc?.publishDate}
                 githubEditUrl={githubEditUrl}
               />
             </div>


### PR DESCRIPTION
## Summary

Handle an unknown documentation route without dereferencing an absent document. The existing markdown fallback now renders the not-found message while metadata and optional document fields remain safe.

## Validation

- `git diff --check`
- Package build not run because this checkout has no installed website dependencies.
