### PR TITLE
fix(mcp-client): emit one server-started event

### DIFF
--- a/packages/agent-infra/mcp-client/src/index.ts
+++ b/packages/agent-infra/mcp-client/src/index.ts
@@ -291,8 +291,6 @@ export class MCPClient<
           mcpServer.connect(serverTransport),
         ]);
 
-        this.log('info', `[MCP] Server ${name} started successfully`);
-        this.emit('server-started', { name });
       } else {
         throw new Error('No command or url provided for server');
       }

--- a/packages/agent-infra/mcp-client/test/index.test.ts
+++ b/packages/agent-infra/mcp-client/test/index.test.ts
@@ -597,6 +597,7 @@ describe('MCPClient', () => {
       await client.addServer(server);
 
       expect(startedHandler).toHaveBeenCalledWith({ name: 'event-server' });
+      expect(startedHandler).toHaveBeenCalledTimes(1);
     });
 
     it('should emit server-stopped event on deactivation', async () => {


### PR DESCRIPTION
## Summary

Emit `server-started` once for in-memory MCP servers. The shared completion path already emits the event after activation, so the in-memory branch no longer emits a duplicate notification.

## Validation

- `pnpm test -- --run test/index.test.ts` (30 passed)
- `git diff --check`
