### PR TITLE
docs(tarko): require Node.js 22.15 or newer

### DIFF
--- a/multimodal/websites/tarko/README.md
+++ b/multimodal/websites/tarko/README.md
@@ -6,7 +6,7 @@ This is the documentation site for Tarko - Tool-augmented Agent Runtime Kernel.
 
 ### Prerequisites
 
-- Node.js 18+
+- Node.js 22.15+
 - pnpm (recommended) or npm
 
 ### Getting Started

--- a/multimodal/websites/tarko/docs/en/guide/basic/ui-integration.mdx
+++ b/multimodal/websites/tarko/docs/en/guide/basic/ui-integration.mdx
@@ -679,7 +679,7 @@ npm run build
 
 ```dockerfile
 # Dockerfile
-FROM node:18-alpine
+FROM node:22.15-alpine
 
 WORKDIR /app
 COPY package*.json ./

--- a/multimodal/websites/tarko/docs/en/guide/deployment/cli.mdx
+++ b/multimodal/websites/tarko/docs/en/guide/deployment/cli.mdx
@@ -101,7 +101,7 @@ Create a production Docker image:
 
 ```dockerfile
 # Dockerfile
-FROM node:18-alpine
+FROM node:22.15-alpine
 
 WORKDIR /app
 
@@ -603,7 +603,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v3
       with:
-        node-version: '18'
+        node-version: '22.15.0'
         cache: 'npm'
     
     - name: Install dependencies

--- a/multimodal/websites/tarko/docs/en/guide/deployment/server.mdx
+++ b/multimodal/websites/tarko/docs/en/guide/deployment/server.mdx
@@ -435,7 +435,7 @@ await server.start();
 ### Docker Deployment
 
 ```dockerfile
-FROM node:18-alpine
+FROM node:22.15-alpine
 
 WORKDIR /app
 COPY package*.json ./

--- a/multimodal/websites/tarko/docs/en/guide/get-started/quick-start.mdx
+++ b/multimodal/websites/tarko/docs/en/guide/get-started/quick-start.mdx
@@ -9,7 +9,7 @@ Get up and running with Tarko in just a few minutes.
 
 ## Prerequisites
 
-- Node.js 18+ 
+- Node.js 22.15+
 - npm or pnpm
 
 ## Installation

--- a/multimodal/websites/tarko/docs/zh/guide/basic/ui-integration.mdx
+++ b/multimodal/websites/tarko/docs/zh/guide/basic/ui-integration.mdx
@@ -679,7 +679,7 @@ npm run build
 
 ```dockerfile
 # Dockerfile
-FROM node:18-alpine
+FROM node:22.15-alpine
 
 WORKDIR /app
 COPY package*.json ./

--- a/multimodal/websites/tarko/docs/zh/guide/deployment/cli.mdx
+++ b/multimodal/websites/tarko/docs/zh/guide/deployment/cli.mdx
@@ -101,7 +101,7 @@ export default config;
 
 ```dockerfile
 # Dockerfile
-FROM node:18-alpine
+FROM node:22.15-alpine
 
 WORKDIR /app
 
@@ -603,7 +603,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v3
       with:
-        node-version: '18'
+        node-version: '22.15.0'
         cache: 'npm'
     
     - name: Install dependencies

--- a/multimodal/websites/tarko/docs/zh/guide/get-started/quick-start.mdx
+++ b/multimodal/websites/tarko/docs/zh/guide/get-started/quick-start.mdx
@@ -9,7 +9,7 @@ description: 几分钟内开始使用 Tarko
 
 ## 前置要求
 
-- Node.js 18+ 
+- Node.js 22.15+
 - npm 或 pnpm
 
 ## 安装


### PR DESCRIPTION
## Summary

Update Tarko setup and deployment examples to match the `@tarko/agent-cli` Node.js engine requirement of `>=22.15.0`. This covers the README, quick starts, Docker images, and CI example.

## Validation

- `git diff --check`
- Searched the Tarko documentation for remaining Node.js 18 runtime examples.
