### PR TITLE
docs: make the default preset pass validation

### DIFF
--- a/docs/preset.md
+++ b/docs/preset.md
@@ -65,6 +65,7 @@ graph TD
 ```yaml
 name: UI TARS Desktop Example Preset
 language: en
+operator: Local Computer Operator
 vlmProvider: Hugging Face for UI-TARS-1.5
 vlmBaseUrl: https://your-endpoint.huggingface.cloud/v1
 vlmApiKey: your_api_key

--- a/examples/presets/default.yaml
+++ b/examples/presets/default.yaml
@@ -1,5 +1,6 @@
 name: UI TARS Desktop Example Preset
 language: en
+operator: Local Computer Operator
 vlmProvider: Hugging Face for UI-TARS-1.5
 vlmBaseUrl: https://your-endpoint.huggingface.cloud/v1
 vlmApiKey: your_api_key


### PR DESCRIPTION
## Summary

Add the required `operator` field to the checked-in default preset and its documentation example. The documented preset now satisfies the same required chat setting enforced by `PresetSchema`.

## Validation

- `git diff --check`
