### PR TITLE
fix(ui-tars): unsubscribe setting listeners on cleanup

### DIFF
--- a/apps/ui-tars/src/preload/index.ts
+++ b/apps/ui-tars/src/preload/index.ts
@@ -48,7 +48,12 @@ const electronHandler = {
       ipcRenderer.invoke('setting:updatePresetFromRemote'),
     resetPreset: () => ipcRenderer.invoke('setting:resetPreset'),
     onUpdate: (callback: (setting: LocalStore) => void) => {
-      ipcRenderer.on('setting-updated', (_, state) => callback(state));
+      const subscription = (_: IpcRendererEvent, state: LocalStore) => callback(state);
+      ipcRenderer.on('setting-updated', subscription);
+
+      return () => {
+        ipcRenderer.removeListener('setting-updated', subscription);
+      };
     },
   },
 };

--- a/apps/ui-tars/src/renderer/src/hooks/useSetting.ts
+++ b/apps/ui-tars/src/renderer/src/hooks/useSetting.ts
@@ -15,13 +15,13 @@ export function useSetting() {
       setSettings(currentSetting);
     };
 
-    settingRpc.onUpdate((newState) => {
+    const unsubscribe = settingRpc.onUpdate((newState) => {
       setSettings(newState);
     });
 
     initSetting();
 
-    // FIXME: clear setting update listener
+    return unsubscribe;
   }, []);
 
   const {


### PR DESCRIPTION
## Summary

Return an unsubscribe function from the preload setting update subscription and invoke it when `useSetting` unmounts. Repeated hook mounts no longer accumulate IPC listeners.

## Validation

- `git diff --check`
